### PR TITLE
discard unneeded query results.

### DIFF
--- a/cartography/intel/aws/dynamodb.py
+++ b/cartography/intel/aws/dynamodb.py
@@ -42,7 +42,7 @@ def load_dynamodb_tables(session, data, region, current_aws_account_id, aws_upda
             Rows=table['Table']['ItemCount'],
             AWS_ACCOUNT_ID=current_aws_account_id,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
         load_gsi(session, table, region, current_aws_account_id, aws_update_tag)
 
 
@@ -72,7 +72,7 @@ def load_gsi(session, table, region, current_aws_account_id, aws_update_tag):
             GSIName=gsi['IndexName'],
             AWS_ACCOUNT_ID=current_aws_account_id,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
 
 def cleanup_dynamodb_tables(session, common_job_parameters):

--- a/cartography/intel/aws/ec2.py
+++ b/cartography/intel/aws/ec2.py
@@ -137,7 +137,7 @@ def load_ec2_instances(session, data, region, current_aws_account_id, aws_update
             AWS_ACCOUNT_ID=current_aws_account_id,
             Region=region,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
         for instance in reservation["Instances"]:
             instanceid = instance["InstanceId"]
@@ -170,7 +170,7 @@ def load_ec2_instances(session, data, region, current_aws_account_id, aws_update
                 AWS_ACCOUNT_ID=current_aws_account_id,
                 Region=region,
                 aws_update_tag=aws_update_tag
-            )
+            ).detach()
 
             if instance.get("SecurityGroups"):
                 for group in instance["SecurityGroups"]:
@@ -182,7 +182,7 @@ def load_ec2_instances(session, data, region, current_aws_account_id, aws_update
                         Region=region,
                         AWS_ACCOUNT_ID=current_aws_account_id,
                         aws_update_tag=aws_update_tag
-                    )
+                    ).detach()
 
             load_ec2_instance_network_interfaces(session, instance, aws_update_tag)
 
@@ -229,7 +229,7 @@ def load_ec2_instance_network_interfaces(session, instance_data, aws_update_tag)
             PrivateIpAddress=interface.get("PrivateIpAddress", ""),
             SubnetId=interface.get("SubnetId", ""),
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
         for group in interface.get("Groups", []):
             session.run(
@@ -237,7 +237,7 @@ def load_ec2_instance_network_interfaces(session, instance_data, aws_update_tag)
                 NetworkId=interface["NetworkInterfaceId"],
                 GroupId=group["GroupId"],
                 aws_update_tag=aws_update_tag
-            )
+            ).detach()
 
 
 def load_ec2_security_groupinfo(session, data, region, current_aws_account_id, aws_update_tag):
@@ -269,7 +269,7 @@ def load_ec2_security_groupinfo(session, data, region, current_aws_account_id, a
             Region=region,
             AWS_ACCOUNT_ID=current_aws_account_id,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
         load_ec2_security_group_rule(session, group, "IpPermissions", aws_update_tag)
         load_ec2_security_group_rule(session, group, "IpPermissionEgress", aws_update_tag)
@@ -330,14 +330,14 @@ def load_ec2_security_group_rule(session, group, rule_type, aws_update_tag):
                 Protocol=protocol,
                 GroupId=group_id,
                 aws_update_tag=aws_update_tag
-            )
+            ).detach()
 
             session.run(
                 ingest_rule_group_pair,
                 GroupId=group_id,
                 RuleId=ruleid,
                 aws_update_tag=aws_update_tag
-            )
+            ).detach()
 
             for ip_range in rule["IpRanges"]:
                 range_id = ip_range["CidrIp"]
@@ -346,7 +346,7 @@ def load_ec2_security_group_rule(session, group, rule_type, aws_update_tag):
                     RangeId=range_id,
                     RuleId=ruleid,
                     aws_update_tag=aws_update_tag
-                )
+                ).detach()
 
 
 def load_ec2_auto_scaling_groups(session, data, region, current_aws_account_id, aws_update_tag):
