### PR TITLE
Bump pytest to >=4.6 from >=3.6 for TravisCI

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 pre-commit
-pytest>=3.6
+pytest>=4.6
 pytest-cov


### PR DESCRIPTION
This fixes the following Travis CI error:

```
pluggy.manager.PluginValidationError: Plugin 'pytest_cov' could not be loaded: (pytest 4.3.1 (/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages), Requirement.parse('pytest>=4.6'))!
```