### PR TITLE
Connect firewalls directly to the instances they apply to, and mark firewalls that have target service accounts

### DIFF
--- a/cartography/data/jobs/analysis/gcp_compute_asset_inet_exposure.json
+++ b/cartography/data/jobs/analysis/gcp_compute_asset_inet_exposure.json
@@ -12,9 +12,9 @@
     "__comment__": "Connect GCP ingress firewall rules to the instances that they apply to via target tags"
   },
   {
-   "query": "MATCH (fw:GCPFirewall{direction: 'INGRESS'})\nWHERE NOT (fw)-[:TARGET_TAG]->(:GCPNetworkTag)\nmatch (inst:GCPInstance)-[mem:MEMBER_OF_GCP_VPC]->(vpc:GCPVpc)-[res:RESOURCE]->(fw)\nMERGE (fw)-[a:FIREWALL_INGRESS]->(inst)\nON CREATE SET a.firstseen = timestamp()\nSET a.lastupdated = {UPDATE_TAG}\nRETURN count(*) as TotalCompleted",
+   "query": "MATCH (fw:GCPFirewall{direction: 'INGRESS', has_target_service_accounts: False})\nWHERE NOT (fw)-[:TARGET_TAG]->(:GCPNetworkTag)\nmatch (inst:GCPInstance)-[mem:MEMBER_OF_GCP_VPC]->(vpc:GCPVpc)-[res:RESOURCE]->(fw)\nMERGE (fw)-[a:FIREWALL_INGRESS]->(inst)\nON CREATE SET a.firstseen = timestamp()\nSET a.lastupdated = {UPDATE_TAG}\nRETURN count(*) as TotalCompleted",
     "iterative": false,
-    "__comment__": "Connect GCP ingress firewall rules that don't specify target tags to the instances that they apply to via sharing the same VPC"
+    "__comment__": "Connect GCP ingress firewall rules that don't specify target tags and don't specify target service accounts to the instances that they apply to via sharing the same VPC"
   },
   {
     "query": "MATCH (fw:GCPFirewall)-[a:FIREWALL_INGRESS]->(inst:GCPInstance)\nWHERE a.lastupdated <> {UPDATE_TAG}\nDELETE (a)\nRETURN count(*) as TotalCompleted",

--- a/cartography/data/jobs/analysis/gcp_compute_asset_inet_exposure.json
+++ b/cartography/data/jobs/analysis/gcp_compute_asset_inet_exposure.json
@@ -1,0 +1,26 @@
+{
+  "statements": [
+  {
+    "query": "MATCH (n) where EXISTS(n.exposed_internet) AND labels(n) IN ['GCPInstance'] WITH n LIMIT {LIMIT_SIZE} REMOVE n.exposed_internet, n.exposed_internet_type return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 1000,
+    "__comment__": "Delete exposed_internet off nodes so we can start fresh"
+    },
+  {
+    "query": "MATCH (vpc:GCPVpc)<-[mem:MEMBER_OF_GCP_VPC]-(inst:GCPInstance)-[t:TAGGED]->(tag:GCPNetworkTag)-[tt:TARGET_TAG]-(fw:GCPFirewall{direction: 'INGRESS'})<-[res:RESOURCE]-(vpc)\nMERGE (fw)-[a:FIREWALL_INGRESS]->(inst)\nON CREATE SET a.firstseen = timestamp()\nSET a.lastupdated = {UPDATE_TAG}\nRETURN count(*) as TotalCompleted",
+    "iterative": false,
+    "__comment__": "Connect GCP ingress firewall rules to the instances that they apply to via target tags"
+  },
+  {
+   "query": "MATCH (fw:GCPFirewall{direction: 'INGRESS'})\nWHERE NOT (fw)-[:TARGET_TAG]->(:GCPNetworkTag)\nmatch (inst:GCPInstance)-[mem:MEMBER_OF_GCP_VPC]->(vpc:GCPVpc)-[res:RESOURCE]->(fw)\nMERGE (fw)-[a:FIREWALL_INGRESS]->(inst)\nON CREATE SET a.firstseen = timestamp()\nSET a.lastupdated = {UPDATE_TAG}\nRETURN count(*) as TotalCompleted",
+    "iterative": false,
+    "__comment__": "Connect GCP ingress firewall rules that don't specify target tags to the instances that they apply to via sharing the same VPC"
+  },
+  {
+    "query": "MATCH (fw:GCPFirewall)-[a:FIREWALL_INGRESS]->(inst:GCPInstance)\nWHERE a.lastupdated <> {UPDATE_TAG}\nDELETE (a)\nRETURN count(*) as TotalCompleted",
+    "iterative": false,
+    "__comment__": "Delete stale firewall ingress relationships"
+  }
+],
+  "name": "GCP asset internet exposure"
+}

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -4,6 +4,7 @@ import logging
 from collections import namedtuple
 
 from cartography.intel.gcp import crm, compute
+from cartography.util import run_analysis_job
 
 logger = logging.getLogger(__name__)
 Resources = namedtuple('Resources', 'crm_v1 crm_v2 compute')
@@ -128,3 +129,9 @@ def start_gcp_ingestion(session, config):
     projects = crm.get_gcp_projects(resources.crm_v1)
 
     _sync_multiple_projects(session, resources, projects, config.update_tag, common_job_parameters)
+
+    run_analysis_job(
+        'gcp_compute_asset_inet_exposure.json',
+        session,
+        common_job_parameters
+    )

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -268,6 +268,9 @@ def transform_gcp_firewall(fw_response):
 
         fw['transformed_allow_list'] = []
         fw['transformed_deny_list'] = []
+        # Mark whether this FW is defined on a target service account.
+        # In future we will need to ingest GCP IAM objects but for now we simply mark the presence of svc accounts here.
+        fw['has_target_service_accounts'] = True if 'targetServiceAccounts' in fw else False
 
         for allow_rule in fw.get('allowed', []):
             transformed_allow_rules = _transform_fw_entry(allow_rule, fw_partial_uri, is_allow_rule=True)
@@ -688,6 +691,7 @@ def load_gcp_ingress_firewalls(neo4j_session, fw_list, gcp_update_tag):
     fw.name = {Name},
     fw.priority = {Priority},
     fw.self_link = {SelfLink},
+    fw.has_target_service_accounts = {HasTargetServiceAccounts},
     fw.lastupdated = {gcp_update_tag}
 
     MERGE (vpc:GCPVpc{id:{VpcPartialUri}})
@@ -709,6 +713,7 @@ def load_gcp_ingress_firewalls(neo4j_session, fw_list, gcp_update_tag):
             Priority=fw['priority'],
             SelfLink=fw['selfLink'],
             VpcPartialUri=fw['vpc_partial_uri'],
+            HasTargetServiceAccounts=fw['has_target_service_accounts'],
             gcp_update_tag=gcp_update_tag
         )
         _attach_firewall_rules(neo4j_session, fw, gcp_update_tag)

