### PR TITLE
#165: Nameserver name fix

### DIFF
--- a/cartography/intel/aws/route53.py
+++ b/cartography/intel/aws/route53.py
@@ -237,13 +237,15 @@ def parse_record_set(record_set, zone_id, name):
 
 
 def parse_ns_record_set(record_set, zone_id):
+
     if "ResourceRecords" in record_set:
-        servers = [record["Value"][:-1] for record in record_set["ResourceRecords"]]
+        # Sometimes the value records have a trailing period, sometimes they dont.
+        servers = [_normalize_dns_address(record["Value"]) for record in record_set["ResourceRecords"]]
         return {
             "zoneid": zone_id,
             "type": "NS",
             # looks like "name.some.fqdn.net.", so this removes the trailing comma.
-            "name": record_set["Name"][:-1],
+            "name": _normalize_dns_address(record_set["Name"]),
             "servers": servers,
             "id": _generate_id(zone_id, record_set['Name'][:-1], 'NS'),
         }
@@ -326,6 +328,12 @@ def get_zones(client):
 
 def _generate_id(zoneid, name, record_type):
     return "/".join([zoneid, name, record_type])
+
+
+def _normalize_dns_address(address):
+    if address.endswith('.'):
+        address = address[:-1]
+    return address
 
 
 def cleanup_route53(neo4j_session, current_aws_id, update_tag):

--- a/cartography/intel/aws/route53.py
+++ b/cartography/intel/aws/route53.py
@@ -331,9 +331,7 @@ def _generate_id(zoneid, name, record_type):
 
 
 def _normalize_dns_address(address):
-    if address.endswith('.'):
-        address = address[:-1]
-    return address
+    return address.rstrip('.')
 
 
 def cleanup_route53(neo4j_session, current_aws_id, update_tag):

--- a/tests/data/aws/route53.py
+++ b/tests/data/aws/route53.py
@@ -3,7 +3,7 @@ NS_RECORD = {
     "Type": "NS",
     "TTL": 172800,
     "ResourceRecords": [
-        {"Value": "ns-856.awsdns-43.net."},
+        {"Value": "ns-856.awsdns-43.net"},
         {"Value": "ns-1418.awsdns-49.org."},
         {"Value": "ns-1913.awsdns-47.co.uk."},
         {"Value": "ns-192.awsdns-24.com."},

--- a/tests/integration/cartography/intel/aws/test_route53.py
+++ b/tests/integration/cartography/intel/aws/test_route53.py
@@ -17,8 +17,9 @@ def test_cname(neo4j_session):
 def test_ns(neo4j_session):
     # Test that ns records can be parsed and loaded
     data = tests.data.aws.route53.NS_RECORD
-    parsed_data = [cartography.intel.aws.route53.parse_ns_record_set(data, TEST_ZONE_ID)]
-    cartography.intel.aws.route53.load_ns_records(neo4j_session, parsed_data, TEST_ZONE_NAME, TEST_UPDATE_TAG)
+    parsed_data = cartography.intel.aws.route53.parse_ns_record_set(data, TEST_ZONE_ID)
+    assert "ns-856.awsdns-43.net" in parsed_data["servers"]
+    cartography.intel.aws.route53.load_ns_records(neo4j_session, [parsed_data], TEST_ZONE_NAME, TEST_UPDATE_TAG)
 
 
 def test_zone(neo4j_session):


### PR DESCRIPTION
Fixes #165 
Some nameservers end in . some don't. The nameservers that don't end in '.' were losing their last character. This PR fixes that by normalizing all all of the endings