### PR TITLE
read-replica-fix

### DIFF
--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -200,8 +200,8 @@ def _attach_read_replicas(neo4j_session, read_replicas, aws_update_tag):
     Attach read replicas to their source instances
     """
     attach_replica_to_source = """
-    MATCH (replica:RDSInstance{id:{ReplicaArn}}),
-    (source:RDSInstance{db_instance_identifier:{SourceInstanceIdentifier}})
+    MATCH (replica:RDSInstance{id:{ReplicaArn}})
+    MERGE (source:RDSInstance{id:{SourceInstanceIdentifier}})
     MERGE (replica)-[r:IS_READ_REPLICA_OF]->(source)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = {aws_update_tag}


### PR DESCRIPTION
AWS naming convention is ... surprising. `ReadReplicaSourceDBInstanceIdentifier` actually contains the source `DBInstanceArn` (which `cartography` stores in `RDSInstance.id`).

Not sure why `MATCH (replica),(source)` wasn't working for me, but it wasn't updating/building as I expected, so I changed it to `MATCH (replica) MERGE (source)`.