### PR TITLE
Change AWS sync function names to be consistent throughout the intel module.

### DIFF
--- a/cartography/intel/aws/dynamodb.py
+++ b/cartography/intel/aws/dynamodb.py
@@ -88,3 +88,13 @@ def sync_dynamodb_tables(
         data = get_dynamodb_tables(boto3_session, region)
         load_dynamodb_tables(neo4j_session, data, region, current_aws_account_id, aws_update_tag)
     cleanup_dynamodb_tables(neo4j_session, common_job_parameters)
+
+
+def sync(
+        neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
+        common_job_parameters,
+):
+    sync_dynamodb_tables(
+        neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
+        common_job_parameters,
+    )

--- a/cartography/intel/aws/ec2.py
+++ b/cartography/intel/aws/ec2.py
@@ -1008,3 +1008,14 @@ def sync_vpc_peering(
         data = get_ec2_vpc_peering(boto3_session, region)
         load_ec2_vpc_peering(neo4j_session, data, aws_update_tag)
     cleanup_ec2_vpc_peering(neo4j_session, common_job_parameters)
+
+
+def sync(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters):
+    logger.info("Syncing EC2 for account '%s'.", account_id)
+    sync_vpc(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
+    sync_ec2_security_groupinfo(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
+    sync_ec2_key_pairs(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
+    sync_ec2_instances(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
+    sync_ec2_auto_scaling_groups(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
+    sync_load_balancers(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)
+    sync_vpc_peering(neo4j_session, boto3_session, regions, sync_tag, account_id, common_job_parameters)

--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -255,3 +255,7 @@ def sync_rds_instances(
         data = get_rds_instance_data(boto3_session, region)
         load_rds_instances(neo4j_session, data, region, current_aws_account_id, aws_update_tag)
     cleanup_rds_instances_and_db_subnet_groups(neo4j_session, common_job_parameters)
+
+
+def sync(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters):
+    sync_rds_instances(neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters)

--- a/cartography/intel/aws/route53.py
+++ b/cartography/intel/aws/route53.py
@@ -250,7 +250,7 @@ def cleanup_route53(neo4j_session, current_aws_id, update_tag):
     )
 
 
-def sync_route53(neo4j_session, boto3_session, aws_id, update_tag):
+def sync(neo4j_session, boto3_session, aws_id, update_tag):
     logger.info("Syncing Route53 for account '%s'.", aws_id)
     client = boto3_session.client('route53')
     zones = get_zones(client)


### PR DESCRIPTION
Push details of ec2 syncing into separate file, to align with all other aspects of AWS syncing. Also align function names, to use ”sync” everywhere.