### PR TITLE
Specifying edition of Neo4j requirement and linking to JRE download

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ You can learn more about the story behind Cartography in our [presentation at BS
 Time to set up the server that will run Cartography.  Cartography _should_ work on both Linux and Windows servers, but bear in mind we've only tested it in Linux so far.  Cartography requires Python 3.6 or greater.
 
 1. **Get and install the Neo4j graph database** on your server.
+	1. Neo4j requires a JVM (JDK/JRE 11 or higher) to be installed. We suggest downloading and installing [Amazon Coretto 11](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/what-is-corretto-11.html).
 
 	1. Go to the [Neo4j download page](https://neo4j.com/download-center/#releases), click "Community Server" and download Neo4j Community Edition 3.5.\*.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -19,7 +19,7 @@
 
 1. **Install**
 
-    Follow steps 1 and 2 in [Installation](https://github.com/lyft/cartography/blob/master/README.md#installation).  Ensure that Neo4j Community is running on your local machine.
+    Follow steps 1 and 2 in [Installation](https://github.com/lyft/cartography/blob/master/README.md#installation).  Ensure that you have JVM 11 installed and Neo4j Community Edition 3.5 is running on your local machine.
 2. **Clone the source code**
 
     Run `cd {path-where-you-want-your-source-code}`.  Get the source code with `git clone git://github.com/lyft/cartography.git`


### PR DESCRIPTION
In case someone doesn't read the page linked to "Follow steps 1 and 2 in [Installation]" and installs the wrong version of Neo4j (like I did 🥇)

Also adding a link to the Amazon Correto JRE just to make it easier for new users. Oracle makes people sign up to download their JRE now.