### PR TITLE
#205: Delete python-dateutil from setup.py since we don't use it directly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "neo4j>=1.7.0,<4.0.0",
         "neobolt>=1.7.0,<4.0.0",
         "policyuniverse>=1.1.0.0",
-        "python-dateutil>=2.7.0",
+        "python-dateutil<2.8.1",
         "google-api-python-client>=1.7.8",
         "oauth2client>=4.1.3",
         "marshmallow>=3.0.0rc7",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "neo4j>=1.7.0,<4.0.0",
         "neobolt>=1.7.0,<4.0.0",
         "policyuniverse>=1.1.0.0",
-        "python-dateutil>=2.7.0,<2.8.1",
         "google-api-python-client>=1.7.8",
         "oauth2client>=4.1.3",
         "marshmallow>=3.0.0rc7",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "neo4j>=1.7.0,<4.0.0",
         "neobolt>=1.7.0,<4.0.0",
         "policyuniverse>=1.1.0.0",
-        "python-dateutil<2.8.1",
+        "python-dateutil>=2.7.0,<2.8.1",
         "google-api-python-client>=1.7.8",
         "oauth2client>=4.1.3",
         "marshmallow>=3.0.0rc7",


### PR DESCRIPTION
See #205 and https://github.com/boto/botocore/issues/1872, in particular [this comment](https://github.com/boto/botocore/issues/1872#issuecomment-549612354).

> This would only be an issue if you're installing something else that is pulling in the latest version of dateutils. If I just use pip install botocore, it pulls in the right version of dateutils.

Cartography pulls in the latest version of dateutils which conflicts with botocore, so we need to cap it for now.