--- a/docs/schema/gcp.md
+++ b/docs/schema/gcp.md
@@ -152,6 +152,23 @@ Representation of a GCP [Organization](https://cloud.google.com/resource-manager
     ```
     (GCPInstance)-[:TAGGED]->(GCPNetworkTag)
     ```
+
+- GCP Firewalls allow ingress to GCP instances.  
+    ```
+    (GCPFirewall)-[:FIREWALL_INGRESS]->(GCPInstance)
+    ```
+
+    Note that this relationship is a shortcut for:
+    ```
+    (vpc:GCPVpc)<-[MEMBER_OF_GCP_VPC]-(GCPInstance)-[TAGGED]->(GCPNetworkTag)-[TARGET_TAG]-(GCPFirewall{direction: 'INGRESS'})<-[RESOURCE]-(vpc)
+    ```
+    
+    as well as
+    ```
+    MATCH (fw:GCPFirewall{direction: 'INGRESS'})
+    WHERE NOT (fw)-[TARGET_TAG]->(GCPNetworkTag)
+    MATCH (GCPInstance)-[MEMBER_OF_GCP_VPC]->(GCPVpc)-[RESOURCE]->(fw)
+    ```
  
 ## GCPNetworkTag
 
@@ -370,6 +387,23 @@ Representation of a GCP [Firewall](https://cloud.google.com/compute/docs/referen
 - GCP Firewalls can be labeled with tags to direct traffic to or deny traffic to labeled GCPInstances
     ```
     (GCPFirewall)-[:TARGET_TAG]->(GCPNetworkTag)
+    ```
+
+- GCP Firewalls allow ingress to GCP instances.  
+    ```
+    (GCPFirewall)-[:FIREWALL_INGRESS]->(GCPInstance)
+    ```
+
+    Note that this relationship is a shortcut for:
+    ```
+    (vpc:GCPVpc)<-[MEMBER_OF_GCP_VPC]-(GCPInstance)-[TAGGED]->(GCPNetworkTag)-[TARGET_TAG]-(GCPFirewall{direction: 'INGRESS'})<-[RESOURCE]-(vpc)
+    ```
+    
+    as well as
+    ```
+    MATCH (fw:GCPFirewall{direction: 'INGRESS'})
+    WHERE NOT (fw)-[TARGET_TAG]->(GCPNetworkTag)
+    MATCH (GCPInstance)-[MEMBER_OF_GCP_VPC]->(GCPVpc)-[RESOURCE]->(fw)
     ```
 
 

--- a/docs/schema/gcp.md
+++ b/docs/schema/gcp.md
@@ -11,6 +11,7 @@
 - [GCPVpc](#gcpvpc) 
 - [GCPNicAccessConfig](#gcpnicaccessconfig)
 - [GCPSubnet](#gcpsubnet)
+- [GCPFirewall](#gcpfirewall)
 
 
 ## GCPOrganization
@@ -165,7 +166,7 @@ Representation of a GCP [Organization](https://cloud.google.com/resource-manager
     
     as well as
     ```
-    MATCH (fw:GCPFirewall{direction: 'INGRESS'})
+    MATCH (fw:GCPFirewall{direction: 'INGRESS', has_target_service_accounts: False}})
     WHERE NOT (fw)-[TARGET_TAG]->(GCPNetworkTag)
     MATCH (GCPInstance)-[MEMBER_OF_GCP_VPC]->(GCPVpc)-[RESOURCE]->(fw)
     ```
@@ -362,7 +363,7 @@ Representation of a GCP [Firewall](https://cloud.google.com/compute/docs/referen
 | disabled | Whether this firewall object is disabled
 | priority | The priority of this firewall rule from 1 (apply this first)-65535 (apply this last)
 | self_link | The full resource URI to this firewall |
-
+| has_target_service_accounts | Set to True if this Firewall has target service accounts defined. This field is currently a placeholder for future functionality to add GCP IAM objects to Cartography. If True, this firewall rule will only apply to GCP instances that use the specified target service account. |
 
 ### Relationships
 
@@ -401,7 +402,7 @@ Representation of a GCP [Firewall](https://cloud.google.com/compute/docs/referen
     
     as well as
     ```
-    MATCH (fw:GCPFirewall{direction: 'INGRESS'})
+    MATCH (fw:GCPFirewall{direction: 'INGRESS', has_target_service_accounts: False}})
     WHERE NOT (fw)-[TARGET_TAG]->(GCPNetworkTag)
     MATCH (GCPInstance)-[MEMBER_OF_GCP_VPC]->(GCPVpc)-[RESOURCE]->(fw)
     ```

--- a/tests/data/gcp/compute.py
+++ b/tests/data/gcp/compute.py
@@ -515,7 +515,8 @@ TRANSFORMED_FW_LIST = [{
         'toport': None
     }],
     'transformed_deny_list': [],
-    'vpc_partial_uri': 'projects/project-abc/global/networks/default'
+    'vpc_partial_uri': 'projects/project-abc/global/networks/default',
+    'has_target_service_accounts' : False
 }, {
     'allowed': [{
         'IPProtocol': 'tcp',
@@ -557,7 +558,8 @@ TRANSFORMED_FW_LIST = [{
         'toport': None
     }],
     'transformed_deny_list': [],
-    'vpc_partial_uri': 'projects/project-abc/global/networks/default'
+    'vpc_partial_uri': 'projects/project-abc/global/networks/default',
+    'has_target_service_accounts' : False
 }, {
     'allowed': [{
         'IPProtocol': 'tcp',
@@ -584,7 +586,8 @@ TRANSFORMED_FW_LIST = [{
         'toport': 3389
     }],
     'transformed_deny_list': [],
-    'vpc_partial_uri': 'projects/project-abc/global/networks/default'
+    'vpc_partial_uri': 'projects/project-abc/global/networks/default',
+    'has_target_service_accounts' : False
 }, {
     'allowed': [{
         'IPProtocol': 'tcp',
@@ -611,7 +614,8 @@ TRANSFORMED_FW_LIST = [{
         'toport': 22
     }],
     'transformed_deny_list': [],
-    'vpc_partial_uri': 'projects/project-abc/global/networks/default'
+    'vpc_partial_uri': 'projects/project-abc/global/networks/default',
+    'has_target_service_accounts' : False
 }, {
     'allowed': [{
         'IPProtocol': 'tcp',
@@ -639,5 +643,6 @@ TRANSFORMED_FW_LIST = [{
         'toport': 9001
     }],
     'transformed_deny_list': [],
-    'vpc_partial_uri': 'projects/project-abc/global/networks/default'
+    'vpc_partial_uri': 'projects/project-abc/global/networks/default',
+    'has_target_service_accounts' : False
 }]

--- a/tests/integration/cartography/intel/gcp/test_compute.py
+++ b/tests/integration/cartography/intel/gcp/test_compute.py
@@ -152,36 +152,42 @@ def test_transform_and_load_firewalls(neo4j_session):
 
     query = """
     MATCH (vpc:GCPVpc)-[r:RESOURCE]->(fw:GCPFirewall)
-    return vpc.id, fw.id
+    return vpc.id, fw.id, fw.has_target_service_accounts
     """
 
     nodes = neo4j_session.run(query)
     actual_nodes = set([(
         (
             n['vpc.id'],
-            n['fw.id']
+            n['fw.id'],
+            n['fw.has_target_service_accounts']
         )
     ) for n in nodes])
     expected_nodes = set([
         (
             'projects/project-abc/global/networks/default',
-            'projects/project-abc/global/firewalls/default-allow-icmp'
+            'projects/project-abc/global/firewalls/default-allow-icmp',
+            False
         ),
         (
             'projects/project-abc/global/networks/default',
-            'projects/project-abc/global/firewalls/default-allow-internal'
+            'projects/project-abc/global/firewalls/default-allow-internal',
+            False
         ),
         (
             'projects/project-abc/global/networks/default',
-            'projects/project-abc/global/firewalls/default-allow-rdp'
+            'projects/project-abc/global/firewalls/default-allow-rdp',
+            False
         ),
         (
             'projects/project-abc/global/networks/default',
-            'projects/project-abc/global/firewalls/default-allow-ssh'
+            'projects/project-abc/global/firewalls/default-allow-ssh',
+            False
         ),
         (
             'projects/project-abc/global/networks/default',
-            'projects/project-abc/global/firewalls/custom-port-incoming'
+            'projects/project-abc/global/firewalls/custom-port-incoming',
+            False
         )
     ])
     assert actual_nodes == expected_nodes


### PR DESCRIPTION
This PR directly connects instances to the firewalls that apply to them and takes into consideration the following cases:

- Target tags defined on a firewall cause the firewall to apply only to instances with those tags in the firewall's VPC
- Target service accounts defined on a firewall cause the firewall to apply only to instances with those service accounts in the firewall's VPC (this is not fully implemented as we need IAM objects for full functionality; for now this PR sets a `has_target_service_accounts` placeholder field set on the firewall object so we know to not apply the firewall to all instances in the VPC)
- Neither target tag nor target service account are defined so the firewall rule applies to all instances in the VPC