@@ -406,7 +406,7 @@ def load_ec2_auto_scaling_groups(session, data, region, current_aws_account_id, 
             AWS_ACCOUNT_ID=current_aws_account_id,
             Region=region,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
         if group.get('VPCZoneIdentifier'):
             vpclist = group["VPCZoneIdentifier"]
@@ -416,7 +416,7 @@ def load_ec2_auto_scaling_groups(session, data, region, current_aws_account_id, 
                     SubnetId=vpc,
                     GROUPARN=group_arn,
                     aws_update_tag=aws_update_tag
-                )
+                ).detach()
 
         if group.get("Instances"):
             for instance in group["Instances"]:
@@ -428,7 +428,7 @@ def load_ec2_auto_scaling_groups(session, data, region, current_aws_account_id, 
                     AWS_ACCOUNT_ID=current_aws_account_id,
                     Region=region,
                     aws_update_tag=aws_update_tag
-                )
+                ).detach()
 
 
 def load_load_balancers(session, data, region, current_aws_account_id, aws_update_tag):
@@ -488,7 +488,7 @@ def load_load_balancers(session, data, region, current_aws_account_id, aws_updat
             AWS_ACCOUNT_ID=current_aws_account_id,
             Region=region,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
         if lb["Subnets"]:
             load_load_balancer_subnets(session, load_balancer_id, lb["Subnets"], aws_update_tag)
@@ -500,7 +500,7 @@ def load_load_balancers(session, data, region, current_aws_account_id, aws_updat
                     ID=load_balancer_id,
                     GROUP_ID=str(group),
                     aws_update_tag=aws_update_tag
-                )
+                ).detach()
 
         if lb["SourceSecurityGroup"]:
             source_group = lb["SourceSecurityGroup"]
@@ -509,7 +509,7 @@ def load_load_balancers(session, data, region, current_aws_account_id, aws_updat
                 ID=load_balancer_id,
                 GROUP_NAME=source_group["GroupName"],
                 aws_update_tag=aws_update_tag
-            )
+            ).detach()
 
         if lb["Instances"]:
             for instance in lb["Instances"]:
@@ -519,7 +519,7 @@ def load_load_balancers(session, data, region, current_aws_account_id, aws_updat
                     INSTANCE_ID=instance["InstanceId"],
                     AWS_ACCOUNT_ID=current_aws_account_id,
                     aws_update_tag=aws_update_tag
-                )
+                ).detach()
 
         if lb["ListenerDescriptions"]:
             load_load_balancer_listeners(session, load_balancer_id, lb["ListenerDescriptions"], aws_update_tag)
@@ -539,7 +539,7 @@ def load_load_balancer_subnets(session, load_balancer_id, subnets_data, aws_upda
             ID=load_balancer_id,
             SUBNET_ID=subnet_id,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
 
 def load_load_balancer_listeners(session, load_balancer_id, listener_data, aws_update_tag):
@@ -564,7 +564,7 @@ def load_load_balancer_listeners(session, load_balancer_id, listener_data, aws_u
         LoadBalancerId=load_balancer_id,
         Listeners=listener_data,
         aws_update_tag=aws_update_tag
-    )
+    ).detach()
 
 
 def load_ec2_vpc_peering(session, data, aws_update_tag):
@@ -684,7 +684,7 @@ def load_ec2_vpc_peering(session, data, aws_update_tag):
                 StatusMessage=peering["Status"]["Message"],
                 ConnectionId=peering["VpcPeeringConnectionId"],
                 ExpirationTime=peering.get("ExpirationTime", None),
-                aws_update_tag=aws_update_tag)
+                aws_update_tag=aws_update_tag).detach()
 
             for accepter_block in peering["AccepterVpcInfo"].get("CidrBlockSet", []):
                 for requestor_block in peering["RequesterVpcInfo"].get("CidrBlockSet", []):
