### PR TITLE
Respect AWS_PROFILE environment variable for default account

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import boto3
 import botocore.exceptions
@@ -78,7 +79,8 @@ def start_aws_ingestion(neo4j_session, config):
         "UPDATE_TAG": config.update_tag,
     }
     try:
-        boto3_session = boto3.Session()
+        profile_name = os.getenv("AWS_PROFILE", default="default") or "default"
+        boto3_session = boto3.Session(profile_name=profile_name)
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         logger.debug("Error occurred calling boto3.Session().", exc_info=True)
         logger.error(

--- a/cartography/intel/aws/organizations.py
+++ b/cartography/intel/aws/organizations.py
@@ -24,7 +24,7 @@ def get_current_aws_account_id(boto3_session):
 
 def get_aws_account_default(boto3_session):
     try:
-        return {"default": get_current_aws_account_id(boto3_session)}
+        return {boto3_session.profile_name: get_current_aws_account_id(boto3_session)}
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         logger.debug("Error occurred getting default AWS account number.", exc_info=True)
         logger.error(

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -28,13 +28,19 @@ Time to set up the server that will run Cartography.  Cartography _should_ work 
 
 	1. Finally, to sync your data:
 
-		- If you have one AWS account, run
+		- For one account using the `default` profile defined in your AWS config file, run
 
 			```
 			cartography --neo4j-uri <uri for your neo4j instance; usually bolt://localhost:7687>
 			```
 
-		- If you have more than one AWS account, run
+		- Or for a specific account defined as a separate profile in your AWS config file, set the `AWS_PROFILE` environment variable, for example
+
+			```
+			AWS_PROFILE=other-profile cartography --neo4j-uri <uri for your neo4j instance; usually bolt://localhost:7687>
+			```
+
+		- For more than one AWS account, run
 
 			```
 			AWS_CONFIG_FILE=/path/to/your/aws/config cartography --neo4j-uri <uri for your neo4j instance; usually bolt://localhost:7687> --aws-sync-all-profiles


### PR DESCRIPTION
The `boto3_session` will use the `AWS_PROFILE` when discovering the account ID.  However later, uses the `default` profile name for syncing and will fail with a `NoCredentialsError`.   

This sets the profile name for the default account to that of `AWS_PROFILE` otherwise `default` if unset or the empty string.

