### PR TITLE
Switch to project ID

### DIFF
--- a/cartography/intel/gcp/gke.py
+++ b/cartography/intel/gcp/gke.py
@@ -47,7 +47,7 @@ def get_gke_clusters(container, project_id):
             raise
 
 
-def load_gke_clusters(neo4j_session, gke_list, project_number, gcp_update_tag):
+def load_gke_clusters(neo4j_session, gke_list, project_id, gcp_update_tag):
     """
     Ingest GCP GKE Clusters to Neo4j
 
@@ -97,7 +97,7 @@ def load_gke_clusters(neo4j_session, gke_list, project_number, gcp_update_tag):
         cluster.masterauth_username = {ClusterMasterUsername},
         cluster.masterauth_password = {ClusterMasterPassword}
     WITH cluster
-    MATCH (owner:GCPProject{projectnumber:{ProjectNumber}})
+    MATCH (owner:GCPProject{id:{ProjectId}})
     MERGE (owner)-[r:RESOURCE]->(cluster)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = {gcp_update_tag}
@@ -105,7 +105,7 @@ def load_gke_clusters(neo4j_session, gke_list, project_number, gcp_update_tag):
     for cluster in gke_list.get('clusters', []):
         neo4j_session.run(
             query,
-            ProjectNumber=project_number,
+            ProjectId=project_id,
             ClusterSelfLink=cluster['selfLink'],
             ClusterCreateTime=cluster['createTime'],
             ClusterName=cluster['name'],

--- a/tests/integration/cartography/intel/gcp/test_gke.py
+++ b/tests/integration/cartography/intel/gcp/test_gke.py
@@ -34,7 +34,7 @@ def test_load_eks_clusters_relationships(neo4j_session):
     # Create Test GCPProject
     neo4j_session.run(
         """
-        MERGE (gcp:GCPProject{projectnumber: {PROJECT_NUMBER}})
+        MERGE (gcp:GCPProject{id: {PROJECT_NUMBER}})
         ON CREATE SET gcp.firstseen = timestamp()
         SET gcp.lastupdated = {UPDATE_TAG}
         """,
@@ -58,12 +58,12 @@ def test_load_eks_clusters_relationships(neo4j_session):
     # Fetch relationships
     result = neo4j_session.run(
         """
-        MATCH (n1:GCPProject)-[:RESOURCE]->(n2:GKECluster) RETURN n1.projectnumber, n2.id;
+        MATCH (n1:GCPProject)-[:RESOURCE]->(n2:GKECluster) RETURN n1.id, n2.id;
         """
     )
 
     actual = {
-        (r['n1.projectnumber'], r['n2.id']) for r in result
+        (r['n1.id'], r['n2.id']) for r in result
     }
 
     assert actual == expected


### PR DESCRIPTION
This PR proposes to shift from using `ProjectNumber` to `ProjectID` as project identifier within the GKE ingestion.