@@ -698,7 +698,7 @@ def load_ec2_vpc_peering(session, data, aws_update_tag):
                         StatusMessage=peering["Status"]["Message"],
                         ConnectionId=peering["VpcPeeringConnectionId"],
                         ExpirationTime=peering.get("ExpirationTime", None),
-                        aws_update_tag=aws_update_tag)
+                        aws_update_tag=aws_update_tag).detach()
 
 
 def load_ec2_vpcs(session, data, region, current_aws_account_id, aws_update_tag):
@@ -760,7 +760,7 @@ def load_ec2_vpcs(session, data, region, current_aws_account_id, aws_update_tag)
             DhcpOptionsId=vpc.get("DhcpOptionsId", None),
             Region=region,
             AWS_ACCOUNT_ID=current_aws_account_id,
-            aws_update_tag=aws_update_tag)
+            aws_update_tag=aws_update_tag).detach()
 
         load_cidr_association_set(session,
                                   vpc_id=vpc_id,
@@ -826,7 +826,7 @@ def load_cidr_association_set(session, vpc_id, vpc_data, block_type, aws_update_
         VpcId=vpc_id,
         CidrBlock=data,
         aws_update_tag=aws_update_tag
-    )
+    ).detach()
 
 
 def cleanup_ec2_security_groupinfo(session, common_job_parameters):

--- a/cartography/intel/aws/elasticsearch.py
+++ b/cartography/intel/aws/elasticsearch.py
@@ -101,7 +101,7 @@ def _load_es_domains(session, domain_list, aws_account_id, aws_update_tag):
         Records=domain_list,
         AWS_ACCOUNT_ID=aws_account_id,
         aws_update_tag=aws_update_tag
-    )
+    ).detach()
 
     for domain in domain_list:
         domain_id = domain["DomainId"]
@@ -166,7 +166,7 @@ def _link_es_domain_vpc(session, domain_id, domain_data, aws_update_tag):
                 DomainId=domain_id,
                 SubnetList=subnetList,
                 aws_update_tag=aws_update_tag
-            )
+            ).detach()
 
         if len(groupList) > 0:
             session.run(
@@ -174,7 +174,7 @@ def _link_es_domain_vpc(session, domain_id, domain_data, aws_update_tag):
                 DomainId=domain_id,
                 SecGroupList=groupList,
                 aws_update_tag=aws_update_tag
-            )
+            ).detach()
 
 
 def _process_access_policy(session, domain_id, domain_data):
@@ -195,7 +195,7 @@ def _process_access_policy(session, domain_id, domain_data):
         if policy.is_internet_accessible():
             exposed_internet = True
 
-    session.run(tag_es, DomainId=domain_id, InternetExposed=exposed_internet)
+    session.run(tag_es, DomainId=domain_id, InternetExposed=exposed_internet).detach()
 
 
 def cleanup(session, update_tag, aws_account_id):

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -106,7 +106,7 @@ def load_users(session, users, current_aws_account_id, aws_update_tag):
             PASSWORD_LASTUSED=str(user.get("PasswordLastUsed", "")),
             AWS_ACCOUNT_ID=current_aws_account_id,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
 
 def load_groups(session, groups, current_aws_account_id, aws_update_tag):
@@ -131,7 +131,7 @@ def load_groups(session, groups, current_aws_account_id, aws_update_tag):
             PATH=group["Path"],
             AWS_ACCOUNT_ID=current_aws_account_id,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
 
 def load_policies(session, policies, current_aws_account_id, aws_update_tag):
@@ -163,7 +163,7 @@ def load_policies(session, policies, current_aws_account_id, aws_update_tag):
             ATTACHMENT_COUNT=policy["AttachmentCount"],
             AWS_ACCOUNT_ID=current_aws_account_id,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
 
 def load_roles(session, roles, current_aws_account_id, aws_update_tag):
@@ -203,7 +203,7 @@ def load_roles(session, roles, current_aws_account_id, aws_update_tag):
             Path=role["Path"],
             AWS_ACCOUNT_ID=current_aws_account_id,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
         for statement in role["AssumeRolePolicyDocument"]["Statement"]:
             principal = statement["Principal"]
