### PR TITLE
Add AWSPrincipal nodes to represent the root identity of each AWS account being synced.

### DIFF
--- a/cartography/data/jobs/cleanup/aws_import_principals_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_principals_cleanup.json
@@ -1,0 +1,8 @@
+{
+  "statements": [{
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSPrincipal) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  }],
+  "name": "cleanup AWSPrincipal"
+}

--- a/cartography/data/jobs/cleanup/aws_import_roles_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_roles_cleanup.json
@@ -5,14 +5,9 @@
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:AWSPrincipal) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
     "query": "MATCH (:AWSPrincipal)-[r]->(:AWSRole)<-[:AWS_ROLE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   }],
-  "name": "cleanup AWSRole|AWSPrincipal"
+  "name": "cleanup AWSRole"
 }

--- a/cartography/data/jobs/cleanup/aws_post_ingestion_principals_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_post_ingestion_principals_cleanup.json
@@ -1,0 +1,8 @@
+{
+  "statements": [{
+    "query": "MATCH (n:AWSPrincipal) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  }],
+  "name": "cleanup AWSPrincipal"
+}

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -20,6 +20,7 @@ def _sync_one_account(session, boto3_session, account_id, regions, sync_tag, com
     iam.sync_group_policies(session, boto3_session, account_id, sync_tag, common_job_parameters)
     iam.sync_role_policies(session, boto3_session, account_id, sync_tag, common_job_parameters)
     iam.sync_user_access_keys(session, boto3_session, account_id, sync_tag, common_job_parameters)
+    run_cleanup_job('aws_import_principals_cleanup.json', session, common_job_parameters)
 
     # S3
     s3.sync(session, boto3_session, account_id, sync_tag, common_job_parameters)
@@ -64,6 +65,9 @@ def _sync_multiple_accounts(session, accounts, regions, sync_tag, common_job_par
 
     del common_job_parameters["AWS_ID"]
 
+    # There may be orphan Principals which point outside of known AWS accounts. This job cleans
+    # up those nodes after all AWS accounts have been synced.
+    run_cleanup_job('aws_post_ingestion_principals_cleanup.json', session, common_job_parameters)
     # There may be orphan DNS entries that point outside of known AWS zones. This job cleans
     # up those entries after all AWS accounts have been synced.
     run_cleanup_job('aws_post_ingestion_dns_cleanup.json', session, common_job_parameters)

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -10,17 +10,7 @@ logger = logging.getLogger(__name__)
 
 def _sync_one_account(session, boto3_session, account_id, regions, sync_tag, common_job_parameters):
     # IAM
-    # TODO move this to IAM module
-    logger.info("Syncing IAM for account '%s'.", account_id)
-    iam.sync_users(session, boto3_session, account_id, sync_tag, common_job_parameters)
-    iam.sync_groups(session, boto3_session, account_id, sync_tag, common_job_parameters)
-    iam.sync_policies(session, boto3_session, account_id, sync_tag, common_job_parameters)
-    iam.sync_roles(session, boto3_session, account_id, sync_tag, common_job_parameters)
-    iam.sync_group_memberships(session, boto3_session, account_id, sync_tag, common_job_parameters)
-    iam.sync_group_policies(session, boto3_session, account_id, sync_tag, common_job_parameters)
-    iam.sync_role_policies(session, boto3_session, account_id, sync_tag, common_job_parameters)
-    iam.sync_user_access_keys(session, boto3_session, account_id, sync_tag, common_job_parameters)
-    run_cleanup_job('aws_import_principals_cleanup.json', session, common_job_parameters)
+    iam.sync(session, boto3_session, account_id, sync_tag, common_job_parameters)
 
     # S3
     s3.sync(session, boto3_session, account_id, sync_tag, common_job_parameters)

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -472,3 +472,16 @@ def sync_user_access_keys(neo4j_session, boto3_session, current_aws_account_id, 
         neo4j_session,
         common_job_parameters
     )
+
+
+def sync(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters):
+    logger.info("Syncing IAM for account '%s'.", account_id)
+    sync_users(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters)
+    sync_groups(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters)
+    sync_policies(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters)
+    sync_roles(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters)
+    sync_group_memberships(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters)
+    sync_group_policies(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters)
+    sync_role_policies(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters)
+    sync_user_access_keys(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters)
+    run_cleanup_job('aws_import_principals_cleanup.json', neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/organizations.py
+++ b/cartography/intel/aws/organizations.py
@@ -89,9 +89,13 @@ def load_aws_accounts(neo4j_session, aws_accounts, aws_update_tag, common_job_pa
     ON CREATE SET aa.firstseen = timestamp()
     SET aa.lastupdated = {aws_update_tag}, aa.name = {ACCOUNT_NAME}
     WITH aa
-    MERGE (aa)-[:RESOURCE]->(root:AWSPrincipal{arn: {RootArn})
-    ON CREATE SET root.firstseen = timestamp()
-    SET root.lastupdated = {aws_update_tag}, root.type = 'AWS';
+    MERGE (root:AWSPrincipal{arn: {RootArn})
+    ON CREATE SET root.firstseen = timestamp(), root.type = 'AWS'
+    SET root.lastupdated = {aws_update_tag}
+    WITH aa, root
+    MERGE (aa)-[r:RESOURCE]->(root)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = {aws_update_tag};
     """
     for account_name, account_id in aws_accounts.items():
         root_arn = 'arn:aws:iam::{}:root'.format(account_id)

--- a/cartography/intel/aws/organizations.py
+++ b/cartography/intel/aws/organizations.py
@@ -89,7 +89,7 @@ def load_aws_accounts(neo4j_session, aws_accounts, aws_update_tag, common_job_pa
     ON CREATE SET aa.firstseen = timestamp()
     SET aa.lastupdated = {aws_update_tag}, aa.name = {ACCOUNT_NAME}
     WITH aa
-    MERGE (root:AWSPrincipal{arn: {RootArn})
+    MERGE (root:AWSPrincipal{arn: {RootArn}})
     ON CREATE SET root.firstseen = timestamp(), root.type = 'AWS'
     SET root.lastupdated = {aws_update_tag}
     WITH aa, root

--- a/cartography/intel/aws/organizations.py
+++ b/cartography/intel/aws/organizations.py
@@ -88,12 +88,18 @@ def load_aws_accounts(neo4j_session, aws_accounts, aws_update_tag, common_job_pa
     MERGE (aa:AWSAccount{id: {ACCOUNT_ID}})
     ON CREATE SET aa.firstseen = timestamp()
     SET aa.lastupdated = {aws_update_tag}, aa.name = {ACCOUNT_NAME}
+    WITH aa
+    MERGE (aa)-[:RESOURCE]->(root:AWSPrincipal{arn: {RootArn})
+    ON CREATE SET root.firstseen = timestamp()
+    SET root.lastupdated = {aws_update_tag}, root.type = 'AWS';
     """
     for account_name, account_id in aws_accounts.items():
+        root_arn = 'arn:aws:iam::{}:root'.format(account_id)
         neo4j_session.run(
             query,
             ACCOUNT_ID=account_id,
             ACCOUNT_NAME=account_name,
+            RootArn=root_arn,
             aws_update_tag=aws_update_tag
         )
 

--- a/docs/schema/aws.md
+++ b/docs/schema/aws.md
@@ -260,7 +260,7 @@ Representation of an [AWSUser](https://docs.aws.amazon.com/IAM/latest/APIReferen
 
 ## AWSPrincipal::AWSRole
 
-Representation of an AWS [IAM Role](https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html).
+Representation of an AWS [IAM Role](https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html). An AWS Role is a type of AWS Principal.
 
 | Field | Description |
 |-------|-------------|

--- a/docs/schema/aws.md
+++ b/docs/schema/aws.md
@@ -258,7 +258,7 @@ Representation of an [AWSUser](https://docs.aws.amazon.com/IAM/latest/APIReferen
 	```
 
 
-## AWSRole
+## AWSPrincipal::AWSRole
 
 Representation of an AWS [IAM Role](https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html).
 


### PR DESCRIPTION
Each AWS account has a root identity which is a principal (ref: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html ). This PR does a couple of things:

1. Explicitly adds a principal node for the root identity in each AWS account.
2. Refactors AWSPrincipal cleanup to make sure it does not delete principals which will be re-added during multi-account sync.