### PR TITLE
Support federated principal

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -212,6 +212,8 @@ def load_roles(session, roles, current_aws_account_id, aws_update_tag):
                 principal_type, principal_values = 'AWS', principal['AWS']
             elif 'Service' in principal:
                 principal_type, principal_values = 'Service', principal['Service']
+            elif 'Federated' in principal:
+                principal_type, principal_values = 'Federated', principal['Federated']
             if not isinstance(principal_values, list):
                 principal_values = [principal_values]
             for principal_value in principal_values:

--- a/tests/data/aws/iam.py
+++ b/tests/data/aws/iam.py
@@ -135,5 +135,30 @@ LIST_ROLES = {
             "Path": "/",
             "Arn": "arn:aws:iam::000000000000:role/example-role-2"
         },
+        {
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": "sts:AssumeRoleWithSAML",
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Federated": "arn:aws:iam::000000000000:saml-provider/ADFS"
+                        },
+                        "Condition": {
+                            "StringEquals": {
+                                "SAML:aud": "https://signin.aws.amazon.com/saml"
+                            }
+                        }
+                    }
+                ]
+            },
+            "MaxSessionDuration": 3600,
+            "RoleId": "AROA00000000000000003",
+            "CreateDate": datetime.datetime(2019, 1, 1, 0, 0, 1),
+            "RoleName": "example-role-3",
+            "Path": "/",
+            "Arn": "arn:aws:iam::000000000000:role/example-role-3"
+        },
     ]
 }

--- a/tests/integration/cartography/intel/aws/test_iam.py
+++ b/tests/integration/cartography/intel/aws/test_iam.py
@@ -74,6 +74,7 @@ def test_load_roles_creates_trust_relationships(neo4j_session):
             ('arn:aws:iam::000000000000:role/example-role-0', 'arn:aws:iam::000000000000:root'),
             ('arn:aws:iam::000000000000:role/example-role-1', 'arn:aws:iam::000000000000:role/example-role-0'),
             ('arn:aws:iam::000000000000:role/example-role-2', 'ec2.amazonaws.com'),
+            ('arn:aws:iam::000000000000:role/example-role-3', 'arn:aws:iam::000000000000:saml-provider/ADFS'),
         )
     )
     # Transform the results of our query above to match the format of our expectations.


### PR DESCRIPTION
Follow up https://github.com/lyft/cartography/pull/96 .

I check my environment, and notice that we have `Federated` principal type.

According to this document, AWS define 4 principal types.
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
- `AWS`
- `Service`
- `Federated `
- `CanonicalUser`

Actually, we use SAML, it is the reason why `Federated` principal is included.
Currently `cartography` works well in my env.
So this is not required for me, but ignoring `Federated` principal type is not corrected behavior.
I try to fix it.
(I can't test for `CanonicalUser`, I ignore it now...)