### PR TITLE
#353: Only create EC2Subnets if interface.SubnetId is not null

### DIFF
--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -22,56 +22,46 @@ def get_ec2_instances(boto3_session, region):
 
 @timeit
 def load_ec2_instance_network_interfaces(neo4j_session, instance_data, aws_update_tag):
-    ingest_network_interface = """
+    ingest_interfaces = """
     MATCH (instance:EC2Instance{instanceid: {InstanceId}})
-    MERGE (interface:NetworkInterface{id: {NetworkId}})
-    ON CREATE SET interface.firstseen = timestamp()
-    SET interface.status = {Status}, interface.mac_address = {MacAddress}, interface.description = {Description},
-    interface.private_dns_name = {PrivateDnsName}, interface.private_ip_address = {PrivateIpAddress},
-    interface.lastupdated = {aws_update_tag}
-    MERGE (instance)-[r:NETWORK_INTERFACE]->(interface)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
-    WITH interface
-    MERGE (subnet:EC2Subnet{subnetid: {SubnetId}})
-    ON CREATE SET subnet.firstseen = timestamp()
-    SET subnet.lastupdated = {aws_update_tag}
-    MERGE (interface)-[r:PART_OF_SUBNET]->(subnet)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
-    """
+    UNWIND {Interfaces} as interface
+        MERGE (nic:NetworkInterface{id: interface.NetworkInterfaceId})
+        ON CREATE SET nic.firstseen = timestamp()
+        SET nic.status = interface.Status,
+        nic.mac_address = interface.MacAddress,
+        nic.description = interface.Description,
+        nic.private_dns_name = interface.PrivateDnsName,
+        nic.private_ip_address = interface.PrivateIpAddress,
+        nic.lastupdated = {aws_update_tag}
 
-    ingest_network_group = """
-    MATCH (interface:NetworkInterface{id: {NetworkId}}),
-    (group:EC2SecurityGroup{groupid: {GroupId}})
-    MERGE (interface)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(group)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
-    """
+        MERGE (instance)-[r:NETWORK_INTERFACE]->(nic)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
 
+        WITH nic, interface
+        WHERE interface.SubnetId IS NOT NULL
+        MERGE (subnet:EC2Subnet{subnetid: interface.SubnetId})
+        ON CREATE SET subnet.firstseen = timestamp()
+        SET subnet.lastupdated = {aws_update_tag}
+
+        MERGE (nic)-[r:PART_OF_SUBNET]->(subnet)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
+
+        WITH nic, interface
+        UNWIND interface.Groups as group
+            MATCH (ec2group:EC2SecurityGroup{groupid: group.GroupId})
+            MERGE (nic)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(ec2group)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.lastupdated = {aws_update_tag}
+    """
     instance_id = instance_data["InstanceId"]
-
-    for interface in instance_data["NetworkInterfaces"]:
-        neo4j_session.run(
-            ingest_network_interface,
-            InstanceId=instance_id,
-            NetworkId=interface["NetworkInterfaceId"],
-            Status=interface["Status"],
-            MacAddress=interface.get("MacAddress"),
-            Description=interface.get("Description"),
-            PrivateDnsName=interface.get("PrivateDnsName"),
-            PrivateIpAddress=interface.get("PrivateIpAddress"),
-            SubnetId=interface.get("SubnetId"),
-            aws_update_tag=aws_update_tag,
-        ).consume()  # TODO see issue 170
-
-        for group in interface.get("Groups", []):
-            neo4j_session.run(
-                ingest_network_group,
-                NetworkId=interface["NetworkInterfaceId"],
-                GroupId=group["GroupId"],
-                aws_update_tag=aws_update_tag,
-            ).consume()  # TODO see issue 170
+    neo4j_session.run(
+        ingest_interfaces,
+        Interfaces=instance_data['NetworkInterfaces'],
+        InstanceId=instance_id,
+        aws_update_tag=aws_update_tag,
+    ).consume()  # TODO see issue 170
 
 
 @timeit

--- a/tests/data/aws/ec2/instances.py
+++ b/tests/data/aws/ec2/instances.py
@@ -84,7 +84,7 @@ DESCRIBE_INSTANCES = {
                     }],
                     'SourceDestCheck': True,
                     'Status': 'in-use',
-                    'SubnetId': 'SOME_SUBNET_1',
+                    'SubnetId': None,
                     'VpcId': 'SOME_VPC_ID',
                 }],
                 'Placement': {


### PR DESCRIPTION
In #351, we changed the EC2 sync to use None instead of `""` in node fields and uncovered a new bug where we were creating EC2subnets with id set to `“”`. Filed this under new bug #353.

Testing done:
- Updated integration test data to have a `None` subnetid.
- Tested this manually and it works end-to-end.