### PR TITLE
Correctly reference config.okta_api_key

### DIFF
--- a/cartography/intel/okta/__init__.py
+++ b/cartography/intel/okta/__init__.py
@@ -37,7 +37,7 @@ def start_okta_ingestion(neo4j_session, config):
     :param config: A `cartography.config` object
     :return: Nothing
     """
-    if 'okta_api_key' not in config:
+    if not config.okta_api_key:
         logger.warning(
             "No valid Okta credentials could be found. Exiting Okta sync stage.",
         )


### PR DESCRIPTION
Fixes this crash:
```
  File \"{PATH}/cartography/intel/okta/__init__.py\", line 40, in start_okta_ingestion
    if 'okta_api_key' not in config:
    TypeError: argument of type 'Config' is not iterable"
```
I am really not sure how this didn't fail earlier. The correct field is [here](https://github.com/lyft/cartography/blob/7ed380ede47c621a10e9a5afd8192c8e92519ab0/cartography/config.py#L70).