### PR TITLE
GitHub Documentation: fix title

### DIFF
--- a/docs/schema/github.md
+++ b/docs/schema/github.md
@@ -1,4 +1,4 @@
-# Cartography - CRXcavator Schema
+# Cartography - GitHub Schema
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->


### PR DESCRIPTION
Very small PR to fix the title of the GitHub related page in the `docs` folder