### PR TITLE
Fix #356 - Fix another typo, handle `None` RPR paths 

### DIFF
--- a/cartography/config.py
+++ b/cartography/config.py
@@ -31,8 +31,8 @@ class Config:
     :param okta_saml_role_regex: The regex used to map okta groups to AWS roles. Optional.
     :type github_config: str
     :param github_config: Base64 encoded config object for GitHub ingestion. Optional.
-    :type permission_relationship_file: str
-    :param permission_relationship_file: File path for the resource permission relationships file. Optional.
+    :type permission_relationships_file: str
+    :param permission_relationships_file: File path for the resource permission relationships file. Optional.
     :type jamf_base_uri: string
     :param jamf_base_uri: Jamf data provider base URI, e.g. https://example.com/JSSResource. Optional.
     :type jamf_user: string
@@ -61,7 +61,7 @@ class Config:
         okta_api_key=None,
         okta_saml_role_regex=None,
         github_config=None,
-        permission_relationship_file=None,
+        permission_relationships_file=None,
         jamf_base_uri=None,
         jamf_user=None,
         jamf_password=None,
@@ -82,10 +82,10 @@ class Config:
         self.okta_api_key = okta_api_key
         self.okta_saml_role_regex = okta_saml_role_regex
         self.github_config = github_config
-        self.permission_relationship_file = permission_relationship_file
-        self.jamf_base_uri = jamf_base_uri,
-        self.jamf_user = jamf_user,
-        self.jamf_password = jamf_password,
+        self.permission_relationships_file = permission_relationships_file
+        self.jamf_base_uri = jamf_base_uri
+        self.jamf_user = jamf_user
+        self.jamf_password = jamf_password
         self.statsd_enabled = statsd_enabled
         self.statsd_prefix = statsd_prefix
         self.statsd_host = statsd_host

--- a/cartography/intel/aws/permission_relationships.py
+++ b/cartography/intel/aws/permission_relationships.py
@@ -312,7 +312,11 @@ def parse_permission_relationships_file(file_path):
             relationship_mapping = yaml.load(f, Loader=yaml.FullLoader)
         return relationship_mapping
     except FileNotFoundError:
-        logger.warning(f"Permission relationships mapping file {file_path} not found, skipping ingestion")
+        logger.warning(
+            f"Permission relationships mapping file {file_path} not found, skipping ingestion. If the referenced file "
+            f"path does not exist, then please explicitly set a value for --permission-relationships-file in the "
+            f"command line interface.",
+        )
         return []
 
 

--- a/cartography/intel/aws/permission_relationships.py
+++ b/cartography/intel/aws/permission_relationships.py
@@ -313,8 +313,8 @@ def parse_permission_relationships_file(file_path):
         return relationship_mapping
     except FileNotFoundError:
         logger.warning(
-            f"Permission relationships mapping file {file_path} not found, skipping ingestion. If the referenced file "
-            f"path does not exist, then please explicitly set a value for --permission-relationships-file in the "
+            f"Permission relationships mapping file {file_path} not found, skipping sync stage {__name__}. "
+            f"If you want to run this sync, please explicitly set a value for --permission-relationships-file in the "
             f"command line interface.",
         )
         return []

--- a/cartography/intel/aws/permission_relationships.py
+++ b/cartography/intel/aws/permission_relationships.py
@@ -328,7 +328,14 @@ def is_valid_rpr(rpr):
 def sync(neo4j_session, account_id, update_tag, common_job_parameters):
     logger.info("Syncing Permission Relationships for account '%s'.", account_id)
     principals = get_principals_for_account(neo4j_session, account_id)
-    relationship_mapping = parse_permission_relationships_file(common_job_parameters["permission_relationships_file"])
+    pr_file = common_job_parameters["permission_relationships_file"]
+    if not pr_file:
+        logger.warning(
+            f"Permission relationships file was not specified, skipping. If this is not expected, please check your "
+            f"value of --permission-relationships-file",
+        )
+        return
+    relationship_mapping = parse_permission_relationships_file(pr_file)
     for rpr in relationship_mapping:
         if not is_valid_rpr(rpr):
             raise ValueError("""

--- a/tests/integration/cartography/intel/aws/test_iam.py
+++ b/tests/integration/cartography/intel/aws/test_iam.py
@@ -28,6 +28,12 @@ def test_permission_relationships_file_arguments():
     cli_parsed_output = cli_object.parser.parse_args(argv)
     assert cli_parsed_output.permission_relationships_file == '/some/test/file.yaml'
 
+    # Test that the default RPR file is set if --permission-relationships-file is not set in the CLI
+    argv = []
+    cli_object = CLI(build_default_sync(), prog='cartography')
+    cli_parsed_output = cli_object.parser.parse_args(argv)
+    assert cli_parsed_output.permission_relationships_file == 'cartography/data/permission_relationships.yaml'
+
 
 def _create_base_account(neo4j_session):
     neo4j_session.run("MERGE (a:AWSAccount{id:{AccountId}})", AccountId=TEST_ACCOUNT_ID)

--- a/tests/integration/cartography/intel/aws/test_iam.py
+++ b/tests/integration/cartography/intel/aws/test_iam.py
@@ -1,10 +1,32 @@
 import cartography.intel.aws.iam
 import cartography.intel.aws.permission_relationships
 import tests.data.aws.iam
+from cartography.cli import CLI
+from cartography.config import Config
+from cartography.sync import build_default_sync
 
 TEST_ACCOUNT_ID = '000000000000'
 TEST_REGION = 'us-east-1'
 TEST_UPDATE_TAG = 123456789
+
+
+def test_permission_relationships_file_arguments():
+    """
+    Test that we correctly read arguments for --permission-relationships-file
+    """
+    # Test the correct field is set in the Cartography config object
+    fname = '/some/test/file.yaml'
+    config = Config(
+        neo4j_uri='bolt://thisdoesnotmatter:1234',
+        permission_relationships_file=fname,
+    )
+    assert config.permission_relationships_file == fname
+
+    # Test the correct field is set in the Cartography CLI object
+    argv = ['--permission-relationships-file', '/some/test/file.yaml']
+    cli_object = CLI(build_default_sync(), prog='cartography')
+    cli_parsed_output = cli_object.parser.parse_args(argv)
+    assert cli_parsed_output.permission_relationships_file == '/some/test/file.yaml'
 
 
 def _create_base_account(neo4j_session):


### PR DESCRIPTION
- Fix another typo in config.py
- Gracefully handle `None` RPR paths in permission_relationships.py
- Add integration tests to verify correct values of CLI object and config object