### PR TITLE
Loosen up issue staleness rules.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 7
+daysUntilStale: 14
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 14
+daysUntilClose: 21
 # Issues with these labels will never be considered stale
 exemptLabels:
   - keep fresh


### PR DESCRIPTION
It seems the capacity of project reviewers to comment, review and test issues and PRs has lowered recently. Make the stalebot less aggressive to avoid closing issues due to that.