### PR TITLE
Improve perf: implement UNWIND for AWS resourcegroupstaggingapi

### DIFF
--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -73,31 +73,32 @@ def get_tags(boto3_session, resource_types, region):
 @timeit
 def load_tags(neo4j_session, tag_data, resource_type, region, aws_update_tag):
     INGEST_TAG_TEMPLATE = Template("""
-    MATCH (resource:$resource_label{$property:{ResourceId}})
-    MERGE(aws_tag:AWSTag:Tag{id:{TagId}})
-    ON CREATE SET aws_tag.firstseen = timestamp()
-    SET aws_tag.lastupdated = {UpdateTag},
-        aws_tag.key = {TagKey},
-        aws_tag.value =  {TagValue},
-        aws_tag.region = {Region}
-    MERGE (resource)-[r:TAGGED]->(aws_tag)
-    SET r.lastupdated = {UpdateTag},
-        r.firstseen = timestamp()
+    UNWIND {TagData} as tag_mapping
+        UNWIND tag_mapping.Tags as input_tag
+            MATCH (resource:$resource_label{$property:tag_mapping.resource_id})
+            MERGE(aws_tag:AWSTag:Tag{id:input_tag.Key + ":" + input_tag.Value})
+            ON CREATE SET aws_tag.firstseen = timestamp()
+
+            SET aws_tag.lastupdated = {UpdateTag},
+            aws_tag.key = input_tag.Key,
+            aws_tag.value =  input_tag.Value,
+            aws_tag.region = {Region}
+
+            MERGE (resource)-[r:TAGGED]->(aws_tag)
+            SET r.lastupdated = {UpdateTag},
+            r.firstseen = timestamp()
     """)
-    for tag_mapping in tag_data:
-        for tag in tag_mapping['Tags']:
-            neo4j_session.run(
-                INGEST_TAG_TEMPLATE.safe_substitute(
-                    resource_label=TAG_RESOURCE_TYPE_MAPPINGS[resource_type]['label'],
-                    property=TAG_RESOURCE_TYPE_MAPPINGS[resource_type]['property'],
-                ),
-                ResourceId=tag_mapping['resource_id'],
-                TagId=f'{tag["Key"]}:{tag["Value"]}',
-                UpdateTag=aws_update_tag,
-                TagKey=tag['Key'],
-                TagValue=tag['Value'],
-                Region=region,
-            )
+
+    query = INGEST_TAG_TEMPLATE.safe_substitute(
+        resource_label=TAG_RESOURCE_TYPE_MAPPINGS[resource_type]['label'],
+        property=TAG_RESOURCE_TYPE_MAPPINGS[resource_type]['property'],
+    )
+    neo4j_session.run(
+        query,
+        TagData=tag_data,
+        UpdateTag=aws_update_tag,
+        Region=region,
+    )
 
 
 @timeit

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -88,7 +88,6 @@ def load_tags(neo4j_session, tag_data, resource_type, region, aws_update_tag):
             SET r.lastupdated = {UpdateTag},
             r.firstseen = timestamp()
     """)
-
     query = INGEST_TAG_TEMPLATE.safe_substitute(
         resource_label=TAG_RESOURCE_TYPE_MAPPINGS[resource_type]['label'],
         property=TAG_RESOURCE_TYPE_MAPPINGS[resource_type]['property'],


### PR DESCRIPTION
Batches up our calls to load tags to Neo4j instead of sending multiple smaller queries. See [this blog](https://achantavy.github.io/cartography/performance/cypher/neo4j/2020/07/19/loading-7m-items-to-neo4j-with-and-without-unwind.html) on the motivation behind PRs like this.