### PR TITLE
Change Travis CI configuration to force builds builds to run on trusty.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: python
 python:


### PR DESCRIPTION
Temporary solution to our woes to unblock development. Permanent solution is switching to Xenial which #88 does (or will do).