@@ -221,7 +221,7 @@ def load_roles(session, roles, current_aws_account_id, aws_update_tag):
                     SpnType=principal_type,
                     RoleArn=role['Arn'],
                     aws_update_tag=aws_update_tag
-                )
+                ).detach()
 
 
 def load_group_memberships(session, group_memberships, aws_update_tag):
@@ -242,7 +242,7 @@ def load_group_memberships(session, group_memberships, aws_update_tag):
                 GroupName=group_name,
                 PrincipalArn=principal_arn,
                 aws_update_tag=aws_update_tag
-            )
+            ).detach()
 
 
 def _find_roles_assumable_in_policy(policy_data):
@@ -280,7 +280,7 @@ def load_group_policies(session, group_policies, aws_update_tag):
                     GroupName=group_name,
                     RoleArn=role_arn,
                     aws_update_tag=aws_update_tag
-                )
+                ).detach()
 
 
 def load_role_policies(session, role_policies, aws_update_tag):
@@ -306,7 +306,7 @@ def load_role_policies(session, role_policies, aws_update_tag):
                     RoleName=role_name,
                     RoleArn=role_arn,
                     aws_update_tag=aws_update_tag
-                )
+                ).detach()
 
 
 def load_user_access_keys(session, user_access_keys, aws_update_tag):
@@ -333,7 +333,7 @@ def load_user_access_keys(session, user_access_keys, aws_update_tag):
                     CreateDate=str(key['CreateDate']),
                     Status=key['Status'],
                     aws_update_tag=aws_update_tag
-                )
+                ).detach()
 
 
 def sync_users(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):

