### PR TITLE
Exploration of AWS ingestion within opt-in regions

### DIFF
--- a/cartography/intel/aws/ec2/key_pairs.py
+++ b/cartography/intel/aws/ec2/key_pairs.py
@@ -10,8 +10,16 @@ logger = logging.getLogger(__name__)
 @timeit
 def get_ec2_key_pairs(boto3_session, region):
     client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
-    result = client.describe_key_pairs()
-    return result
+    try:
+        return client.describe_key_pairs()
+    except client.exceptions.ClientError as e:
+        # The account is not authorized to use this service in this region
+        # so we can continue without raising an exception
+        if e.response['Error']['Code'] == 'AuthFailure':
+            logger.warn("{} in this region. Skipping...".format(e.response['Error']['Message']))
+        else:
+            raise
+    return {'KeyPairs': []}
 
 
 @timeit

--- a/cartography/intel/aws/ec2/load_balancers.py
+++ b/cartography/intel/aws/ec2/load_balancers.py
@@ -12,8 +12,18 @@ def get_loadbalancer_data(boto3_session, region):
     client = boto3_session.client('elb', region_name=region, config=get_botocore_config())
     paginator = client.get_paginator('describe_load_balancers')
     elbs = []
-    for page in paginator.paginate():
-        elbs.extend(page['LoadBalancerDescriptions'])
+    try:
+        for page in paginator.paginate():
+            elbs.extend(page['LoadBalancerDescriptions'])
+    except client.exceptions.ClientError as e:
+        # The account is not authorized to use this service in this region
+        # so we can continue without raising an exception
+        if e.response['Error']['Code'] == 'InvalidClientTokenId' \
+            or e.response['Error']['Code'] == 'AuthFailure' \
+                or e.response['Error']['Code'] == 'UnrecognizedClientException':
+            logger.warn("{} in this region. Skipping...".format(e.response['Error']['Message']))
+        else:
+            raise
     return {'LoadBalancerDescriptions': elbs}
 
 

--- a/cartography/intel/aws/ec2/security_groups.py
+++ b/cartography/intel/aws/ec2/security_groups.py
@@ -13,8 +13,17 @@ def get_ec2_security_group_data(boto3_session, region):
     client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
     paginator = client.get_paginator('describe_security_groups')
     security_groups = []
-    for page in paginator.paginate():
-        security_groups.extend(page['SecurityGroups'])
+    try:
+        for page in paginator.paginate():
+            security_groups.extend(page['SecurityGroups'])
+    except client.exceptions.ClientError as e:
+        # The account is not authorized to use this service in this region
+        # so we can continue without raising an exception
+        if e.response['Error']['Code'] == 'AuthFailure' \
+                or e.response['Error']['Code'] == 'UnrecognizedClientException':
+            logger.warn("{} in this region. Skipping...".format(e.response['Error']['Message']))
+        else:
+            raise
     return {'SecurityGroups': security_groups}
 
 

--- a/cartography/intel/aws/ec2/vpc.py
+++ b/cartography/intel/aws/ec2/vpc.py
@@ -12,7 +12,16 @@ logger = logging.getLogger(__name__)
 def get_ec2_vpcs(boto3_session, region):
     client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
     # paginator not supported by boto
-    return client.describe_vpcs()
+    try:
+        return client.describe_vpcs()
+    except client.exceptions.ClientError as e:
+        # The account is not authorized to use this service in this region
+        # so we can continue without raising an exception
+        if e.response['Error']['Code'] == 'AuthFailure':
+            logger.warn("{} in this region. Skipping...".format(e.response['Error']['Message']))
+        else:
+            raise
+    return {'Vpcs': []}
 
 
 def _get_cidr_association_statement(block_type):

--- a/cartography/intel/aws/eks.py
+++ b/cartography/intel/aws/eks.py
@@ -18,7 +18,7 @@ def get_eks_clusters(boto3_session, region):
         # The account is not authorized to use this service in this region
         # so we can continue without raising an exception
         if e.response['Error']['Code'] == 'AccessDeniedException' \
-                and 'not authorized to use this service' in e.response['Error']['Message']:
+                or e.response['Error']['Code'] == 'UnrecognizedClientException':
             logger.warn("{} in this region. Skipping...".format(e.response['Error']['Message']))
         else:
             raise


### PR DESCRIPTION
I went down the rabbit hole and patched (in-place) every resource affected by permission issues in regions like `ap-east-1`.

This diff (as it is) is just to show the extent of the issue, and shouldn't get merged (as I'd prefer for these errors to be handled in a single, centralised place)