### PR TITLE
343: NoSuchEntityException ListAccessKeys

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -181,7 +181,6 @@ def get_account_access_key_data(boto3_session, username):
     return access_keys
 
 
-
 @timeit
 def load_users(neo4j_session, users, current_aws_account_id, aws_update_tag):
     ingest_user = """

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -171,7 +171,15 @@ def get_role_list_data(boto3_session):
 def get_account_access_key_data(boto3_session, username):
     client = boto3_session.client('iam')
     # NOTE we can get away without using a paginator here because users are limited to two access keys
-    return client.list_access_keys(UserName=username)
+    access_keys = {}
+    try:
+        access_keys = client.list_access_keys(UserName=username)
+    except client.exceptions.NoSuchEntityException:
+        logger.warning(
+            f"Could not get access key for user {username} due to NoSuchEntityException; skipping.",
+        )
+    return access_keys
+
 
 
 @timeit
@@ -622,8 +630,11 @@ def sync_user_access_keys(neo4j_session, boto3_session, current_aws_account_id, 
     query = "MATCH (user:AWSUser)<-[:RESOURCE]-(AWSAccount{id: {AWS_ACCOUNT_ID}}) return user.name as name"
     result = neo4j_session.run(query, AWS_ACCOUNT_ID=current_aws_account_id)
     usernames = [r['name'] for r in result]
-    account_access_key = {name: get_account_access_key_data(boto3_session, name) for name in usernames}
-    load_user_access_keys(neo4j_session, account_access_key, aws_update_tag)
+    for name in usernames:
+        access_keys = get_account_access_key_data(boto3_session, name)
+        if access_keys:
+            account_access_keys = {name: access_keys}
+            load_user_access_keys(neo4j_session, account_access_keys, aws_update_tag)
     run_cleanup_job(
         'aws_import_account_access_key_cleanup.json',
         neo4j_session,


### PR DESCRIPTION
1. Added error handling within `get_account_access_key_data` to account for when botocore returns exception NoSuchEntity. Function will return an empty dict if this error occurs. 

2. Changed `sync_user_access_keys` function to check if user has access_keys (i.e. dict was not empty). If this check passes, then the user's name and access key is sent to the `load_user_access_keys `

3. No changes were made to the load function as the check in step 2 was created. 

second commit was just for linting... 
