### PR TITLE
Measure sync times: add statsd to cartography

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -4,7 +4,10 @@ import logging
 import os
 import sys
 
+from statsd import StatsClient
+
 import cartography.sync
+import cartography.util
 
 
 logger = logging.getLogger(__name__)
@@ -178,6 +181,37 @@ class CLI:
                 'Required if you are using the GitHub intel module. Ignored otherwise.'
             ),
         )
+        parser.add_argument(
+            '--statsd-enabled',
+            action='store_true',
+            help=(
+                'If set, enables sending metrics using statsd to a server of your choice.'
+            )
+        )
+        parser.add_argument(
+            '--statsd-prefix',
+            type=str,
+            default='',
+            help=(
+                'The string to prefix statsd metrics with. Only used if --statsd-enabled is on. Empty string by default.'
+            )
+        )
+        parser.add_argument(
+            '--statsd-host',
+            type=str,
+            default='127.0.0.1',
+            help=(
+                'The IP address of your statsd server. Only used if --statsd-enabled is on. Default = 127.0.0.1.'
+            )
+        )
+        parser.add_argument(
+            '--statsd-port',
+            type=int,
+            default=8125,
+            help=(
+                'The port of your statsd server. Only used if --statsd-enabled is on. Default = UDP 8125.'
+            )
+        )
         return parser
 
     def main(self, argv):
@@ -233,6 +267,14 @@ class CLI:
             config.github_config = os.environ.get(config.github_config_env_var)
         else:
             config.github_config = None
+
+        # Statsd config
+        if config.statsd_enabled:
+            cartography.util.stats_client = StatsClient(
+                host=config.statsd_host,
+                port=config.statsd_port,
+                prefix=config.statsd_prefix,
+            )
 
         # Run cartography
         try:

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -186,7 +186,7 @@ class CLI:
             action='store_true',
             help=(
                 'If set, enables sending metrics using statsd to a server of your choice.'
-            )
+            ),
         )
         parser.add_argument(
             '--statsd-prefix',
@@ -194,7 +194,7 @@ class CLI:
             default='',
             help=(
                 'The string to prefix statsd metrics with. Only used if --statsd-enabled is on. Empty string by default.'
-            )
+            ),
         )
         parser.add_argument(
             '--statsd-host',
@@ -202,7 +202,7 @@ class CLI:
             default='127.0.0.1',
             help=(
                 'The IP address of your statsd server. Only used if --statsd-enabled is on. Default = 127.0.0.1.'
-            )
+            ),
         )
         parser.add_argument(
             '--statsd-port',
@@ -210,7 +210,7 @@ class CLI:
             default=8125,
             help=(
                 'The port of your statsd server. Only used if --statsd-enabled is on. Default = UDP 8125.'
-            )
+            ),
         )
         return parser
 

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -193,7 +193,7 @@ class CLI:
             type=str,
             default='',
             help=(
-                'The string to prefix statsd metrics with. Only used if --statsd-enabled is on. Empty string by default.'
+                'The string to prefix statsd metrics with. Only used if --statsd-enabled is on. Default = empty string.'
             ),
         )
         parser.add_argument(

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -47,6 +47,10 @@ class Config:
         okta_api_key=None,
         okta_saml_role_regex=None,
         github_config=None,
+        statsd_enabled=False,
+        statsd_prefix=None,
+        statsd_host=None,
+        statsd_port=None,
     ):
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user
@@ -60,3 +64,7 @@ class Config:
         self.okta_api_key = okta_api_key
         self.okta_saml_role_regex = okta_saml_role_regex
         self.github_config = github_config
+        self.statsd_enabled = statsd_enabled
+        self.statsd_prefix = statsd_prefix
+        self.statsd_host = statsd_host
+        self.statsd_port = statsd_port

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import boto3
 import botocore.exceptions
@@ -79,8 +78,7 @@ def start_aws_ingestion(neo4j_session, config):
         "UPDATE_TAG": config.update_tag,
     }
     try:
-        profile_name = os.getenv("AWS_PROFILE", default="default") or "default"
-        boto3_session = boto3.Session(profile_name=profile_name)
+        boto3_session = boto3.Session()
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         logger.debug("Error occurred calling boto3.Session().", exc_info=True)
         logger.error(

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -15,6 +15,7 @@ from . import route53
 from . import s3
 from cartography.util import run_analysis_job
 from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,7 @@ def _sync_multiple_accounts(neo4j_session, accounts, sync_tag, common_job_parame
     run_cleanup_job('aws_post_ingestion_dns_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def start_aws_ingestion(neo4j_session, config):
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,

--- a/cartography/intel/aws/dynamodb.py
+++ b/cartography/intel/aws/dynamodb.py
@@ -1,6 +1,7 @@
 import logging
 
-from cartography.util import run_cleanup_job, timeit
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 

--- a/cartography/intel/aws/ec2.py
+++ b/cartography/intel/aws/ec2.py
@@ -4,7 +4,8 @@ from string import Template
 
 import botocore.config
 
-from cartography.util import run_cleanup_job, timeit
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +18,7 @@ def _get_botocore_config():
             'max_attempts': 10,
         },
     )
+
 
 @timeit
 def get_ec2_regions(boto3_session):

--- a/cartography/intel/aws/ec2.py
+++ b/cartography/intel/aws/ec2.py
@@ -4,7 +4,7 @@ from string import Template
 
 import botocore.config
 
-from cartography.util import run_cleanup_job
+from cartography.util import run_cleanup_job, timeit
 
 logger = logging.getLogger(__name__)
 
@@ -18,13 +18,14 @@ def _get_botocore_config():
         },
     )
 
-
+@timeit
 def get_ec2_regions(boto3_session):
     client = boto3_session.client('ec2')
     result = client.describe_regions()
     return [r['RegionName'] for r in result['Regions']]
 
 
+@timeit
 def get_ec2_security_group_data(boto3_session, region):
     client = boto3_session.client('ec2', region_name=region, config=_get_botocore_config())
     paginator = client.get_paginator('describe_security_groups')
@@ -34,12 +35,14 @@ def get_ec2_security_group_data(boto3_session, region):
     return {'SecurityGroups': security_groups}
 
 
+@timeit
 def get_ec2_key_pairs(boto3_session, region):
     client = boto3_session.client('ec2', region_name=region, config=_get_botocore_config())
     result = client.describe_key_pairs()
     return result
 
 
+@timeit
 def get_ec2_instances(boto3_session, region):
     client = boto3_session.client('ec2', region_name=region, config=_get_botocore_config())
     paginator = client.get_paginator('describe_instances')
@@ -49,6 +52,7 @@ def get_ec2_instances(boto3_session, region):
     return {'Reservations': reservations}
 
 
+@timeit
 def get_ec2_auto_scaling_groups(boto3_session, region):
     client = boto3_session.client('autoscaling', region_name=region, config=_get_botocore_config())
     paginator = client.get_paginator('describe_auto_scaling_groups')
@@ -58,6 +62,7 @@ def get_ec2_auto_scaling_groups(boto3_session, region):
     return {'AutoScalingGroups': asgs}
 
 
+@timeit
 def get_loadbalancer_data(boto3_session, region):
     client = boto3_session.client('elb', region_name=region, config=_get_botocore_config())
     paginator = client.get_paginator('describe_load_balancers')
@@ -67,6 +72,7 @@ def get_loadbalancer_data(boto3_session, region):
     return {'LoadBalancerDescriptions': elbs}
 
 
+@timeit
 def get_load_balancer_v2_listeners(client, load_balancer_arn):
     paginator = client.get_paginator('describe_listeners')
     listeners = []
@@ -76,6 +82,7 @@ def get_load_balancer_v2_listeners(client, load_balancer_arn):
     return listeners
 
 
+@timeit
 def get_load_balancer_v2_target_groups(client, load_balancer_arn):
     paginator = client.get_paginator('describe_target_groups')
     target_groups = []
@@ -92,6 +99,7 @@ def get_load_balancer_v2_target_groups(client, load_balancer_arn):
     return target_groups
 
 
+@timeit
 def get_loadbalancer_v2_data(boto3_session, region):
     client = boto3_session.client('elbv2', region_name=region, config=_get_botocore_config())
     paginator = client.get_paginator('describe_load_balancers')
@@ -107,18 +115,21 @@ def get_loadbalancer_v2_data(boto3_session, region):
     return {'LoadBalancers': elbv2s}
 
 
+@timeit
 def get_ec2_vpc_peering(boto3_session, region):
     client = boto3_session.client('ec2', region_name=region, config=_get_botocore_config())
     # paginator not supported by boto
     return client.describe_vpc_peering_connections()
 
 
+@timeit
 def get_ec2_vpcs(boto3_session, region):
     client = boto3_session.client('ec2', region_name=region, config=_get_botocore_config())
     # paginator not supported by boto
     return client.describe_vpcs()
 
 
+@timeit
 def load_ec2_key_pairs(neo4j_session, data, region, current_aws_account_id, aws_update_tag):
     ingest_key_pair = """
     MERGE (keypair:KeyPair:EC2KeyPair{arn: {ARN}, id: {ARN}})
@@ -148,6 +159,7 @@ def load_ec2_key_pairs(neo4j_session, data, region, current_aws_account_id, aws_
         )
 
 
+@timeit
 def load_ec2_instances(neo4j_session, data, region, current_aws_account_id, aws_update_tag):
     ingest_reservation = """
     MERGE (reservation:EC2Reservation{reservationid: {ReservationId}})
