### PR TITLE
#12: Fix get_account_access_key_data race condition w/ exception handling

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -63,7 +63,12 @@ def get_role_list_data(session):
 def get_account_access_key_data(session, username):
     client = session.client('iam')
     # NOTE we can get away without using a paginator here because users are limited to two access keys
-    return client.list_access_keys(UserName=username)
+    keys = []
+    try:
+        keys.append(client.list_access_keys(UserName=username))
+    except Exception:
+        logger.debug("Could not get access keys for user %s.  Returning empty list and moving on.", username)
+    return keys
 
 
 def load_users(session, users, current_aws_account_id, aws_update_tag):


### PR DESCRIPTION
Fix for issue #12 

Ran a test:
```
usernames = ["achantavy","USERTHATDOESNOTEXIST"]
account_access_key = {name: iam.get_account_access_key_data(boto3_session, name) for name in usernames}
print(account_access_key)
```


Result:
```
INFO:cartography.intel.aws:Syncing AWS account with ID '{ID}' using configured profile 'default'.
{'achantavy': [{'AccessKeyMetadata': [{'UserName': 'achantavy', 'AccessKeyId': '{ACCESSKEY}', 'Status': 'Active', 'CreateDate': datetime.datetime(2019, 1, 8, 22, 9, 24, tzinfo=tzutc())}], 'IsTruncated': False, 'ResponseMetadata': {'RequestId': '{REQUEST_ID}', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '{REQUEST_ID}', 'content-type': 'text/xml', 'content-length': '557', 'date': 'Wed, 13 Mar 2019 19:12:52 GMT'}, 'RetryAttempts': 0}}], 
'{USERTHATDOESNOTEXIST': []}
```