### PR TITLE
Use partial_uri as unique identifier on GCP instances

### DIFF
--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -106,9 +106,9 @@ def transform_gcp_instance(instance, project_id, zone_name):
     """
     instance['project_id'] = project_id
     instance['zone_name'] = zone_name
-    # Follow the format of a partial URL as shown here:
+    # Follow the format of a partial URI as shown here:
     # https://cloud.google.com/apis/design/resource_names#relative_resource_name
-    instance['partial_url'] = f"projects/{project_id}/zones/{zone_name}/instances/{instance['name']}"
+    instance['partial_uri'] = f"projects/{project_id}/zones/{zone_name}/instances/{instance['name']}"
     return instance
 
 
@@ -123,9 +123,9 @@ def load_gcp_instances(neo4j_session, data, gcp_update_tag):
     """
     query = """
     MATCH (p:GCPProject{id:{ProjectId}})
-    MERGE (i:Instance:GCPInstance{id:{PartialUrl}})
+    MERGE (i:Instance:GCPInstance{id:{PartialUri}})
     ON CREATE SET i.firstseen = timestamp()
-    SET i.partial_url = {PartialUrl},
+    SET i.partial_uri = {PartialUri},
     i.self_link = {SelfLink},
     i.instancename = {InstanceName},
     i.hostname = {Hostname},
@@ -140,9 +140,9 @@ def load_gcp_instances(neo4j_session, data, gcp_update_tag):
         neo4j_session.run(
             query,
             ProjectId=instance['project_id'],
-            PartialUrl=instance['partial_url'],
+            PartialUri=instance['partial_uri'],
             SelfLink=instance['selfLink'],
-            InstanceName = instance['name'],
+            InstanceName=instance['name'],
             ZoneName=instance['zone_name'],
             Hostname=instance.get('hostname', None),
             gcp_update_tag=gcp_update_tag

--- a/docs/schema/gcp.md
+++ b/docs/schema/gcp.md
@@ -102,8 +102,8 @@ Representation of a GCP [Organization](https://cloud.google.com/resource-manager
 | firstseen| Timestamp of when a sync job first discovered this node  |
 | lastupdated |  Timestamp of the last time the node was updated | 
 | id | The partial resource URI representing this instance. Has the form `projects/{project_name}/zones/{zone_name}/instances/{instance_name}`. |
-| partial_url | Same as `id` above. |
-| self_link | The full resource URI representing this instance. Has the form `https://www.googleapis.com/compute/v1/{partial_url}` |
+| partial_uri | Same as `id` above. |
+| self_link | The full resource URI representing this instance. Has the form `https://www.googleapis.com/compute/v1/{partial_uri}` |
 | instancename | The name of the instance, e.g. "my-instance" |
 | zone_name | The zone that the instance is installed on |
 | hostname | If present, the hostname of the instance |

--- a/docs/schema/gcp.md
+++ b/docs/schema/gcp.md
@@ -101,10 +101,12 @@ Representation of a GCP [Organization](https://cloud.google.com/resource-manager
 |-------|--------------| 
 | firstseen| Timestamp of when a sync job first discovered this node  |
 | lastupdated |  Timestamp of the last time the node was updated | 
-| id | The server-defined unique identifier of the instance, usually all numbers
-| displayname | The friendly name of the instance, e.g. "my-instance"
-| hostname | If present, the hostname of the instance
-| zone_name | The zone that the instance is installed on
+| id | The partial resource URI representing this instance. Has the form `projects/{project_name}/zones/{zone_name}/instances/{instance_name}`. |
+| partial_url | Same as `id` above. |
+| self_link | The full resource URI representing this instance. Has the form `https://www.googleapis.com/compute/v1/{partial_url}` |
+| instancename | The name of the instance, e.g. "my-instance" |
+| zone_name | The zone that the instance is installed on |
+| hostname | If present, the hostname of the instance |
 
 ### Relationships
 


### PR DESCRIPTION
GCP uses the `name` field to uniquely identify resources, not the `id` field (which in the case of GCP instances returns a number assigned by the server that doesn't communicate much meaning to the user).  

As such, this PR makes it so that GCP instances are now uniquely identified by their [partial resource URIs](https://cloud.google.com/apis/design/resource_names#relative_resource_name).  Compute instance partial URIs have the form `projects/{project}/zones/{zone name}/instances/{instance name}`.