### PR TITLE
fix UnboundLocalError

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -207,6 +207,7 @@ def load_roles(session, roles, current_aws_account_id, aws_update_tag):
 
         for statement in role["AssumeRolePolicyDocument"]["Statement"]:
             principal = statement["Principal"]
+            principal_values = []
             if 'AWS' in principal:
                 principal_type, principal_values = 'AWS', principal['AWS']
             elif 'Service' in principal:


### PR DESCRIPTION
I tried to use cartography on my env. And I get following error.
I guess my env has some unexpected IAM resource which Lyft environment doesn't have.
By adding `principal_values` initialization, cartography runs without error.

```
python_1  | Traceback (most recent call last):
python_1  |   File "/usr/local/bin/cartography", line 10, in <module>
python_1  |     sys.exit(main())
python_1  |   File "/usr/local/lib/python3.7/site-packages/cartography/cli.py", line 180, in main
python_1  |     return CLI(default_sync, prog='cartography').main(argv)
python_1  |   File "/usr/local/lib/python3.7/site-packages/cartography/cli.py", line 161, in main
python_1  |     return cartography.sync.run_with_config(self.sync, config)
python_1  |   File "/usr/local/lib/python3.7/site-packages/cartography/sync.py", line 130, in run_with_config
python_1  |     return sync.run(neo4j_driver, config)
python_1  |   File "/usr/local/lib/python3.7/site-packages/cartography/sync.py", line 64, in run
python_1  |     stage_func(neo4j_session, config)
python_1  |   File "/usr/local/lib/python3.7/site-packages/cartography/intel/aws/__init__.py", line 116, in start_aws_ingestion
python_1  |     _sync_multiple_accounts(session, aws_accounts, regions, config.update_tag, common_job_parameters)
python_1  |   File "/usr/local/lib/python3.7/site-packages/cartography/intel/aws/__init__.py", line 54, in _sync_multiple_accounts
python_1  |     _sync_one_account(session, boto3_session, account_id, regions, sync_tag, common_job_parameters)
python_1  |   File "/usr/local/lib/python3.7/site-packages/cartography/intel/aws/__init__.py", line 13, in _sync_one_account
python_1  |     iam.sync(session, boto3_session, account_id, sync_tag, common_job_parameters)
python_1  |   File "/usr/local/lib/python3.7/site-packages/cartography/intel/aws/iam.py", line 439, in sync
python_1  |     sync_roles(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters)
python_1  |   File "/usr/local/lib/python3.7/site-packages/cartography/intel/aws/iam.py", line 362, in sync_roles
python_1  |     load_roles(neo4j_session, data['Roles'], current_aws_account_id, aws_update_tag)
python_1  |   File "/usr/local/lib/python3.7/site-packages/cartography/intel/aws/iam.py", line 214, in load_roles
python_1  |     if not isinstance(principal_values, list):
python_1  | UnboundLocalError: local variable 'principal_values' referenced before assignment
python_1  | 2019/06/28 10:19:02 Command exited with error: exit status 
```