### PR TITLE
Fix bug in IAM role policy sync caused by AWSRole nodes created without name attributes.

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -440,7 +440,11 @@ def sync_group_policies(neo4j_session, boto3_session, current_aws_account_id, aw
 
 def sync_role_policies(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.debug("Syncing IAM role policies for account '%s'.", current_aws_account_id)
-    query = "MATCH (role:AWSRole)<-[:AWS_ROLE]-(AWSAccount{id: {AWS_ACCOUNT_ID}}) return role.name as name;"
+    query = """
+    MATCH (role:AWSRole)<-[:AWS_ROLE]-(AWSAccount{id: {AWS_ACCOUNT_ID}})
+    WHERE NOT empty(role.name)
+    RETURN role.name AS name;
+    """
     result = neo4j_session.run(query, AWS_ACCOUNT_ID=current_aws_account_id)
     roles = [r['name'] for r in result]
     roles_policies = {}

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -442,7 +442,7 @@ def sync_role_policies(neo4j_session, boto3_session, current_aws_account_id, aws
     logger.debug("Syncing IAM role policies for account '%s'.", current_aws_account_id)
     query = """
     MATCH (role:AWSRole)<-[:AWS_ROLE]-(AWSAccount{id: {AWS_ACCOUNT_ID}})
-    WHERE NOT empty(role.name)
+    WHERE exists(role.name)
     RETURN role.name AS name;
     """
     result = neo4j_session.run(query, AWS_ACCOUNT_ID=current_aws_account_id)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -307,6 +307,12 @@ Representation of an AWS [IAM Role](https://docs.aws.amazon.com/IAM/latest/APIRe
     (AWSGroup, AWSUser, AWSPrincipal)-[STS_ASSUMEROLE_ALLOW]->(AWSRole)
     ```
 
+- Some AWS Roles can assume other AWS Roles.
+
+    ```
+    (AWSRole)-[STS_ASSUMEROLE_ALLOW]->(AWSRole)
+    ```
+
 - AWS Roles are defined in AWS Accounts.
 
     ```


### PR DESCRIPTION
Roles without names can be created during both group and role policy syncs right now.

Fixes bugs introduced in #53.