--- a/cartography/intel/aws/organizations.py
+++ b/cartography/intel/aws/organizations.py
@@ -105,7 +105,7 @@ def load_aws_accounts(neo4j_session, aws_accounts, aws_update_tag, common_job_pa
             ACCOUNT_NAME=account_name,
             RootArn=root_arn,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
 
 def cleanup(neo4j_session, common_job_parameters):

--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -104,7 +104,7 @@ def load_rds_instances(neo4j_session, data, region, current_aws_account_id, aws_
             Region=region,
             AWS_ACCOUNT_ID=current_aws_account_id,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
         _attach_ec2_security_groups(neo4j_session, rds, aws_update_tag)
         _attach_ec2_subnet_groups(neo4j_session, rds, region, current_aws_account_id, aws_update_tag)
     _attach_read_replicas(neo4j_session, read_replicas, aws_update_tag)
@@ -140,7 +140,7 @@ def _attach_ec2_subnet_groups(neo4j_session, instance, region, current_aws_accou
             DBSubnetGroupStatus=db_sng.get('SubnetGroupStatus'),
             DBInstanceArn=instance['DBInstanceArn'],
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
         _attach_ec2_subnets_to_subnetgroup(neo4j_session, db_sng, region, current_aws_account_id, aws_update_tag)
 
 
@@ -172,7 +172,7 @@ def _attach_ec2_subnets_to_subnetgroup(neo4j_session, db_subnet_group, region, c
             sng_arn=arn,
             aws_update_tag=aws_update_tag,
             SubnetAvailabilityZone=sn.get('SubnetAvailabilityZone', {}).get('Name')
-        )
+        ).detach()
 
 
 def _attach_ec2_security_groups(neo4j_session, instance, aws_update_tag):
@@ -192,7 +192,7 @@ def _attach_ec2_security_groups(neo4j_session, instance, aws_update_tag):
             RdsArn=instance['DBInstanceArn'],
             GroupId=group['VpcSecurityGroupId'],
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
 
 def _attach_read_replicas(neo4j_session, read_replicas, aws_update_tag):
@@ -212,7 +212,7 @@ def _attach_read_replicas(neo4j_session, read_replicas, aws_update_tag):
             ReplicaArn=replica['DBInstanceArn'],
             SourceInstanceIdentifier=replica['ReadReplicaSourceDBInstanceIdentifier'],
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
 
 def _validate_rds_endpoint(rds):

--- a/cartography/intel/aws/route53.py
+++ b/cartography/intel/aws/route53.py
@@ -13,7 +13,7 @@ def link_aws_resources(session, update_tag):
     ON CREATE SET p.firstseen = timestamp()
     SET p.lastupdated = {aws_update_tag}
     """
-    session.run(link_records, aws_update_tag=update_tag)
+    session.run(link_records, aws_update_tag=update_tag).detach()
 
     # find records that point to AWS LoadBalancers
     link_elb = """
@@ -22,7 +22,7 @@ def link_aws_resources(session, update_tag):
     ON CREATE SET p.firstseen = timestamp()
     SET p.lastupdated = {aws_update_tag}
     """
-    session.run(link_elb, aws_update_tag=update_tag)
+    session.run(link_elb, aws_update_tag=update_tag).detach()
 
     # find records that point to AWS EC2 Instances
     link_ec2 = """
@@ -31,7 +31,7 @@ def link_aws_resources(session, update_tag):
     ON CREATE SET p.firstseen = timestamp()
     SET p.lastupdated = {aws_update_tag}
     """
-    session.run(link_ec2, aws_update_tag=update_tag)
+    session.run(link_ec2, aws_update_tag=update_tag).detach()
 
 
 def load_a_records(session, records, update_tag):
@@ -50,7 +50,7 @@ def load_a_records(session, records, update_tag):
         ingest_records,
         records=records,
         aws_update_tag=update_tag
-    )
+    ).detach()
 
 
 def load_alias_records(session, records, update_tag):
@@ -70,7 +70,7 @@ def load_alias_records(session, records, update_tag):
         ingest_records,
         records=records,
         aws_update_tag=update_tag
-    )
+    ).detach()
 
 
 def load_cname_records(session, records, update_tag):
@@ -89,7 +89,7 @@ def load_cname_records(session, records, update_tag):
         ingest_records,
         records=records,
         aws_update_tag=update_tag
-    )
+    ).detach()
 
 
 def load_zone(session, zone, current_aws_id, update_tag):
@@ -111,7 +111,7 @@ def load_zone(session, zone, current_aws_id, update_tag):
         PrivateZone=zone['privatezone'],
         AWS_ACCOUNT_ID=current_aws_id,
         aws_update_tag=update_tag
-    )
+    ).detach()
 
 
 def parse_record_set(record_set, zone_id):

--- a/cartography/intel/aws/s3.py
+++ b/cartography/intel/aws/s3.py
@@ -80,7 +80,7 @@ def _load_s3_acls(session, acls, aws_account_id, update_tag):
         ingest_acls,
         acls=acls,
         UpdateTag=update_tag
-    )
+    ).detach()
 
     # implement the acl permission
     # https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#permissions
@@ -108,7 +108,7 @@ def _load_s3_policies(session, policies, update_tag):
         ingest_policies,
         policies=policies,
         UpdateTag=update_tag
-    )
+    ).detach()
 
 
 def _set_default_values(session, aws_account_id):
@@ -120,7 +120,7 @@ def _set_default_values(session, aws_account_id):
     session.run(
         set_defaults,
         AWS_ID=aws_account_id
-    )
+    ).detach()
 
 
 def load_s3_details(session, s3_details_iter, aws_account_id, update_tag):
@@ -300,7 +300,7 @@ def load_s3_buckets(session, data, current_aws_account_id, aws_update_tag):
             CreationDate=str(bucket["CreationDate"]),
             AWS_ACCOUNT_ID=current_aws_account_id,
             aws_update_tag=aws_update_tag
-        )
+        ).detach()
 
 
 def cleanup_s3_buckets(session, common_job_parameters):

--- a/cartography/intel/create_indexes.py
+++ b/cartography/intel/create_indexes.py
@@ -19,4 +19,4 @@ def run(neo4j_session, config):
     logger.info("Creating indexes for cartography node types.")
     for statement in get_index_statements():
         logger.debug("Executing statement: %s", statement)
-        neo4j_session.run(statement)
+        neo4j_session.run(statement).detach()

--- a/cartography/intel/crxcavator/crxcavator.py
+++ b/cartography/intel/crxcavator/crxcavator.py
@@ -137,7 +137,7 @@ def load_extensions(extensions, session, update_tag):
     """
 
     logger.info('Ingesting {} extensions'.format(len(extensions)))
-    session.run(ingestion_cypher, ExtensionsData=extensions, UpdateTag=update_tag)
+    session.run(ingestion_cypher, ExtensionsData=extensions, UpdateTag=update_tag).detach()
 
 
 def transform_user_extensions(user_extension_json):
@@ -192,9 +192,9 @@ def load_user_extensions(users, extensions_by_user, session, update_tag):
     """
 
     logger.info('Ingesting {} users'.format(len(users)))
-    session.run(user_ingestion_cypher, Users=users, UpdateTag=update_tag)
+    session.run(user_ingestion_cypher, Users=users, UpdateTag=update_tag).detach()
     logger.info('Ingesting {} user->extension relationships'.format(len(extensions_by_user)))
-    session.run(extension_ingestion_cypher, ExtensionsUsers=extensions_by_user, UpdateTag=update_tag)
+    session.run(extension_ingestion_cypher, ExtensionsUsers=extensions_by_user, UpdateTag=update_tag).detach()
 
 
 def sync_extensions(session, common_job_parameters, crxcavator_api_key, crxcavator_base_url):

--- a/cartography/intel/dns.py
+++ b/cartography/intel/dns.py
@@ -65,7 +65,7 @@ def _link_ip_to_A_record(session, update_tag, ip_list, parent_record):
         ParentId=parent_record,
         IP_LIST=ip_list,
         update_tag=update_tag
-    )
+    ).detach()
 
 
 def ingest_dns_record(session, name, value, type, update_tag, points_to_record):
@@ -101,7 +101,7 @@ def ingest_dns_record(session, name, value, type, update_tag, points_to_record):
         Value=value,
         PointsToId=points_to_record,
         update_tag=update_tag
-    )
+    ).detach()
 
     return record_id
 

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -430,7 +430,7 @@ def load_gcp_instances(neo4j_session, data, gcp_update_tag):
             ZoneName=instance['zone_name'],
             Hostname=instance.get('hostname', None),
             gcp_update_tag=gcp_update_tag
-        )
+        ).detach()
         _attach_instance_tags(neo4j_session, instance, gcp_update_tag)
         _attach_gcp_nics(neo4j_session, instance, gcp_update_tag)
         _attach_gcp_vpc(neo4j_session, instance['partial_uri'], gcp_update_tag)
@@ -475,7 +475,7 @@ def load_gcp_vpcs(neo4j_session, vpcs, gcp_update_tag):
             RoutingMode=vpc['routing_config_routing_mode'],
             Description=vpc['description'],
             gcp_update_tag=gcp_update_tag
-        )
+        ).detach()
 
 
 def load_gcp_subnets(neo4j_session, subnets, gcp_update_tag):
@@ -522,7 +522,7 @@ def load_gcp_subnets(neo4j_session, subnets, gcp_update_tag):
             IpCidrRange=s['ip_cidr_range'],
             PrivateIpGoogleAccess=s['private_ip_google_access'],
             gcp_update_tag=gcp_update_tag
-        )
+        ).detach()
 
 
 def _attach_instance_tags(neo4j_session, instance, gcp_update_tag):
@@ -563,7 +563,7 @@ def _attach_instance_tags(neo4j_session, instance, gcp_update_tag):
                 TagValue=tag,
                 VpcPartialUri=nic['vpc_partial_uri'],
                 gcp_update_tag=gcp_update_tag
-            )
+            ).detach()
 
 
 def _attach_gcp_nics(neo4j_session, instance, gcp_update_tag):
@@ -608,7 +608,7 @@ def _attach_gcp_nics(neo4j_session, instance, gcp_update_tag):
             NicName=nic['name'],
             gcp_update_tag=gcp_update_tag,
             SubnetPartialUri=nic['subnet_partial_uri']
-        )
+        ).detach()
         _attach_gcp_nic_access_configs(neo4j_session, nic_id, nic, gcp_update_tag)
 
 
@@ -651,7 +651,7 @@ def _attach_gcp_nic_access_configs(neo4j_session, nic_id, nic, gcp_update_tag):
             PublicPtrDomainName=ac.get('publicPtrDomainName', None),
             NetworkTier=ac.get('networkTier', None),
             gcp_update_tag=gcp_update_tag
-        )
+        ).detach()
 
 
 def _attach_gcp_vpc(neo4j_session, instance_id, gcp_update_tag):
@@ -673,7 +673,7 @@ def _attach_gcp_vpc(neo4j_session, instance_id, gcp_update_tag):
         query,
         InstanceId=instance_id,
         gcp_update_tag=gcp_update_tag
-    )
+    ).detach()
 
 
 def load_gcp_ingress_firewalls(neo4j_session, fw_list, gcp_update_tag):
@@ -715,7 +715,7 @@ def load_gcp_ingress_firewalls(neo4j_session, fw_list, gcp_update_tag):
             VpcPartialUri=fw['vpc_partial_uri'],
             HasTargetServiceAccounts=fw['has_target_service_accounts'],
             gcp_update_tag=gcp_update_tag
-        )
+        ).detach()
         _attach_firewall_rules(neo4j_session, fw, gcp_update_tag)
         _attach_target_tags(neo4j_session, fw, gcp_update_tag)
 
@@ -775,7 +775,7 @@ def _attach_firewall_rules(neo4j_session, fw, gcp_update_tag):
                     ToPort=rule.get('toport'),
                     Range=ip_range,
                     gcp_update_tag=gcp_update_tag
-                )
+                ).detach()
 
 
 def _attach_target_tags(neo4j_session, fw, gcp_update_tag):
@@ -807,7 +807,7 @@ def _attach_target_tags(neo4j_session, fw, gcp_update_tag):
             TagId=tag_id,
             TagValue=tag,
             gcp_update_tag=gcp_update_tag
-        )
+        ).detach()
 
 
 def cleanup_gcp_instances(session, common_job_parameters):

--- a/cartography/intel/gcp/crm.py
+++ b/cartography/intel/gcp/crm.py
@@ -82,7 +82,7 @@ def load_gcp_organizations(neo4j_session, data, gcp_update_tag):
             DisplayName=org_object.get('displayName', None),
             LifecycleState=org_object.get('lifecycleState', None),
             gcp_update_tag=gcp_update_tag
-        )
+        ).detach()
 
 
 def load_gcp_folders(neo4j_session, data, gcp_update_tag):
@@ -123,7 +123,7 @@ def load_gcp_folders(neo4j_session, data, gcp_update_tag):
             DisplayName=folder.get('displayName', None),
             LifecycleState=folder.get('lifecycleState', None),
             gcp_update_tag=gcp_update_tag
-        )
+        ).detach()
 
 
 def load_gcp_projects(neo4j_session, data, gcp_update_tag):
@@ -167,7 +167,7 @@ def load_gcp_projects(neo4j_session, data, gcp_update_tag):
             DisplayName=project.get('name', None),
             LifecycleState=project.get('lifecycleState', None),
             gcp_update_tag=gcp_update_tag
-        )
+        ).detach()
 
 
 def cleanup_gcp_organizations(session, common_job_parameters):


### PR DESCRIPTION
Hi maintainers.

When a large number of queries were executed, the socket buffer was stuck unless the execution results were not read.
I fixed it by discard unneeded query result.