### PR TITLE
Move statsd initialization to sync.run_with_config() and add doc strings

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -4,8 +4,6 @@ import logging
 import os
 import sys
 
-from statsd import StatsClient
-
 import cartography.sync
 import cartography.util
 
@@ -268,12 +266,10 @@ class CLI:
         else:
             config.github_config = None
 
-        # Statsd config
         if config.statsd_enabled:
-            cartography.util.stats_client = StatsClient(
-                host=config.statsd_host,
-                port=config.statsd_port,
-                prefix=config.statsd_prefix,
+            logger.debug(
+                f'statsd enabled. Sending metrics to server {config.statsd_host}:{config.statsd_port}. '
+                f'Metrics have prefix "{config.statsd_prefix}".',
             )
 
         # Run cartography

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -32,11 +32,11 @@ class Config:
     :type github_config: str
     :param github_config: Base64 encoded config object for GitHub ingestion. Optional
     :type statsd_enabled: bool
-    :param statsd_enabled: Whether to collect statsd metrics such as sync execution times.
+    :param statsd_enabled: Whether to collect statsd metrics such as sync execution times. Optional.
     :type statsd_host: str
-    :param statsd_host: If statsd_enabled is True, send metrics to this host. Default=127.0.0.1.
+    :param statsd_host: If statsd_enabled is True, send metrics to this host. Optional.
     :type: statsd_port: int
-    :param statsd_port: If statsd_enabled is True, send metrics to this port on statsd_host. Default=8125.
+    :param statsd_port: If statsd_enabled is True, send metrics to this port on statsd_host. Optional.
     """
 
     def __init__(

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -31,6 +31,12 @@ class Config:
     :param okta_saml_role_regex: The regex used to map okta groups to AWS roles. Optional.
     :type github_config: str
     :param github_config: Base64 encoded config object for GitHub ingestion. Optional
+    :type statsd_enabled: bool
+    :param statsd_enabled: Whether to collect statsd metrics such as sync execution times.
+    :type statsd_host: str
+    :param statsd_host: If statsd_enabled is True, send metrics to this host. Default=127.0.0.1.
+    :type: statsd_port: int
+    :param statsd_port: If statsd_enabled is True, send metrics to this port on statsd_host. Default=8125.
     """
 
     def __init__(

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 import neobolt.exceptions
 from neo4j import GraphDatabase
+from statsd import StatsClient
 
 import cartography.intel.analysis
 import cartography.intel.aws
@@ -90,6 +91,14 @@ def run_with_config(sync, config):
     :type config: cartography.config.Config
     :param config: The configuration to use to run the sync task.
     """
+    # Initialize statsd client if enabled
+    if config.statsd_enabled:
+        cartography.util.stats_client = StatsClient(
+            host=config.statsd_host,
+            port=config.statsd_port,
+            prefix=config.statsd_prefix,
+        )
+
     neo4j_auth = None
     if config.neo4j_user or config.neo4j_password:
         neo4j_auth = (config.neo4j_user, config.neo4j_password)


### PR DESCRIPTION
Previously the statsd client would not get initialized unless cartography was run through the CLI. I've moved this initialization to `sync.run_with_config()`.  I think this fits better and this is better for consistency because this is also where we initialize the neo4j_driver.