@@ -295,6 +307,7 @@ def load_ec2_instances(neo4j_session, data, region, current_aws_account_id, aws_
             load_ec2_instance_network_interfaces(neo4j_session, instance, aws_update_tag)
 
 
+@timeit
 def load_ec2_instance_network_interfaces(neo4j_session, instance_data, aws_update_tag):
     ingest_network_interface = """
     MATCH (instance:EC2Instance{instanceid: {InstanceId}})
@@ -348,6 +361,7 @@ def load_ec2_instance_network_interfaces(neo4j_session, instance_data, aws_updat
             ).consume()  # TODO see issue 170
 
 
+@timeit
 def load_ec2_security_groupinfo(neo4j_session, data, region, current_aws_account_id, aws_update_tag):
     ingest_security_group = """
     MERGE (group:EC2SecurityGroup{id: {GroupId}})
@@ -383,6 +397,7 @@ def load_ec2_security_groupinfo(neo4j_session, data, region, current_aws_account
         load_ec2_security_group_rule(neo4j_session, group, "IpPermissionEgress", aws_update_tag)
 
 
+@timeit
 def load_ec2_security_group_rule(neo4j_session, group, rule_type, aws_update_tag):
     INGEST_RULE_TEMPLATE = Template("""
     MERGE (rule:$rule_label{ruleid: {RuleId}})
@@ -457,6 +472,7 @@ def load_ec2_security_group_rule(neo4j_session, group, rule_type, aws_update_tag
                 )
 
 
+@timeit
 def load_ec2_auto_scaling_groups(neo4j_session, data, region, current_aws_account_id, aws_update_tag):
     ingest_group = """
     MERGE (group:AutoScalingGroup{arn: {ARN}})
@@ -539,6 +555,7 @@ def load_ec2_auto_scaling_groups(neo4j_session, data, region, current_aws_accoun
                 )
 
 
+@timeit
 def load_load_balancer_v2s(neo4j_session, data, region, current_aws_account_id, aws_update_tag):
     ingest_load_balancer_v2 = """
     MERGE (elbv2:LoadBalancerV2{id: {ID}})
@@ -607,6 +624,7 @@ def load_load_balancer_v2s(neo4j_session, data, region, current_aws_account_id, 
             )
 
 
+@timeit
 def load_load_balancers(neo4j_session, data, region, current_aws_account_id, aws_update_tag):
     ingest_load_balancer = """
     MERGE (elb:LoadBalancer{id: {ID}})
@@ -701,6 +719,7 @@ def load_load_balancers(neo4j_session, data, region, current_aws_account_id, aws
             load_load_balancer_listeners(neo4j_session, load_balancer_id, lb["ListenerDescriptions"], aws_update_tag)
 
 
+@timeit
 def load_load_balancer_v2_subnets(neo4j_session, load_balancer_id, az_data, region, aws_update_tag):
     ingest_load_balancer_subnet = """
     MATCH (elbv2:LoadBalancerV2{id: {ID}})
@@ -722,6 +741,7 @@ def load_load_balancer_v2_subnets(neo4j_session, load_balancer_id, az_data, regi
         )
 
 
+@timeit
 def load_load_balancer_subnets(neo4j_session, load_balancer_id, subnets_data, aws_update_tag):
     ingest_load_balancer_subnet = """
     MATCH (elb:LoadBalancer{id: {ID}}), (subnet:EC2Subnet{subnetid: {SUBNET_ID}})
@@ -739,6 +759,7 @@ def load_load_balancer_subnets(neo4j_session, load_balancer_id, subnets_data, aw
         )
 
 
+@timeit
 def load_load_balancer_v2_target_groups(
     neo4j_session, load_balancer_id, target_groups, current_aws_account_id,
     aws_update_tag,
@@ -770,6 +791,7 @@ def load_load_balancer_v2_target_groups(
             )
 
 
+@timeit
 def load_load_balancer_v2_listeners(neo4j_session, load_balancer_id, listener_data, aws_update_tag):
     ingest_listener = """
     MATCH (elbv2:LoadBalancerV2{id: {LoadBalancerId}})
@@ -793,6 +815,7 @@ def load_load_balancer_v2_listeners(neo4j_session, load_balancer_id, listener_da
     )
 
 
+@timeit
 def load_load_balancer_listeners(neo4j_session, load_balancer_id, listener_data, aws_update_tag):
     ingest_listener = """
     MATCH (elb:LoadBalancer{id: {LoadBalancerId}})
@@ -818,6 +841,7 @@ def load_load_balancer_listeners(neo4j_session, load_balancer_id, listener_data,
     )
 
 
+@timeit
 def load_ec2_vpc_peering(neo4j_session, data, aws_update_tag):
     # https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpc-peering-connections.html
     # {
@@ -954,6 +978,7 @@ def load_ec2_vpc_peering(neo4j_session, data, aws_update_tag):
                     )
 
 
+@timeit
 def load_ec2_vpcs(neo4j_session, data, region, current_aws_account_id, aws_update_tag):
     # https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpcs.html
     # {
@@ -1068,6 +1093,7 @@ def _get_cidr_association_statement(block_type):
     return INGEST_CIDR_TEMPLATE.safe_substitute(block_label=BLOCK_TYPE, block_cidr=BLOCK_CIDR, state_name=STATE_NAME)
 
 
+@timeit
 def load_cidr_association_set(neo4j_session, vpc_id, vpc_data, block_type, aws_update_tag):
     ingest_statement = _get_cidr_association_statement(block_type)
 
@@ -1084,6 +1110,7 @@ def load_cidr_association_set(neo4j_session, vpc_id, vpc_data, block_type, aws_u
     )
 
 
+@timeit
 def cleanup_ec2_security_groupinfo(neo4j_session, common_job_parameters):
     run_cleanup_job(
         'aws_import_ec2_security_groupinfo_cleanup.json',
@@ -1092,14 +1119,17 @@ def cleanup_ec2_security_groupinfo(neo4j_session, common_job_parameters):
     )
 
 
+@timeit
 def cleanup_ec2_key_pairs(neo4j_session, common_job_parameters):
     run_cleanup_job('aws_import_ec2_key_pairs_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def cleanup_ec2_instances(neo4j_session, common_job_parameters):
     run_cleanup_job('aws_import_ec2_instances_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def cleanup_ec2_auto_scaling_groups(neo4j_session, common_job_parameters):
     run_cleanup_job(
         'aws_ingest_ec2_auto_scaling_groups_cleanup.json',
@@ -1108,23 +1138,28 @@ def cleanup_ec2_auto_scaling_groups(neo4j_session, common_job_parameters):
     )
 
 
+@timeit
 def cleanup_load_balancers(neo4j_session, common_job_parameters):
     run_cleanup_job('aws_ingest_load_balancers_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def cleanup_load_balancer_v2s(neo4j_session, common_job_parameters):
     """Delete elbv2's and dependent resources in the DB without the most recent lastupdated tag."""
     run_cleanup_job('aws_ingest_load_balancers_v2_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def cleanup_ec2_vpcs(neo4j_session, common_job_parameters):
     run_cleanup_job('aws_import_vpc_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def cleanup_ec2_vpc_peering(neo4j_session, common_job_parameters):
     run_cleanup_job('aws_import_vpc_peering_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_ec2_security_groupinfo(
         neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
         common_job_parameters,
@@ -1136,6 +1171,7 @@ def sync_ec2_security_groupinfo(
     cleanup_ec2_security_groupinfo(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_ec2_key_pairs(
     neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
     common_job_parameters,
@@ -1147,6 +1183,7 @@ def sync_ec2_key_pairs(
     cleanup_ec2_key_pairs(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_ec2_instances(
     neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
     common_job_parameters,
@@ -1158,6 +1195,7 @@ def sync_ec2_instances(
     cleanup_ec2_instances(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_ec2_auto_scaling_groups(
         neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
         common_job_parameters,
@@ -1169,6 +1207,7 @@ def sync_ec2_auto_scaling_groups(
     cleanup_ec2_auto_scaling_groups(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_load_balancers(
     neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
     common_job_parameters,
@@ -1180,6 +1219,7 @@ def sync_load_balancers(
     cleanup_load_balancers(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_load_balancer_v2s(
     neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
     common_job_parameters,
@@ -1191,6 +1231,7 @@ def sync_load_balancer_v2s(
     cleanup_load_balancer_v2s(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_vpc(neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag, common_job_parameters):
     for region in regions:
         logger.debug("Syncing EC2 VPC for region '%s' in account '%s'.", region, current_aws_account_id)
@@ -1199,9 +1240,10 @@ def sync_vpc(neo4j_session, boto3_session, regions, current_aws_account_id, aws_
     cleanup_ec2_vpcs(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_vpc_peering(
-    neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
-    common_job_parameters,
+        neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
+        common_job_parameters,
 ):
     for region in regions:
         logger.debug("Syncing EC2 VPC peering for region '%s' in account '%s'.", region, current_aws_account_id)

--- a/cartography/intel/aws/eks.py
+++ b/cartography/intel/aws/eks.py
@@ -1,10 +1,11 @@
 import logging
 
-from cartography.util import run_cleanup_job
+from cartography.util import run_cleanup_job, timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def get_eks_clusters(boto3_session, region):
     client = boto3_session.client('eks', region_name=region)
     clusters = []
@@ -23,12 +24,14 @@ def get_eks_clusters(boto3_session, region):
     return clusters
 
 
+@timeit
 def get_eks_describe_cluster(boto3_session, region, cluster_name):
     client = boto3_session.client('eks', region_name=region)
     response = client.describe_cluster(name=cluster_name)
     return response['cluster']
 
 
+@timeit
 def load_eks_clusters(neo4j_session, cluster_data, region, current_aws_account_id, aws_update_tag):
     query = """
     MERGE (cluster:EKSCluster{id: {ClusterArn}})
@@ -84,10 +87,12 @@ def _process_logging(cluster):
     return logging
 
 
+@timeit
 def cleanup(neo4j_session, common_job_parameters):
     run_cleanup_job('aws_import_eks_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync(neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag, common_job_parameters):
     for region in regions:
         logger.info("Syncing EKS for region '%s' in account '%s'.", region, current_aws_account_id)

--- a/cartography/intel/aws/eks.py
+++ b/cartography/intel/aws/eks.py
@@ -1,6 +1,7 @@
 import logging
 
-from cartography.util import run_cleanup_job, timeit
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 

--- a/cartography/intel/aws/elasticsearch.py
+++ b/cartography/intel/aws/elasticsearch.py
@@ -5,7 +5,8 @@ import botocore.config
 from policyuniverse.policy import Policy
 
 from cartography.intel.dns import ingest_dns_record_by_fqdn
-from cartography.util import run_cleanup_job, timeit
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 

--- a/cartography/intel/aws/elasticsearch.py
+++ b/cartography/intel/aws/elasticsearch.py
@@ -5,7 +5,7 @@ import botocore.config
 from policyuniverse.policy import Policy
 
 from cartography.intel.dns import ingest_dns_record_by_fqdn
-from cartography.util import run_cleanup_job
+from cartography.util import run_cleanup_job, timeit
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +40,7 @@ def _get_botocore_config():
     )
 
 
+@timeit
 def _get_es_domains(client):
     """
     Get ES domains.
@@ -58,6 +59,7 @@ def _get_es_domains(client):
     return domains
 
 
+@timeit
 def _load_es_domains(neo4j_session, domain_list, aws_account_id, aws_update_tag):
     """
     Ingest Elastic Search domains
@@ -112,6 +114,7 @@ def _load_es_domains(neo4j_session, domain_list, aws_account_id, aws_update_tag)
         _process_access_policy(neo4j_session, domain_id, domain)
 
 
+@timeit
 def _link_es_domains_to_dns(neo4j_session, domain_id, domain_data, aws_update_tag):
     """
     Link the ES domain to its DNS FQDN endpoint and create associated nodes in the graph
@@ -131,6 +134,7 @@ def _link_es_domains_to_dns(neo4j_session, domain_id, domain_data, aws_update_ta
         logger.debug(f"No es endpoint data for domain id {domain_id}")
 
 
+@timeit
 def _link_es_domain_vpc(neo4j_session, domain_id, domain_data, aws_update_tag):
     """
     Link the ES domain to its DNS FQDN endpoint and create associated nodes in the graph
@@ -182,6 +186,7 @@ def _link_es_domain_vpc(neo4j_session, domain_id, domain_data, aws_update_tag):
             )
 
 
+@timeit
 def _process_access_policy(neo4j_session, domain_id, domain_data):
     """
     Link the ES domain to its DNS FQDN endpoint and create associated nodes in the graph
@@ -203,6 +208,7 @@ def _process_access_policy(neo4j_session, domain_id, domain_data):
     neo4j_session.run(tag_es, DomainId=domain_id, InternetExposed=exposed_internet)
 
 
+@timeit
 def cleanup(neo4j_session, update_tag, aws_account_id):
     run_cleanup_job(
         'aws_import_es_cleanup.json',
@@ -211,6 +217,7 @@ def cleanup(neo4j_session, update_tag, aws_account_id):
     )
 
 
+@timeit
 def sync(neo4j_session, boto3_session, aws_account_id, update_tag):
     for region in es_regions:
         logger.info("Syncing Elasticsearch Service for region '%s' in account '%s'.", region, aws_account_id)

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -2,7 +2,8 @@ import logging
 
 import policyuniverse.statement
 
-from cartography.util import run_cleanup_job, timeit
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -2,11 +2,12 @@ import logging
 
 import policyuniverse.statement
 
-from cartography.util import run_cleanup_job
+from cartography.util import run_cleanup_job, timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def get_group_policies(boto3_session, group_name):
     client = boto3_session.client('iam')
     paginator = client.get_paginator('list_group_policies')
@@ -16,11 +17,13 @@ def get_group_policies(boto3_session, group_name):
     return {'PolicyNames': policy_names}
 
 
+@timeit
 def get_group_policy_info(boto3_session, group_name, policy_name):
     client = boto3_session.client('iam')
     return client.get_group_policy(GroupName=group_name, PolicyName=policy_name)
 
 
+@timeit
 def get_group_membership_data(boto3_session, group_name):
     client = boto3_session.client('iam')
     try:
@@ -32,6 +35,7 @@ def get_group_membership_data(boto3_session, group_name):
         return {}
 
 
+@timeit
 def get_user_list_data(boto3_session):
     client = boto3_session.client('iam')
     paginator = client.get_paginator('list_users')
@@ -41,6 +45,7 @@ def get_user_list_data(boto3_session):
     return {'Users': users}
 
 
+@timeit
 def get_group_list_data(boto3_session):
     client = boto3_session.client('iam')
     paginator = client.get_paginator('list_groups')
@@ -50,6 +55,7 @@ def get_group_list_data(boto3_session):
     return {'Groups': groups}
 
 
+@timeit
 def get_policy_list_data(boto3_session):
     client = boto3_session.client('iam')
     paginator = client.get_paginator('list_policies')
@@ -59,6 +65,7 @@ def get_policy_list_data(boto3_session):
     return {'Policies': policies}
 
 
+@timeit
 def get_role_list_data(boto3_session):
     client = boto3_session.client('iam')
     paginator = client.get_paginator('list_roles')
@@ -68,6 +75,7 @@ def get_role_list_data(boto3_session):
     return {'Roles': roles}
 
 
+@timeit
 def get_role_policies(boto3_session, role_name):
     client = boto3_session.client('iam')
     paginator = client.get_paginator('list_role_policies')
@@ -77,17 +85,20 @@ def get_role_policies(boto3_session, role_name):
     return {'PolicyNames': policy_names}
 
 
+@timeit
 def get_role_policy_info(boto3_session, role_name, policy_name):
     client = boto3_session.client('iam')
     return client.get_role_policy(RoleName=role_name, PolicyName=policy_name)
 
 
+@timeit
 def get_account_access_key_data(boto3_session, username):
     client = boto3_session.client('iam')
     # NOTE we can get away without using a paginator here because users are limited to two access keys
     return client.list_access_keys(UserName=username)
 
 
+@timeit
 def load_users(neo4j_session, users, current_aws_account_id, aws_update_tag):
     ingest_user = """
     MERGE (unode:AWSUser{arn: {ARN}})
@@ -116,6 +127,7 @@ def load_users(neo4j_session, users, current_aws_account_id, aws_update_tag):
         )
 
 
+@timeit
 def load_groups(neo4j_session, groups, current_aws_account_id, aws_update_tag):
     ingest_group = """
     MERGE (gnode:AWSGroup{arn: {ARN}})
@@ -141,6 +153,7 @@ def load_groups(neo4j_session, groups, current_aws_account_id, aws_update_tag):
         )
 
 
+@timeit
 def load_policies(neo4j_session, policies, current_aws_account_id, aws_update_tag):
     ingest_policy = """
     MERGE (pnode:AWSPolicy{arn: {ARN}})
@@ -173,6 +186,7 @@ def load_policies(neo4j_session, policies, current_aws_account_id, aws_update_ta
         )
 
 
+@timeit
 def load_roles(neo4j_session, roles, current_aws_account_id, aws_update_tag):
     ingest_role = """
     MERGE (rnode:AWSRole{arn: {Arn}})
@@ -233,6 +247,7 @@ def load_roles(neo4j_session, roles, current_aws_account_id, aws_update_tag):
                 )
 
 
+@timeit
 def load_group_memberships(neo4j_session, group_memberships, aws_update_tag):
     ingest_membership = """
     MATCH (group:AWSGroup{arn: {GroupArn}})
@@ -266,6 +281,7 @@ def _find_roles_assumable_in_policy(policy_data):
     return ret
 
 
+@timeit
 def load_group_policies(neo4j_session, group_policies, aws_update_tag):
     ingest_policies_assume_role = """
     MATCH (group:AWSGroup{arn: {GroupArn}})
@@ -292,6 +308,7 @@ def load_group_policies(neo4j_session, group_policies, aws_update_tag):
                 )
 
 
+@timeit
 def load_role_policies(neo4j_session, role_policies, aws_update_tag):
     ingest_policies_assume_role = """
     MATCH (assumer:AWSRole{arn: {FromArn}})
@@ -318,6 +335,7 @@ def load_role_policies(neo4j_session, role_policies, aws_update_tag):
                 )
 
 
+@timeit
 def load_user_access_keys(neo4j_session, user_access_keys, aws_update_tag):
     # TODO change the node label to reflect that this is a user access key, not an account access key
     ingest_account_key = """
@@ -345,6 +363,7 @@ def load_user_access_keys(neo4j_session, user_access_keys, aws_update_tag):
                 )
 
 
+@timeit
 def sync_users(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.debug("Syncing IAM users for account '%s'.", current_aws_account_id)
     data = get_user_list_data(boto3_session)
@@ -352,6 +371,7 @@ def sync_users(neo4j_session, boto3_session, current_aws_account_id, aws_update_
     run_cleanup_job('aws_import_users_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_groups(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.debug("Syncing IAM groups for account '%s'.", current_aws_account_id)
     data = get_group_list_data(boto3_session)
@@ -359,6 +379,7 @@ def sync_groups(neo4j_session, boto3_session, current_aws_account_id, aws_update
     run_cleanup_job('aws_import_groups_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_policies(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.debug("Syncing IAM policies for account '%s'.", current_aws_account_id)
     data = get_policy_list_data(boto3_session)
@@ -366,6 +387,7 @@ def sync_policies(neo4j_session, boto3_session, current_aws_account_id, aws_upda
     run_cleanup_job('aws_import_policies_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_roles(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.debug("Syncing IAM roles for account '%s'.", current_aws_account_id)
     data = get_role_list_data(boto3_session)
@@ -373,6 +395,7 @@ def sync_roles(neo4j_session, boto3_session, current_aws_account_id, aws_update_
     run_cleanup_job('aws_import_roles_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_group_memberships(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.debug("Syncing IAM group membership for account '%s'.", current_aws_account_id)
     query = "MATCH (group:AWSGroup)<-[:RESOURCE]-(AWSAccount{id: {AWS_ACCOUNT_ID}}) " \
@@ -387,6 +410,7 @@ def sync_group_memberships(neo4j_session, boto3_session, current_aws_account_id,
     )
 
 
+@timeit
 def sync_group_policies(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.debug("Syncing IAM group policies for account '%s'.", current_aws_account_id)
     query = "MATCH (group:AWSGroup)<-[:RESOURCE]-(AWSAccount{id: {AWS_ACCOUNT_ID}}) " \
@@ -407,6 +431,7 @@ def sync_group_policies(neo4j_session, boto3_session, current_aws_account_id, aw
     )
 
 
+@timeit
 def sync_role_policies(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.debug("Syncing IAM role policies for account '%s'.", current_aws_account_id)
     query = """
@@ -430,6 +455,7 @@ def sync_role_policies(neo4j_session, boto3_session, current_aws_account_id, aws
     )
 
 
+@timeit
 def sync_user_access_keys(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.debug("Syncing IAM user access keys for account '%s'.", current_aws_account_id)
     query = "MATCH (user:AWSUser)<-[:RESOURCE]-(AWSAccount{id: {AWS_ACCOUNT_ID}}) return user.name as name"
@@ -444,6 +470,7 @@ def sync_user_access_keys(neo4j_session, boto3_session, current_aws_account_id, 
     )
 
 
+@timeit
 def sync(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters):
     logger.info("Syncing IAM for account '%s'.", account_id)
     sync_users(neo4j_session, boto3_session, account_id, update_tag, common_job_parameters)

--- a/cartography/intel/aws/organizations.py
+++ b/cartography/intel/aws/organizations.py
@@ -3,7 +3,8 @@ import logging
 import boto3
 import botocore.exceptions
 
-from cartography.util import run_cleanup_job, timeit
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 

--- a/cartography/intel/aws/organizations.py
+++ b/cartography/intel/aws/organizations.py
@@ -3,7 +3,7 @@ import logging
 import boto3
 import botocore.exceptions
 
-from cartography.util import run_cleanup_job
+from cartography.util import run_cleanup_job, timeit
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +113,7 @@ def cleanup(neo4j_session, common_job_parameters):
     run_cleanup_job('aws_account_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync(neo4j_session, accounts, aws_update_tag, common_job_parameters):
     load_aws_accounts(neo4j_session, accounts, aws_update_tag, common_job_parameters)
     cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -1,6 +1,7 @@
 import logging
 
-from cartography.util import run_cleanup_job, timeit
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 

--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -1,10 +1,11 @@
 import logging
 
-from cartography.util import run_cleanup_job
+from cartography.util import run_cleanup_job, timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def get_rds_instance_data(boto3_session, region):
     """
     Create an RDS boto3 client and grab all the DBInstances.
@@ -17,6 +18,7 @@ def get_rds_instance_data(boto3_session, region):
     return {'DBInstances': instances}
 
 
+@timeit
 def load_rds_instances(neo4j_session, data, region, current_aws_account_id, aws_update_tag):
     """
     Ingest the RDS instances to neo4j and link them to necessary nodes.
@@ -114,6 +116,7 @@ def load_rds_instances(neo4j_session, data, region, current_aws_account_id, aws_
     _attach_read_replicas(neo4j_session, read_replicas, aws_update_tag)
 
 
+@timeit
 def _attach_ec2_subnet_groups(neo4j_session, instance, region, current_aws_account_id, aws_update_tag):
     """
     Attach RDS instance to its EC2 subnets
@@ -148,6 +151,7 @@ def _attach_ec2_subnet_groups(neo4j_session, instance, region, current_aws_accou
         _attach_ec2_subnets_to_subnetgroup(neo4j_session, db_sng, region, current_aws_account_id, aws_update_tag)
 
 
+@timeit
 def _attach_ec2_subnets_to_subnetgroup(neo4j_session, db_subnet_group, region, current_aws_account_id, aws_update_tag):
     """
     Attach EC2Subnets to the DB Subnet Group.
@@ -179,6 +183,7 @@ def _attach_ec2_subnets_to_subnetgroup(neo4j_session, db_subnet_group, region, c
         )
 
 
+@timeit
 def _attach_ec2_security_groups(neo4j_session, instance, aws_update_tag):
     """
     Attach an RDS instance to its EC2SecurityGroups
@@ -199,6 +204,7 @@ def _attach_ec2_security_groups(neo4j_session, instance, aws_update_tag):
         )
 
 
+@timeit
 def _attach_read_replicas(neo4j_session, read_replicas, aws_update_tag):
     """
     Attach read replicas to their source instances
@@ -240,6 +246,7 @@ def _get_db_subnet_group_arn(region, current_aws_account_id, db_subnet_group_nam
     return f"arn:aws:rds:{region}:{current_aws_account_id}:subgrp:{db_subnet_group_name}"
 
 
+@timeit
 def cleanup_rds_instances_and_db_subnet_groups(neo4j_session, common_job_parameters):
     """
     Remove RDS graph nodes and DBSubnetGroups that were created from other ingestion runs
@@ -247,6 +254,7 @@ def cleanup_rds_instances_and_db_subnet_groups(neo4j_session, common_job_paramet
     run_cleanup_job('aws_import_rds_instances_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_rds_instances(
     neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag,
     common_job_parameters,

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -1,11 +1,12 @@
 import logging
 from string import Template
 
-from cartography.util import run_cleanup_job
+from cartography.util import run_cleanup_job, timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def get_short_id_from_ec2_arn(arn):
     """
     Return the short-form resource ID from an EC2 ARN.
@@ -16,6 +17,7 @@ def get_short_id_from_ec2_arn(arn):
     return arn.split('/')[-1]
 
 
+@timeit
 def get_bucket_name_from_arn(bucket_arn):
     """
     Return the bucket name from an S3 bucket ARN.
@@ -47,6 +49,7 @@ TAG_RESOURCE_TYPE_MAPPINGS = {
 }
 
 
+@timeit
 def get_tags(boto3_session, resource_types, region):
     """
     Create boto3 client and retrieve tag data.
@@ -63,6 +66,7 @@ def get_tags(boto3_session, resource_types, region):
     return resources
 
 
+@timeit
 def load_tags(neo4j_session, tag_data, resource_type, region, aws_update_tag):
     INGEST_TAG_TEMPLATE = Template("""
     MATCH (resource:$resource_label{$property:{ResourceId}})
@@ -92,11 +96,13 @@ def load_tags(neo4j_session, tag_data, resource_type, region, aws_update_tag):
             )
 
 
+@timeit
 def transform_tags(tag_data, resource_type):
     for tag_mapping in tag_data:
         tag_mapping['resource_id'] = compute_resource_id(tag_mapping, resource_type)
 
 
+@timeit
 def compute_resource_id(tag_mapping, resource_type):
     resource_id = tag_mapping['ResourceARN']
     if 'id_func' in TAG_RESOURCE_TYPE_MAPPINGS[resource_type]:
@@ -105,10 +111,12 @@ def compute_resource_id(tag_mapping, resource_type):
     return resource_id
 
 
+@timeit
 def cleanup(neo4j_session, common_job_parameters):
     run_cleanup_job('aws_import_tags_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync(neo4j_session, boto3_session, regions, aws_update_tag, common_job_parameters):
     for region in regions:
         logger.info("Syncing AWS tags for region '%s'.", region)

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -1,7 +1,8 @@
 import logging
 from string import Template
 
-from cartography.util import run_cleanup_job, timeit
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 

--- a/cartography/intel/aws/route53.py
+++ b/cartography/intel/aws/route53.py
@@ -1,6 +1,7 @@
 import logging
 
-from cartography.util import run_cleanup_job, timeit
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
@@ -354,6 +355,7 @@ def cleanup_route53(neo4j_session, current_aws_id, update_tag):
         neo4j_session,
         {'UPDATE_TAG': update_tag, 'AWS_ID': current_aws_id},
     )
+
 
 @timeit
 def sync(neo4j_session, boto3_session, aws_id, update_tag):

--- a/cartography/intel/aws/s3.py
+++ b/cartography/intel/aws/s3.py
@@ -5,18 +5,19 @@ import logging
 from botocore.exceptions import ClientError
 from policyuniverse.policy import Policy
 
-from cartography.util import run_analysis_job
-from cartography.util import run_cleanup_job
+from cartography.util import run_analysis_job, run_cleanup_job, timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def get_s3_bucket_list(boto3_session):
     client = boto3_session.client('s3')
     # NOTE no paginator available for this operation
     return client.list_buckets()
 
 
+@timeit
 def get_s3_bucket_details(boto3_session, bucket_data):
     """
     Iterates over all S3 buckets. Yields bucket name (string) and pairs of S3 bucket policies (JSON) and ACLs (JSON)
@@ -28,6 +29,7 @@ def get_s3_bucket_details(boto3_session, bucket_data):
         yield bucket['Name'], acl, policy
 
 
+@timeit
 def get_policy(bucket, client):
     """
     Gets the S3 bucket policy. Returns policy string or None if no policy
@@ -46,6 +48,7 @@ def get_policy(bucket, client):
     return policy
 
 
+@timeit
 def get_acl(bucket, client):
     """
     Gets the S3 bucket ACL. Returns ACL string
@@ -64,6 +67,7 @@ def get_acl(bucket, client):
     return acl
 
 
+@timeit
 def _load_s3_acls(neo4j_session, acls, aws_account_id, update_tag):
     """
     Ingest S3 ACL into neo4j.
@@ -95,6 +99,7 @@ def _load_s3_acls(neo4j_session, acls, aws_account_id, update_tag):
     )
 
 
+@timeit
 def _load_s3_policies(neo4j_session, policies, update_tag):
     """
     Ingest S3 policy results into neo4j.
@@ -127,6 +132,7 @@ def _set_default_values(neo4j_session, aws_account_id):
     )
 
 
+@timeit
 def load_s3_details(neo4j_session, s3_details_iter, aws_account_id, update_tag):
     """
     Create dictionaries for all bucket ACLs and all bucket policies so we can import them in a single query for each
@@ -157,6 +163,7 @@ def load_s3_details(neo4j_session, s3_details_iter, aws_account_id, update_tag):
     _set_default_values(neo4j_session, aws_account_id)
 
 
+@timeit
 def parse_policy(bucket, policy):
     """
     Uses PolicyUniverse to parse S3 policies and returns the internet accessibility results
@@ -211,6 +218,7 @@ def parse_policy(bucket, policy):
         return None
 
 
+@timeit
 def parse_acl(acl, bucket, aws_account_id):
     """ Parses the AWS ACL object and returns a dict of the relevant data """
     # ACL JSON looks like
@@ -281,6 +289,7 @@ def parse_acl(acl, bucket, aws_account_id):
     return acl_list
 
 
+@timeit
 def load_s3_buckets(neo4j_session, data, current_aws_account_id, aws_update_tag):
     ingest_bucket = """
     MERGE (bucket:S3Bucket{id:{BucketName}})
@@ -307,14 +316,17 @@ def load_s3_buckets(neo4j_session, data, current_aws_account_id, aws_update_tag)
         )
 
 
+@timeit
 def cleanup_s3_buckets(neo4j_session, common_job_parameters):
     run_cleanup_job('aws_import_s3_buckets_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def cleanup_s3_bucket_acl_and_policy(neo4j_session, common_job_parameters):
     run_cleanup_job('aws_import_s3_acl_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.info("Syncing S3 for account '%s'.", current_aws_account_id)
     bucket_data = get_s3_bucket_list(boto3_session)

--- a/cartography/intel/aws/s3.py
+++ b/cartography/intel/aws/s3.py
@@ -5,7 +5,9 @@ import logging
 from botocore.exceptions import ClientError
 from policyuniverse.policy import Policy
 
-from cartography.util import run_analysis_job, run_cleanup_job, timeit
+from cartography.util import run_analysis_job
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 

--- a/cartography/intel/crxcavator/__init__.py
+++ b/cartography/intel/crxcavator/__init__.py
@@ -4,10 +4,12 @@ from requests import exceptions
 
 from cartography.intel.crxcavator.crxcavator import sync_extensions
 from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def start_extension_ingestion(neo4j_session, config):
     """
     If this module is configured, perform ingestion of CRXcavator data. Otherwise warn and exit

--- a/cartography/intel/crxcavator/crxcavator.py
+++ b/cartography/intel/crxcavator/crxcavator.py
@@ -4,9 +4,12 @@ import logging
 import requests.auth
 from requests import exceptions
 
+from cartography.util import timeit
+
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def get_extension_details(crxcavator_api_key, crxcavator_base_url, extension_id, version):
     """
     Get metadata for the specific extension_id and version number provided
@@ -20,6 +23,7 @@ def get_extension_details(crxcavator_api_key, crxcavator_base_url, extension_id,
     return call_crxcavator_api(f"/report/{extension_id}/{version}", crxcavator_api_key, crxcavator_base_url)
 
 
+@timeit
 def get_users_extensions(crxcavator_api_key, crxcavator_base_url):
     """
     Gets listing of all users who have installed each extension
@@ -31,6 +35,7 @@ def get_users_extensions(crxcavator_api_key, crxcavator_base_url):
     return call_crxcavator_api("/group/users/extensions", crxcavator_api_key, crxcavator_base_url)
 
 
+@timeit
 def call_crxcavator_api(api_and_parameters, crxcavator_api_key, crxcavator_base_url):
     """
     Perform the call requested to the CRXcavator API
@@ -52,6 +57,7 @@ def call_crxcavator_api(api_and_parameters, crxcavator_api_key, crxcavator_base_
     return data.json()
 
 
+@timeit
 def get_extensions(crxcavator_api_key, crxcavator_base_url, extensions_list):
     """
     Retrieves the detailed information for all the extension_id and version pairs
@@ -83,6 +89,7 @@ def get_extensions(crxcavator_api_key, crxcavator_base_url, extensions_list):
     return extensions_details
 
 
+@timeit
 def transform_extensions(extension_details):
     """
     Transforms the raw extensions JSON from the API into a list of extensions data
@@ -137,6 +144,7 @@ def transform_extensions(extension_details):
     return extensions
 
 
+@timeit
 def get_risk_data(data_dict, key):
     """
     Gets the total risk value from the provided key and returns the value else 0
@@ -149,6 +157,7 @@ def get_risk_data(data_dict, key):
     return data_score
 
 
+@timeit
 def load_extensions(extensions, session, update_tag):
     """
     Ingests the extension details into Neo4J
@@ -199,6 +208,7 @@ def load_extensions(extensions, session, update_tag):
     session.run(ingestion_cypher, ExtensionsData=extensions, UpdateTag=update_tag)
 
 
+@timeit
 def transform_user_extensions(user_extension_json):
     """
     Transforms the raw extensions JSON from the API into a list of extensions mapped to users
@@ -237,6 +247,7 @@ def transform_user_extensions(user_extension_json):
     return list(users_set), extensions, extensions_by_user
 
 
+@timeit
 def load_user_extensions(users, extensions_by_user, session, update_tag):
     """
     Ingests the extension to user mapping details into Neo4J
@@ -270,6 +281,7 @@ def load_user_extensions(users, extensions_by_user, session, update_tag):
     session.run(extension_ingestion_cypher, ExtensionsUsers=extensions_by_user, UpdateTag=update_tag)
 
 
+@timeit
 def sync_extensions(neo4j_session, common_job_parameters, crxcavator_api_key, crxcavator_base_url):
     """
     Performs the sequential tasks to collect, transform, and sync extension data

--- a/cartography/intel/dns.py
+++ b/cartography/intel/dns.py
@@ -3,10 +3,12 @@ from string import Template
 
 import dns.rdatatype
 import dns.resolver
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def ingest_dns_record_by_fqdn(
     neo4j_session, update_tag, fqdn, points_to_record, record_label,
     dns_node_additional_label=None,
@@ -59,6 +61,7 @@ def ingest_dns_record_by_fqdn(
         )
 
 
+@timeit
 def _link_ip_to_A_record(neo4j_session, update_tag, ip_list, parent_record):
     """
     Link A record to to its IP
@@ -89,6 +92,7 @@ def _link_ip_to_A_record(neo4j_session, update_tag, ip_list, parent_record):
     )
 
 
+@timeit
 def ingest_dns_record(
     neo4j_session, name, value, type, update_tag, points_to_record, record_label,
     dns_node_additional_label,
@@ -132,6 +136,7 @@ def ingest_dns_record(
     return record_id
 
 
+@timeit
 def get_dns_resolution_by_fqdn(fqdn):
     """
     Get dns resolution data for fqdn

--- a/cartography/intel/dns.py
+++ b/cartography/intel/dns.py
@@ -3,6 +3,7 @@ from string import Template
 
 import dns.rdatatype
 import dns.resolver
+
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -10,6 +10,7 @@ from cartography.intel.gcp import crm
 from cartography.intel.gcp import gke
 from cartography.intel.gcp import storage
 from cartography.util import run_analysis_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 Resources = namedtuple('Resources', 'crm_v1 crm_v2 compute storage container')
@@ -123,6 +124,7 @@ def _sync_multiple_projects(neo4j_session, resources, projects, gcp_update_tag, 
         _sync_single_project(neo4j_session, resources, project_id, gcp_update_tag, common_job_parameters)
 
 
+@timeit
 def start_gcp_ingestion(neo4j_session, config):
     """
     Starts the GCP ingestion process by initializing Google Application Default Credentials, creating the necessary

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -8,6 +8,7 @@ from string import Template
 from googleapiclient.discovery import HttpError
 
 from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 InstanceUriPrefix = namedtuple('InstanceUriPrefix', 'zone_name project_id')
@@ -35,6 +36,7 @@ def _get_error_reason(http_error):
     return reason
 
 
+@timeit
 def get_zones_in_project(project_id, compute, max_results=None):
     """
     Return the zones where the Compute Engine API is enabled for the given project_id.
@@ -77,6 +79,7 @@ def get_zones_in_project(project_id, compute, max_results=None):
             raise
 
 
+@timeit
 def get_gcp_instance_responses(project_id, zones, compute):
     """
     Return list of GCP instance response objects for a given project and list of zones
@@ -96,6 +99,7 @@ def get_gcp_instance_responses(project_id, zones, compute):
     return response_objects
 
 
+@timeit
 def get_gcp_subnets(projectid, region, compute):
     """
     Return list of all subnets in the given projectid and region
@@ -108,6 +112,7 @@ def get_gcp_subnets(projectid, region, compute):
     return req.execute()
 
 
+@timeit
 def get_gcp_vpcs(projectid, compute):
     """
     Get VPC data for given project
@@ -119,6 +124,7 @@ def get_gcp_vpcs(projectid, compute):
     return req.execute()
 
 
+@timeit
 def get_gcp_firewall_ingress_rules(project_id, compute):
     """
     Get ingress Firewall data for a given project
@@ -130,6 +136,7 @@ def get_gcp_firewall_ingress_rules(project_id, compute):
     return req.execute()
 
 
+@timeit
 def transform_gcp_instances(response_objects):
     """
     Process the GCP instance response objects and return a flattened list of GCP instances with all the necessary fields
@@ -191,6 +198,7 @@ def _create_gcp_network_tag_id(vpc_partial_uri, tag):
     return f"{vpc_partial_uri}/tags/{tag}"
 
 
+@timeit
 def transform_gcp_vpcs(vpc_res):
     """
     Transform the VPC response object for Neo4j ingestion
@@ -218,6 +226,7 @@ def transform_gcp_vpcs(vpc_res):
     return vpc_list
 
 
+@timeit
 def transform_gcp_subnets(subnet_res):
     """
     Add additional fields to the subnet object to make it easier to process in `load_gcp_subnets()`.
@@ -254,6 +263,7 @@ def transform_gcp_subnets(subnet_res):
     return subnet_list
 
 
+@timeit
 def transform_gcp_firewall(fw_response):
     """
     Adjust the firewall response objects into a format that is easy to write to Neo4j.
@@ -393,6 +403,7 @@ def _parse_port_string_to_rule(port, protocol, fw_partial_uri, is_allow_rule):
     }
 
 
+@timeit
 def load_gcp_instances(neo4j_session, data, gcp_update_tag):
     """
     Ingest GCP instance objects to Neo4j
@@ -440,6 +451,7 @@ def load_gcp_instances(neo4j_session, data, gcp_update_tag):
         _attach_gcp_vpc(neo4j_session, instance['partial_uri'], gcp_update_tag)
 
 
+@timeit
 def load_gcp_vpcs(neo4j_session, vpcs, gcp_update_tag):
     """
     Ingest VPCs to Neo4j
@@ -482,6 +494,7 @@ def load_gcp_vpcs(neo4j_session, vpcs, gcp_update_tag):
         )
 
 
+@timeit
 def load_gcp_subnets(neo4j_session, subnets, gcp_update_tag):
     """
     Ingest GCP subnet data to Neo4j
@@ -529,6 +542,7 @@ def load_gcp_subnets(neo4j_session, subnets, gcp_update_tag):
         )
 
 
+@timeit
 def _attach_instance_tags(neo4j_session, instance, gcp_update_tag):
     """
     Attach tags to GCP instance and to the VPCs that they are defined in.
@@ -570,6 +584,7 @@ def _attach_instance_tags(neo4j_session, instance, gcp_update_tag):
             )
 
 
+@timeit
 def _attach_gcp_nics(neo4j_session, instance, gcp_update_tag):
     """
     Attach GCP Network Interfaces to GCP Instances and GCP Subnets.
@@ -616,6 +631,7 @@ def _attach_gcp_nics(neo4j_session, instance, gcp_update_tag):
         _attach_gcp_nic_access_configs(neo4j_session, nic_id, nic, gcp_update_tag)
 
 
+@timeit
 def _attach_gcp_nic_access_configs(neo4j_session, nic_id, nic, gcp_update_tag):
     """
     Attach an access configuration to the GCP NIC.
@@ -658,6 +674,7 @@ def _attach_gcp_nic_access_configs(neo4j_session, nic_id, nic, gcp_update_tag):
         )
 
 
+@timeit
 def _attach_gcp_vpc(neo4j_session, instance_id, gcp_update_tag):
     """
     Attach a GCP instance directly to a VPC
@@ -680,6 +697,7 @@ def _attach_gcp_vpc(neo4j_session, instance_id, gcp_update_tag):
     )
 
 
+@timeit
 def load_gcp_ingress_firewalls(neo4j_session, fw_list, gcp_update_tag):
     """
     Load the firewall list to Neo4j
@@ -724,6 +742,7 @@ def load_gcp_ingress_firewalls(neo4j_session, fw_list, gcp_update_tag):
         _attach_target_tags(neo4j_session, fw, gcp_update_tag)
 
 
+@timeit
 def _attach_firewall_rules(neo4j_session, fw, gcp_update_tag):
     """
     Attach the allow_rules to the Firewall object
@@ -778,6 +797,7 @@ def _attach_firewall_rules(neo4j_session, fw, gcp_update_tag):
                 )
 
 
+@timeit
 def _attach_target_tags(neo4j_session, fw, gcp_update_tag):
     """
     Attach target tags to the firewall object
@@ -810,6 +830,7 @@ def _attach_target_tags(neo4j_session, fw, gcp_update_tag):
         )
 
 
+@timeit
 def cleanup_gcp_instances(neo4j_session, common_job_parameters):
     """
     Delete out-of-date GCP instance nodes and relationships
@@ -820,6 +841,7 @@ def cleanup_gcp_instances(neo4j_session, common_job_parameters):
     run_cleanup_job('gcp_compute_instance_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def cleanup_gcp_vpcs(neo4j_session, common_job_parameters):
     """
     Delete out-of-date GCP VPC nodes and relationships
@@ -830,6 +852,7 @@ def cleanup_gcp_vpcs(neo4j_session, common_job_parameters):
     run_cleanup_job('gcp_compute_vpc_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def cleanup_gcp_subnets(neo4j_session, common_job_parameters):
     """
     Delete out-of-date GCP VPC subnet nodes and relationships
@@ -840,6 +863,7 @@ def cleanup_gcp_subnets(neo4j_session, common_job_parameters):
     run_cleanup_job('gcp_compute_vpc_subnet_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def cleanup_gcp_firewall_rules(neo4j_session, common_job_parameters):
     """
     Delete out of date GCP firewalls and their relationships
@@ -850,6 +874,7 @@ def cleanup_gcp_firewall_rules(neo4j_session, common_job_parameters):
     run_cleanup_job('gcp_compute_firewall_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_gcp_instances(neo4j_session, compute, project_id, zones, gcp_update_tag, common_job_parameters):
     """
     Get GCP instances using the Compute resource object, ingest to Neo4j, and clean up old data.
@@ -869,6 +894,7 @@ def sync_gcp_instances(neo4j_session, compute, project_id, zones, gcp_update_tag
     cleanup_gcp_instances(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_gcp_vpcs(neo4j_session, compute, project_id, gcp_update_tag, common_job_parameters):
     """
     Get GCP VPCs, ingest to Neo4j, and clean up old data.
@@ -885,6 +911,7 @@ def sync_gcp_vpcs(neo4j_session, compute, project_id, gcp_update_tag, common_job
     cleanup_gcp_vpcs(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_gcp_subnets(neo4j_session, compute, project_id, regions, gcp_update_tag, common_job_parameters):
     for r in regions:
         subnet_res = get_gcp_subnets(project_id, r, compute)
@@ -893,6 +920,7 @@ def sync_gcp_subnets(neo4j_session, compute, project_id, regions, gcp_update_tag
         cleanup_gcp_subnets(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_gcp_firewall_rules(neo4j_session, compute, project_id, gcp_update_tag, common_job_parameters):
     """
     Sync GCP firewalls

--- a/cartography/intel/gcp/crm.py
+++ b/cartography/intel/gcp/crm.py
@@ -6,10 +6,12 @@ from string import Template
 from googleapiclient.discovery import HttpError
 
 from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def get_gcp_organizations(crm_v1):
     """
     Return list of GCP organizations that the crm_v1 resource object has permissions to access.
@@ -27,6 +29,7 @@ def get_gcp_organizations(crm_v1):
         return []
 
 
+@timeit
 def get_gcp_folders(crm_v2):
     """
     Return list of GCP folders that the crm_v2 resource object has permissions to access.
@@ -44,6 +47,7 @@ def get_gcp_folders(crm_v2):
         return []
 
 
+@timeit
 def get_gcp_projects(crm_v1):
     """
     Return list of GCP projects that the crm_v1 resource object has permissions to access.
@@ -61,6 +65,7 @@ def get_gcp_projects(crm_v1):
         return []
 
 
+@timeit
 def load_gcp_organizations(neo4j_session, data, gcp_update_tag):
     """
     Ingest the GCP organizations to Neo4j
@@ -87,6 +92,7 @@ def load_gcp_organizations(neo4j_session, data, gcp_update_tag):
         )
 
 
+@timeit
 def load_gcp_folders(neo4j_session, data, gcp_update_tag):
     """
     Ingest the GCP folders to Neo4j
@@ -128,6 +134,7 @@ def load_gcp_folders(neo4j_session, data, gcp_update_tag):
         )
 
 
+@timeit
 def load_gcp_projects(neo4j_session, data, gcp_update_tag):
     """
     Ingest the GCP projects to Neo4j
@@ -159,6 +166,7 @@ def load_gcp_projects(neo4j_session, data, gcp_update_tag):
             _attach_gcp_project_parent(neo4j_session, project, gcp_update_tag)
 
 
+@timeit
 def _attach_gcp_project_parent(neo4j_session, project, gcp_update_tag):
     """
     Attach a project to its respective parent, as in the Resource Hierarchy -
@@ -194,6 +202,7 @@ def _attach_gcp_project_parent(neo4j_session, project, gcp_update_tag):
     )
 
 
+@timeit
 def cleanup_gcp_organizations(neo4j_session, common_job_parameters):
     """
     Remove stale GCP organizations and their relationships
@@ -204,6 +213,7 @@ def cleanup_gcp_organizations(neo4j_session, common_job_parameters):
     run_cleanup_job('gcp_crm_organization_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def cleanup_gcp_folders(neo4j_session, common_job_parameters):
     """
     Remove stale GCP folders and their relationships
@@ -214,6 +224,7 @@ def cleanup_gcp_folders(neo4j_session, common_job_parameters):
     run_cleanup_job('gcp_crm_folder_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def cleanup_gcp_projects(neo4j_session, common_job_parameters):
     """
     Remove stale GCP projects and their relationships
@@ -224,6 +235,7 @@ def cleanup_gcp_projects(neo4j_session, common_job_parameters):
     run_cleanup_job('gcp_crm_project_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_gcp_organizations(neo4j_session, crm_v1, gcp_update_tag, common_job_parameters):
     """
     Get GCP organization data using the CRM v1 resource object, load the data to Neo4j, and clean up stale nodes.
@@ -240,6 +252,7 @@ def sync_gcp_organizations(neo4j_session, crm_v1, gcp_update_tag, common_job_par
     cleanup_gcp_organizations(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_gcp_folders(neo4j_session, crm_v2, gcp_update_tag, common_job_parameters):
     """
     Get GCP folder data using the CRM v2 resource object, load the data to Neo4j, and clean up stale nodes.
@@ -256,6 +269,7 @@ def sync_gcp_folders(neo4j_session, crm_v2, gcp_update_tag, common_job_parameter
     cleanup_gcp_folders(neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_gcp_projects(neo4j_session, projects, gcp_update_tag, common_job_parameters):
     """
     Load a given list of GCP project data to Neo4j and clean up stale nodes.

--- a/cartography/intel/gcp/gke.py
+++ b/cartography/intel/gcp/gke.py
@@ -4,9 +4,12 @@ from googleapiclient.discovery import HttpError
 
 from cartography.intel.gcp import compute
 from cartography.util import run_cleanup_job
+from cartography.util import timeit
+
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def get_gke_clusters(container, project_id):
     """
     Returns a list of GKE clusters within some given project.
@@ -47,6 +50,7 @@ def get_gke_clusters(container, project_id):
             raise
 
 
+@timeit
 def load_gke_clusters(neo4j_session, gke_list, project_number, gcp_update_tag):
     """
     Ingest GCP GKE Clusters to Neo4j
@@ -149,6 +153,7 @@ def _process_network_policy(cluster):
     return False
 
 
+@timeit
 def cleanup_gke_clusters(neo4j_session, common_job_parameters):
     """
     Delete out-of-date GCP GKE Clusters nodes and relationships
@@ -165,6 +170,7 @@ def cleanup_gke_clusters(neo4j_session, common_job_parameters):
     run_cleanup_job('gcp_gke_cluster_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_gke_clusters(neo4j_session, container, project_id, gcp_update_tag, common_job_parameters):
     """
     Get GCP GKE Clusters using the Container resource object, ingest to Neo4j, and clean up old data.

--- a/cartography/intel/gcp/storage.py
+++ b/cartography/intel/gcp/storage.py
@@ -4,9 +4,12 @@ from googleapiclient.discovery import HttpError
 
 from cartography.intel.gcp import compute
 from cartography.util import run_cleanup_job
+from cartography.util import timeit
+
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def get_gcp_buckets(storage, project_id):
     """
     Returns a list of storage objects within some given project
@@ -47,6 +50,7 @@ def get_gcp_buckets(storage, project_id):
             raise
 
 
+@timeit
 def transform_gcp_buckets(bucket_res):
     '''
     Transform the GCP Storage Bucket response object for Neo4j ingestion
@@ -87,6 +91,7 @@ def transform_gcp_buckets(bucket_res):
     return bucket_list
 
 
+@timeit
 def load_gcp_buckets(neo4j_session, buckets, gcp_update_tag):
     '''
     Ingest GCP Storage Buckets to Neo4j
@@ -159,6 +164,7 @@ def load_gcp_buckets(neo4j_session, buckets, gcp_update_tag):
         _attach_gcp_bucket_labels(neo4j_session, bucket, gcp_update_tag)
 
 
+@timeit
 def _attach_gcp_bucket_labels(neo4j_session, bucket, gcp_update_tag):
     """
     Attach GCP bucket labels to the bucket.
@@ -190,6 +196,7 @@ def _attach_gcp_bucket_labels(neo4j_session, bucket, gcp_update_tag):
         )
 
 
+@timeit
 def cleanup_gcp_buckets(neo4j_session, common_job_parameters):
     """
     Delete out-of-date GCP Storage Bucket nodes and relationships
@@ -206,6 +213,7 @@ def cleanup_gcp_buckets(neo4j_session, common_job_parameters):
     run_cleanup_job('gcp_storage_bucket_cleanup.json', neo4j_session, common_job_parameters)
 
 
+@timeit
 def sync_gcp_buckets(neo4j_session, storage, project_id, gcp_update_tag, common_job_parameters):
     """
     Get GCP instances using the Storage resource object, ingest to Neo4j, and clean up old data.

--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -6,10 +6,12 @@ from requests import exceptions
 
 from cartography.intel.github.github import sync_github
 from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def start_github_ingestion(neo4j_session, config):
     """
     If this module is configured, perform ingestion of CRXcavator data. Otherwise warn and exit

--- a/cartography/intel/github/github.py
+++ b/cartography/intel/github/github.py
@@ -3,6 +3,8 @@ from string import Template
 
 import requests
 
+from cartography.util import timeit
+
 logger = logging.getLogger(__name__)
 
 
@@ -21,6 +23,7 @@ def call_github_api(query, variables, token, api_url):
     return response.json()
 
 
+@timeit
 def get_github_repos(token, api_url, organization):
     """
     Gets the repo data for all repos in the organization
@@ -100,6 +103,7 @@ def get_github_repos(token, api_url, organization):
     return repos
 
 
+@timeit
 def transform_github_repos(repos_json, github_url):
     """
     Parses the JSON returned from GitHub API to create data for graph ingestion
@@ -170,6 +174,7 @@ def transform_github_repos(repos_json, github_url):
     return results
 
 
+@timeit
 def load_github_repos(session, update_tag, repo_data):
     """
     Ingest the GitHub repository information
@@ -206,6 +211,7 @@ def load_github_repos(session, update_tag, repo_data):
     )
 
 
+@timeit
 def load_github_owners(session, update_tag, repo_owners):
     """
     Ingest the relationships for repo owners
@@ -235,6 +241,7 @@ def load_github_owners(session, update_tag, repo_owners):
         )
 
 
+@timeit
 def load_github_languages(session, update_tag, repo_languages):
     """
     Ingest the relationships for repo languages
@@ -260,6 +267,7 @@ def load_github_languages(session, update_tag, repo_languages):
     )
 
 
+@timeit
 def sync_github(neo4j_session, common_job_parameters, github_api_key, github_url, organization):
     """
         Performs the sequential tasks to collect, transform, and sync github data

--- a/cartography/intel/gsuite/__init__.py
+++ b/cartography/intel/gsuite/__init__.py
@@ -7,6 +7,7 @@ from oauth2client.client import ApplicationDefaultCredentialsError
 from oauth2client.client import GoogleCredentials
 
 from cartography.intel.gsuite import api
+from  cartography.util import timeit
 
 # GSuite Delegated admin e-mail https://developers.google.com/admin-sdk/directory/v1/guides/delegation
 GSUITE_DELEGATED_ADMIN = os.environ.get('GSUITE_DELEGATED_ADMIN')
@@ -45,6 +46,7 @@ def _initialize_resources(credentials):
     )
 
 
+@timeit
 def start_gsuite_ingestion(session, config):
     """
     Starts the GSuite ingestion process by initializing

--- a/cartography/intel/gsuite/__init__.py
+++ b/cartography/intel/gsuite/__init__.py
@@ -7,7 +7,7 @@ from oauth2client.client import ApplicationDefaultCredentialsError
 from oauth2client.client import GoogleCredentials
 
 from cartography.intel.gsuite import api
-from  cartography.util import timeit
+from cartography.util import timeit
 
 # GSuite Delegated admin e-mail https://developers.google.com/admin-sdk/directory/v1/guides/delegation
 GSUITE_DELEGATED_ADMIN = os.environ.get('GSUITE_DELEGATED_ADMIN')

--- a/cartography/intel/gsuite/api.py
+++ b/cartography/intel/gsuite/api.py
@@ -1,6 +1,7 @@
 import logging
 
 from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 
 logger = logging.getLogger(__name__)
@@ -9,6 +10,7 @@ logger = logging.getLogger(__name__)
 GOOGLE_API_NUM_RETRIES = 5
 
 
+@timeit
 def get_all_groups(admin):
     """
     Return list of Google Groups in your organization
@@ -29,6 +31,7 @@ def get_all_groups(admin):
     return response_objects
 
 
+@timeit
 def transform_groups(response_objects):
     """  Strips list of API response objects to return list of group objects only
 
@@ -42,6 +45,7 @@ def transform_groups(response_objects):
     return groups
 
 
+@timeit
 def transform_users(response_objects):
     """  Strips list of API response objects to return list of group objects only
     :param response_objects:
@@ -54,6 +58,7 @@ def transform_users(response_objects):
     return users
 
 
+@timeit
 def get_all_groups_for_email(admin, email):
     """ Fetch all groups of which the given group is a member
 
@@ -72,6 +77,7 @@ def get_all_groups_for_email(admin, email):
     return groups
 
 
+@timeit
 def get_members_for_group(admin, group_email):
     """ Get all members for a google group
 
@@ -92,6 +98,7 @@ def get_members_for_group(admin, group_email):
     return members
 
 
+@timeit
 def get_all_users(admin):
     """
     Return list of Google Users in your organization
@@ -112,6 +119,7 @@ def get_all_users(admin):
     return response_objects
 
 
+@timeit
 def load_gsuite_groups(session, groups, gsuite_update_tag):
     ingestion_qry = """
         UNWIND {GroupData} as group
@@ -133,6 +141,7 @@ def load_gsuite_groups(session, groups, gsuite_update_tag):
     session.run(ingestion_qry, GroupData=groups, UpdateTag=gsuite_update_tag)
 
 
+@timeit
 def load_gsuite_users(session, users, gsuite_update_tag):
     ingestion_qry = """
         UNWIND {UserData} as user
@@ -171,6 +180,7 @@ def load_gsuite_users(session, users, gsuite_update_tag):
     session.run(ingestion_qry, UserData=users, UpdateTag=gsuite_update_tag)
 
 
+@timeit
 def load_gsuite_members(session, group, members, gsuite_update_tag):
     ingestion_qry = """
         UNWIND {MemberData} as member
@@ -199,6 +209,7 @@ def load_gsuite_members(session, group, members, gsuite_update_tag):
     session.run(membership_qry, MemberData=members, GroupID=group.get("id"), UpdateTag=gsuite_update_tag)
 
 
+@timeit
 def cleanup_gsuite_users(session, common_job_parameters):
     run_cleanup_job(
         'gsuite_ingest_users_cleanup.json',
@@ -207,6 +218,7 @@ def cleanup_gsuite_users(session, common_job_parameters):
     )
 
 
+@timeit
 def cleanup_gsuite_groups(session, common_job_parameters):
     run_cleanup_job(
         'gsuite_ingest_groups_cleanup.json',
@@ -215,6 +227,7 @@ def cleanup_gsuite_groups(session, common_job_parameters):
     )
 
 
+@timeit
 def sync_gsuite_users(session, admin, gsuite_update_tag, common_job_parameters):
     """
     GET GSuite user objects using the google admin api resource, load the data into Neo4j and clean up stale nodes.
@@ -233,6 +246,7 @@ def sync_gsuite_users(session, admin, gsuite_update_tag, common_job_parameters):
     cleanup_gsuite_users(session, common_job_parameters)
 
 
+@timeit
 def sync_gsuite_groups(session, admin, gsuite_update_tag, common_job_parameters):
     """
     GET GSuite group objects using the google admin api resource, load the data into Neo4j and clean up stale nodes.
@@ -252,6 +266,7 @@ def sync_gsuite_groups(session, admin, gsuite_update_tag, common_job_parameters)
     sync_gsuite_members(groups, session, admin, gsuite_update_tag)
 
 
+@timeit
 def sync_gsuite_members(groups, session, admin, gsuite_update_tag):
     for group in groups:
         members = get_members_for_group(admin, group['email'])

--- a/cartography/intel/okta/__init__.py
+++ b/cartography/intel/okta/__init__.py
@@ -29,6 +29,7 @@ def _cleanup_okta_organizations(session, common_job_parameters):
     run_cleanup_job('okta_import_cleanup.json', session, common_job_parameters)
 
 
+@timeit
 def start_okta_ingestion(neo4j_session, config):
     """
     Starts the OKTA ingestion process

--- a/cartography/intel/okta/__init__.py
+++ b/cartography/intel/okta/__init__.py
@@ -12,10 +12,12 @@ from cartography.intel.okta import roles
 from cartography.intel.okta import users
 from cartography.intel.okta.sync_state import OktaSyncState
 from cartography.util import run_cleanup_job
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def _cleanup_okta_organizations(session, common_job_parameters):
     """
     Remove stale Okta organization

--- a/cartography/intel/okta/applications.py
+++ b/cartography/intel/okta/applications.py
@@ -7,11 +7,13 @@ from okta.framework.OktaError import OktaError
 
 from cartography.intel.okta.utils import create_api_client
 from cartography.intel.okta.utils import is_last_page
+from cartography.util import timeit
 
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def _get_okta_applications(api_client):
     """
     Get application data from Okta server
@@ -45,6 +47,7 @@ def _get_okta_applications(api_client):
     return app_list
 
 
+@timeit
 def _get_application_assigned_users(api_client, app_id):
     """
     Get users assigned to a specific application
@@ -79,6 +82,7 @@ def _get_application_assigned_users(api_client, app_id):
     return app_users
 
 
+@timeit
 def _get_application_assigned_groups(api_client, app_id):
     """
     Get groups assigned to a specific application
@@ -113,6 +117,7 @@ def _get_application_assigned_groups(api_client, app_id):
     return app_groups
 
 
+@timeit
 def transform_application_assigned_users_list(assigned_user_list):
     """
     Transform application users Okta data
@@ -127,6 +132,7 @@ def transform_application_assigned_users_list(assigned_user_list):
     return users
 
 
+@timeit
 def transform_application_assigned_users(json_app_data):
     """
     Transform application users data for graph consumption
@@ -142,6 +148,7 @@ def transform_application_assigned_users(json_app_data):
     return users
 
 
+@timeit
 def transform_application_assigned_groups_list(assigned_group_list):
     group_list = []
 
@@ -152,6 +159,7 @@ def transform_application_assigned_groups_list(assigned_group_list):
     return group_list
 
 
+@timeit
 def transform_application_assigned_groups(json_app_data):
     """
     Transform application group assignment to consumable data for the graph
@@ -167,6 +175,7 @@ def transform_application_assigned_groups(json_app_data):
     return groups
 
 
+@timeit
 def transform_okta_application_list(okta_applications):
     app_list = []
 
@@ -177,6 +186,7 @@ def transform_okta_application_list(okta_applications):
     return app_list
 
 
+@timeit
 def transform_okta_application(okta_application):
     app_props = {}
     app_props["id"] = okta_application["id"]
@@ -211,6 +221,7 @@ def transform_okta_application(okta_application):
     return app_props
 
 
+@timeit
 def transform_okta_application_extract_replyurls(okta_application):
     """
     Extracts the reply uri information from an okta app
@@ -222,6 +233,7 @@ def transform_okta_application_extract_replyurls(okta_application):
     return None
 
 
+@timeit
 def _load_okta_applications(neo4j_session, okta_org_id, app_list, okta_update_tag):
     """
     Add application into the graph
@@ -260,6 +272,7 @@ def _load_okta_applications(neo4j_session, okta_org_id, app_list, okta_update_ta
     )
 
 
+@timeit
 def _load_application_user(neo4j_session, app_id, user_list, okta_update_tag):
     """
     Add application users into the graph
@@ -288,6 +301,7 @@ def _load_application_user(neo4j_session, app_id, user_list, okta_update_tag):
     )
 
 
+@timeit
 def _load_application_group(neo4j_session, app_id, group_list, okta_update_tag):
     """
     Add application groups into the graph
@@ -316,6 +330,7 @@ def _load_application_group(neo4j_session, app_id, group_list, okta_update_tag):
     )
 
 
+@timeit
 def _load_application_reply_urls(neo4j_session, app_id, reply_urls, okta_update_tag):
     """
     Add reply urls to their applications
@@ -349,6 +364,7 @@ def _load_application_reply_urls(neo4j_session, app_id, reply_urls, okta_update_
     )
 
 
+@timeit
 def sync_okta_applications(neo4j_session, okta_org_id, okta_update_tag, okta_api_key):
     """
     Sync okta application

--- a/cartography/intel/okta/awssaml.py
+++ b/cartography/intel/okta/awssaml.py
@@ -2,6 +2,8 @@
 import logging
 import re
 
+from cartography.util import timeit
+
 
 logger = logging.getLogger(__name__)
 
@@ -10,6 +12,7 @@ def _parse_regex(regex_string):
     return regex_string.replace("{{accountid}}", "P<accountid>").replace("{{role}}", "P<role>").strip()
 
 
+@timeit
 def transform_okta_group_to_aws_role(group_id, group_name, mapping_regex):
     regex = _parse_regex(mapping_regex)
     matches = re.search(regex, group_name)
@@ -20,6 +23,7 @@ def transform_okta_group_to_aws_role(group_id, group_name, mapping_regex):
         return {"groupid": group_id, "role": role_arn}
 
 
+@timeit
 def query_for_okta_to_aws_role_mapping(neo4j_session, mapping_regex):
     """
     Query the graph for all groups associated with the amazon_aws application and map them to AWSRoles
@@ -47,6 +51,7 @@ def query_for_okta_to_aws_role_mapping(neo4j_session, mapping_regex):
     return group_to_role_mapping
 
 
+@timeit
 def _load_okta_group_to_aws_roles(neo4j_session, group_to_role, okta_update_tag):
     """
     Add the ALLOWED_BY relationship between OktaGroups and the AWSRoles they enable
@@ -72,6 +77,7 @@ def _load_okta_group_to_aws_roles(neo4j_session, group_to_role, okta_update_tag)
     )
 
 
+@timeit
 def _load_human_can_assume_role(neo4j_session, okta_update_tag):
     """
     Add the CAN_ASSUME_ROLE relationship between Humans and the AWSRoles they can assume
@@ -91,6 +97,7 @@ def _load_human_can_assume_role(neo4j_session, okta_update_tag):
     )
 
 
+@timeit
 def sync_okta_aws_saml(neo4j_session, mapping_regex, okta_update_tag):
     """
     Sync okta integration with saml. This will link OktaGroups to the AWSRoles they enable.

--- a/cartography/intel/okta/factors.py
+++ b/cartography/intel/okta/factors.py
@@ -4,10 +4,13 @@ import logging
 from okta import FactorsClient
 from okta.framework.OktaError import OktaError
 
+from cartography.util import timeit
+
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def _create_factor_client(okta_org, okta_api_key):
     """
     Create Okta FactorsClient
@@ -25,6 +28,7 @@ def _create_factor_client(okta_org, okta_api_key):
     return factor_client
 
 
+@timeit
 def _get_factor_for_user_id(factor_client, user_id):
     """
     Get factor for user from the Okta server
@@ -46,6 +50,7 @@ def _get_factor_for_user_id(factor_client, user_id):
     return factor_results
 
 
+@timeit
 def transform_okta_user_factor_list(okta_factor_list):
     factors = []
 
@@ -55,6 +60,7 @@ def transform_okta_user_factor_list(okta_factor_list):
     return factors
 
 
+@timeit
 def transform_okta_user_factor(okta_factor_info):
     """
     Transform okta user factor into consumable data for the graph
@@ -82,6 +88,7 @@ def transform_okta_user_factor(okta_factor_info):
     return factor_props
 
 
+@timeit
 def _load_user_factors(neo4j_session, user_id, factors, okta_update_tag):
     """
     Add user factors into the graph
@@ -118,6 +125,7 @@ def _load_user_factors(neo4j_session, user_id, factors, okta_update_tag):
     )
 
 
+@timeit
 def sync_users_factors(neo4j_session, okta_org_id, okta_update_tag, okta_api_key, sync_state):
     """
     Sync user factors

--- a/cartography/intel/okta/groups.py
+++ b/cartography/intel/okta/groups.py
@@ -8,10 +8,12 @@ from okta.models.usergroup import UserGroup
 
 from cartography.intel.okta.utils import create_api_client
 from cartography.intel.okta.utils import is_last_page
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def _get_okta_groups(api_client):
     """
     Get groups from Okta server
@@ -46,6 +48,7 @@ def _get_okta_groups(api_client):
     return group_list
 
 
+@timeit
 def _get_okta_group_members(api_client, group_id):
     """
     Get group members from Okta server
@@ -80,6 +83,7 @@ def _get_okta_group_members(api_client, group_id):
     return member_list
 
 
+@timeit
 def transform_okta_group_list(okta_group_list):
     groups = []
     groups_id = []
@@ -91,6 +95,7 @@ def transform_okta_group_list(okta_group_list):
     return groups, groups_id
 
 
+@timeit
 def transform_okta_group(okta_group):
     """
     Transform okta group object to consumable dictionary for graph
@@ -125,6 +130,7 @@ def transform_okta_group(okta_group):
     return group_props
 
 
+@timeit
 def transform_okta_group_member_list(okta_member_list):
     member_list = []
 
@@ -134,6 +140,7 @@ def transform_okta_group_member_list(okta_member_list):
     return member_list
 
 
+@timeit
 def transform_okta_group_member(raw_json_response):
     """
     Transform group member object to graph consumable data
@@ -149,6 +156,7 @@ def transform_okta_group_member(raw_json_response):
     return member_list
 
 
+@timeit
 def _load_okta_groups(neo4j_session, okta_org_id, group_list, okta_update_tag):
     """
     Add okta groups to the graph
@@ -185,6 +193,7 @@ def _load_okta_groups(neo4j_session, okta_org_id, group_list, okta_update_tag):
     )
 
 
+@timeit
 def _load_okta_group_members(neo4j_session, group_id, member_list, okta_update_tag):
     """
     Add group membership data into the graph
@@ -213,6 +222,7 @@ def _load_okta_group_members(neo4j_session, group_id, member_list, okta_update_t
     )
 
 
+@timeit
 def _sync_okta_group_membership(neo4j_session, api_client, group_list_info, okta_update_tag):
     """
     Map group members in the graph
@@ -230,6 +240,7 @@ def _sync_okta_group_membership(neo4j_session, api_client, group_list_info, okta
         _load_okta_group_members(neo4j_session, group_id, members, okta_update_tag)
 
 
+@timeit
 def sync_okta_groups(neo4_session, okta_org_id, okta_update_tag, okta_api_key, sync_state):
     """
     Synchronize okta groups

--- a/cartography/intel/okta/organization.py
+++ b/cartography/intel/okta/organization.py
@@ -1,9 +1,12 @@
 # Okta intel module - Organization
 import logging
 
+from cartography.util import timeit
+
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def create_okta_organization(neo4j_session, organization, okta_update_tag):
     """
     Create Okta organization in the graph

--- a/cartography/intel/okta/origins.py
+++ b/cartography/intel/okta/origins.py
@@ -3,10 +3,12 @@ import json
 import logging
 
 from cartography.intel.okta.utils import create_api_client
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def _get_trusted_origins(api_client):
     """
     Get trusted origins from Okta
@@ -19,6 +21,7 @@ def _get_trusted_origins(api_client):
     return response.text
 
 
+@timeit
 def transform_trusted_origins(data):
     """
     Transform trusted origin data returned by Okta Server
@@ -51,6 +54,7 @@ def transform_trusted_origins(data):
     return ret_list
 
 
+@timeit
 def _load_trusted_origins(neo4j_session, okta_org_id, trusted_list, okta_update_tag):
     """
     Add trusted origins to the graph
@@ -90,6 +94,7 @@ def _load_trusted_origins(neo4j_session, okta_org_id, trusted_list, okta_update_
     )
 
 
+@timeit
 def sync_trusted_origins(neo4j_session, okta_org_id, okta_update_tag, okta_api_key):
     """
     Sync trusted origins

--- a/cartography/intel/okta/roles.py
+++ b/cartography/intel/okta/roles.py
@@ -3,10 +3,12 @@ import json
 import logging
 
 from cartography.intel.okta.utils import create_api_client
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
+@timeit
 def _get_user_roles(api_client, user_id, okta_org_id):
     """
     Get user roles from Okta
@@ -22,6 +24,7 @@ def _get_user_roles(api_client, user_id, okta_org_id):
     return response.text
 
 
+@timeit
 def _get_group_roles(api_client, group_id, okta_org_id):
     """
     Get user roles from Okta
@@ -37,6 +40,7 @@ def _get_group_roles(api_client, group_id, okta_org_id):
     return response.text
 
 
+@timeit
 def transform_user_roles_data(data, okta_org_id):
     """
     Transform user role data
@@ -59,6 +63,7 @@ def transform_user_roles_data(data, okta_org_id):
     return user_roles
 
 
+@timeit
 def transform_group_roles_data(data, okta_org_id):
     """
     Transform user role data
@@ -81,6 +86,7 @@ def transform_group_roles_data(data, okta_org_id):
     return user_roles
 
 
+@timeit
 def _load_user_role(neo4j_session, user_id, roles_data, okta_update_tag):
     ingest = """
     MATCH (user:OktaUser{id: {USER_ID}})<-[:RESOURCE]-(org:OktaOrganization)
@@ -107,6 +113,7 @@ def _load_user_role(neo4j_session, user_id, roles_data, okta_update_tag):
     )
 
 
+@timeit
 def _load_group_role(neo4j_session, group_id, roles_data, okta_update_tag):
     ingest = """
     MATCH (group:OktaGroup{id: {GROUP_ID}})<-[:RESOURCE]-(org:OktaOrganization)
@@ -133,6 +140,7 @@ def _load_group_role(neo4j_session, group_id, roles_data, okta_update_tag):
     )
 
 
+@timeit
 def sync_roles(neo4j_session, okta_org_id, okta_update_tag, okta_api_key, sync_state):
     """
     Sync okta roles

--- a/cartography/intel/okta/users.py
+++ b/cartography/intel/okta/users.py
@@ -3,6 +3,9 @@ import logging
 
 from okta import UsersClient
 
+from cartography.util import timeit
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -22,6 +25,7 @@ def _create_user_client(okta_org, okta_api_key):
     return user_client
 
 
+@timeit
 def _get_okta_users(user_client):
     """
     Get Okta users from Okta server
@@ -41,6 +45,7 @@ def _get_okta_users(user_client):
     return user_list
 
 
+@timeit
 def transform_okta_user_list(okta_user_list):
     users = []
     user_ids = []
@@ -52,6 +57,7 @@ def transform_okta_user_list(okta_user_list):
     return users, user_ids
 
 
+@timeit
 def transform_okta_user(okta_user):
     """
     Transform okta user data
@@ -102,6 +108,7 @@ def transform_okta_user(okta_user):
     return user_props
 
 
+@timeit
 def _load_okta_users(neo4j_session, okta_org_id, user_list, okta_update_tag):
     """
     Load Okta user information into the graph
@@ -152,6 +159,7 @@ def _load_okta_users(neo4j_session, okta_org_id, user_list, okta_update_tag):
     )
 
 
+@timeit
 def sync_okta_users(neo4j_session, okta_org_id, okta_update_tag, okta_api_key, sync_state):
     """
     Sync okta users

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -32,3 +32,29 @@ def run_cleanup_job(filename, neo4j_session, common_job_parameters):
 
 def load_resource_binary(package, resource_name):
     return open_binary(package, resource_name)
+
+
+# The statsd client used for observability.  This is `None` unless cartography.config.statsd_enabled is True.
+stats_client = None
+
+def timeit(method):
+    """
+    This decorator uses statsd to time the execution of the wrapped method and sends it to the statsd server.
+    This is only active if config.statsd_enabled is True.
+    :param method: The function to measure execution
+    """
+    def timed(*args, **kwargs):
+        if stats_client:
+            # Example metric name "cartography.intel.aws.iam.get_group_membership_data"
+            metric_name = f"{method.__module__}.{method.__name__}"
+            print(metric_name)
+            timer = stats_client.timer(metric_name)
+            timer.start()
+            result = method(*args, **kwargs)
+            timer.stop()
+            return result
+        else:
+            # statsd is disabled, so don't time anything
+            return method(*args, **kwargs)
+
+    return timed

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -37,6 +37,7 @@ def load_resource_binary(package, resource_name):
 # The statsd client used for observability.  This is `None` unless cartography.config.statsd_enabled is True.
 stats_client = None
 
+
 def timeit(method):
     """
     This decorator uses statsd to time the execution of the wrapped method and sends it to the statsd server.

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -48,7 +48,6 @@ def timeit(method):
         if stats_client:
             # Example metric name "cartography.intel.aws.iam.get_group_membership_data"
             metric_name = f"{method.__module__}.{method.__name__}"
-            print(metric_name)
             timer = stats_client.timer(metric_name)
             timer.start()
             result = method(*args, **kwargs)

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -49,5 +49,5 @@ Time to set up the server that will run Cartography.  Cartography _should_ work 
 	    You can view a full list of Cartography's CLI arguments by running `cartography --help`
 
 		The sync will pull data from your configured accounts and ingest data to Neo4j!  This process might take a long time if your account has a lot of assets.
-	
+
 	1. See our [Operations Guide](ops.md) for tips on running Cartography in production.

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -49,3 +49,5 @@ Time to set up the server that will run Cartography.  Cartography _should_ work 
 	    You can view a full list of Cartography's CLI arguments by running `cartography --help`
 
 		The sync will pull data from your configured accounts and ingest data to Neo4j!  This process might take a long time if your account has a lot of assets.
+	
+	1. See our [Operations Guide](ops.md) for tips on running Cartography in production.

--- a/docs/setup/ops.md
+++ b/docs/setup/ops.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Cartography operations guide](#cartography-operations-guide)
+  - [Maintaining a up-to-date picture of your infrastructure](#maintaining-a-up-to-date-picture-of-your-infrastructure)
+    - [Update tags](#update-tags)
+    - [Cleanup jobs](#cleanup-jobs)
+    - [Sync frequency](#sync-frequency)
+  - [Observability](#observability)
+    - [statsd](#statsd)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Cartography operations guide
 
 This document contains tips for running Cartography in production.
@@ -5,7 +19,7 @@ This document contains tips for running Cartography in production.
 
 ## Maintaining a up-to-date picture of your infrastructure
 
-Running `cartography` ensures that your Neo4j instance contains the most recent snapshot of your infrastructure. Here's 
+Running `cartography` ensures that your Neo4j instance contains the most recent snapshot of your infrastructure. Here's
 how that process works.
 
 ### Update tags
@@ -14,19 +28,19 @@ started](https://github.com/lyft/cartography/blob/8d60311a10156cd8aa16de7e1fe3e1
 but in theory could be anything provided that it is unique per sync (more details [here](../dev/writing-intel-modules.md#handling-cartographys-update_tag)).
 
 ### Cleanup jobs
-Each node and relationship created or updated during the sync will have their `lastupdated` field set to the 
+Each node and relationship created or updated during the sync will have their `lastupdated` field set to the
 `update_tag`. At the end of a sync run, nodes and relationships with out-of-date `lastupdated` fields are considered
 stale and will be deleted via a [cleanup job](../dev/writing-intel-modules.md#cleanup).
 
 ### Sync frequency
-To keep data updated, you can run `cartography` as part of a periodic script (cronjobs in Linux, scheduled tasks in 
+To keep data updated, you can run `cartography` as part of a periodic script (cronjobs in Linux, scheduled tasks in
 Windows). Determine your needs for data freshness and adjust accordingly.
 
 
 ## Observability
 
 ### statsd
-Cartography can be configured to send metrics to a [statsd](https://github.com/statsd/statsd) server. Specify the 
-`--statsd-enabled` flag when running `cartography` for sync execution times to be recorded and sent to 
-`127.0.0.1:8125` by default (these options are also configurable with the `--statsd-host` and `--statsd-port` options). 
+Cartography can be configured to send metrics to a [statsd](https://github.com/statsd/statsd) server. Specify the
+`--statsd-enabled` flag when running `cartography` for sync execution times to be recorded and sent to
+`127.0.0.1:8125` by default (these options are also configurable with the `--statsd-host` and `--statsd-port` options).
 You can also provide your own `--statsd-prefix` to make these metrics easier to find in your own environment.

--- a/docs/setup/ops.md
+++ b/docs/setup/ops.md
@@ -1,0 +1,32 @@
+# Cartography operations guide
+
+This document contains tips for running Cartography in production.
+
+
+## Maintaining a up-to-date picture of your infrastructure
+
+Running `cartography` ensures that your Neo4j instance contains the most recent snapshot of your infrastructure. Here's 
+how that process works.
+
+### Update tags
+Each sync run has an `update_tag` associated with it, which by default is the [Unix timestamp of when the sync
+started](https://github.com/lyft/cartography/blob/8d60311a10156cd8aa16de7e1fe3e109cc3eca0f/cartography/sync.py#L131-L134),
+but in theory could be anything provided that it is unique per sync (more details [here](../dev/writing-intel-modules.md#handling-cartographys-update_tag)).
+
+### Cleanup jobs
+Each node and relationship created or updated during the sync will have their `lastupdated` field set to the 
+`update_tag`. At the end of a sync run, nodes and relationships with out-of-date `lastupdated` fields are considered
+stale and will be deleted via a [cleanup job](../dev/writing-intel-modules.md#cleanup).
+
+### Sync frequency
+To keep data updated, you can run `cartography` as part of a periodic script (cronjobs in Linux, scheduled tasks in 
+Windows). Determine your needs for data freshness and adjust accordingly.
+
+
+## Observability
+
+### statsd
+Cartography can be configured to send metrics to a [statsd](https://github.com/statsd/statsd) server. Specify the 
+`--statsd-enabled` flag when running `cartography` for sync execution times to be recorded and sent to 
+`127.0.0.1:8125` by default (these options are also configurable with the `--statsd-host` and `--statsd-port` options). 
+You can also provide your own `--statsd-prefix` to make these metrics easier to find in your own environment.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "marshmallow>=3.0.0rc7",
         "okta>=0.0.4",
         "requests>=2.22.0",
-        "statsd"
+        "statsd",
     ],
     extras_require={
         ':python_version<"3.7"': [

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "marshmallow>=3.0.0rc7",
         "okta>=0.0.4",
         "requests>=2.22.0",
+        "statsd"
     ],
     extras_require={
         ':python_version<"3.7"': [


### PR DESCRIPTION
Initial commit to add toggle-able statsd to cartography. Default: statsd = off.

I've tested this against a statsd docker container and have verified that the statsd server receives the timing metrics.
![image](https://user-images.githubusercontent.com/46503781/79166619-6a4ba780-7d9a-11ea-93a2-552891ad1c56.png)

The main changes are in cartography/[cli.py](https://github.com/lyft/cartography/pull/282/files#diff-45cb6296a0d6cbd50fe03c5a9e738eec), cartography/[config.py](https://github.com/lyft/cartography/pull/282/files#diff-5efeb69439864d9aee0e4aef0391eee2), and cartography/[util.py](https://github.com/lyft/cartography/pull/282/files#diff-c71b252e2a66286776d3ff804fd5c815).