### PR TITLE
Allow boto3 to determine the current profile name

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import boto3
 import botocore.exceptions
@@ -79,8 +78,7 @@ def start_aws_ingestion(neo4j_session, config):
         "UPDATE_TAG": config.update_tag,
     }
     try:
-        profile_name = os.getenv("AWS_PROFILE", default="default") or "default"
-        boto3_session = boto3.Session(profile_name=profile_name)
+        boto3_session = boto3.Session()
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         logger.debug("Error occurred calling boto3.Session().", exc_info=True)
         logger.error(


### PR DESCRIPTION
A small fix to revert the changes that picks up the `AWS_PROFILE` environment variable and now lets boto3 decide, as highlighted in https://github.com/lyft/cartography/pull/272#discussion_r406471526 

For a single account, `boto3_session.profile_name` will contain the correct value at https://github.com/lyft/cartography/blob/713cc5b3f9bc410e61ae5f7e595b15b39ab588bf/cartography/intel/aws/organizations.py#L27