### PR TITLE
Fix #353 (part 2) - Add int test for instance with SubnetId=None, implement fix

### DIFF
--- a/docs/schema/aws.md
+++ b/docs/schema/aws.md
@@ -1260,6 +1260,7 @@ Representation of a generic Network Interface.  Currently however, we only creat
 | **id** | The ID of the network interface.  (known as `networkInterfaceId` in EC2) |
 | private\_dns\_name| The private DNS name |
 | status | Status of the network interface.  Valid Values: `available | associated | attaching | in-use | detaching ` |
+| subnetid | The ID of the subnet |
 
 
 ### Relationships

--- a/tests/data/aws/ec2/instances.py
+++ b/tests/data/aws/ec2/instances.py
@@ -84,6 +84,8 @@ DESCRIBE_INSTANCES = {
                     }],
                     'SourceDestCheck': True,
                     'Status': 'in-use',
+                    # SubnetId is set to None intentionally on this NIC.
+                    # The AWS APIs return None on subnetids intermittently.
                     'SubnetId': None,
                     'VpcId': 'SOME_VPC_ID',
                 }],
@@ -114,7 +116,8 @@ DESCRIBE_INSTANCES = {
                     'Name': 'running',
                 },
                 'StateTransitionReason': '',
-                'SubnetId': 'SOME_SUBNET_1',
+                # SubnetId is set to None intentionally on this instance.
+                'SubnetId': None,
                 'Tags': [
                     {
                         'Key': 'aws:autoscaling:groupName',


### PR DESCRIPTION
As seen in #353, the AWS API can sometimes return instances with SubnetIds set to None. PR #354 handled this correctly for an instance's network interfaces, but failed to account for SubnetId field directly on an instance, which is what this PR solves.