### PR TITLE
Fix #379: run GitHub cleanup only on successful sync

### DIFF
--- a/cartography/data/jobs/cleanup/github_repos_cleanup.json
+++ b/cartography/data/jobs/cleanup/github_repos_cleanup.json
@@ -9,7 +9,6 @@
     "iterative": true,
     "iterationsize": 100
   },
-
   {
     "query": "MATCH (n:ProgrammingLanguage) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,

--- a/cartography/data/jobs/cleanup/github_repos_cleanup.json
+++ b/cartography/data/jobs/cleanup/github_repos_cleanup.json
@@ -9,33 +9,14 @@
     "iterative": true,
     "iterationsize": 100
   },
-  {
-    "query": "MATCH (n:GitHubUser) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (n:GitHubOrganization) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
-    "iterative": true,
-    "iterationsize": 100
-  },
+
   {
     "query": "MATCH (n:ProgrammingLanguage) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (GSuiteUser)-[r:INSTALLS]->(:ChromeExtension) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
     "query": "MATCH (:GitHubBranch)-[r:BRANCH]->(:GitHubRepository) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:GitHubUser)-[r:OWNER]->(:GitHubRepository) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },
@@ -48,11 +29,6 @@
     "query": "MATCH (:GitHubRepository)-[r:LANGUAGE]->(:ProgrammingLanguage) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:GitHubUser)-[r:MEMBER_OF]->(:GitHubOrganization) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
-    "iterative": true,
-    "iterationsize": 100
   }],
-  "name": "cleanup GitHub data"
+  "name": "cleanup GitHub repos data"
 }

--- a/cartography/data/jobs/cleanup/github_users_cleanup.json
+++ b/cartography/data/jobs/cleanup/github_users_cleanup.json
@@ -4,7 +4,7 @@
     "iterative": true,
     "iterationsize": 100
   },
-    {
+  {
     "query": "MATCH (n:GitHubOrganization) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100

--- a/cartography/data/jobs/cleanup/github_users_cleanup.json
+++ b/cartography/data/jobs/cleanup/github_users_cleanup.json
@@ -1,0 +1,23 @@
+{
+  "statements": [{
+    "query": "MATCH (n:GitHubUser) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  },
+    {
+    "query": "MATCH (n:GitHubOrganization) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  },
+  {
+    "query": "MATCH (:GitHubUser)-[r:OWNER]->(:GitHubRepository) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  },
+  {
+    "query": "MATCH (:GitHubUser)-[r:MEMBER_OF]->(:GitHubOrganization) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  }],
+  "name": "cleanup GitHub users data"
+}

--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -6,7 +6,6 @@ from requests import exceptions
 
 import cartography.intel.github.repos
 import cartography.intel.github.users
-from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -21,7 +20,7 @@ def start_github_ingestion(neo4j_session, config):
     :return: None
     """
     if not config.github_config:
-        logger.debug('GitHub import is not configured - skipping this module. See docs to configure.')
+        logger.info('GitHub import is not configured - skipping this module. See docs to configure.')
         return
 
     auth_tokens = json.loads(base64.b64decode(config.github_config).decode())
@@ -47,8 +46,3 @@ def start_github_ingestion(neo4j_session, config):
             )
         except exceptions.RequestException as e:
             logger.error("Could not complete request to the GitHub API: {}", e)
-    run_cleanup_job(
-        'github_import_cleanup.json',
-        neo4j_session,
-        common_job_parameters,
-    )

--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -45,4 +45,4 @@ def start_github_ingestion(neo4j_session, config):
                 auth_data['name'],
             )
         except exceptions.RequestException as e:
-            logger.error("Could not complete request to the GitHub API: {}", e)
+            logger.error("Could not complete request to the GitHub API: %s", e)

--- a/cartography/intel/github/users.py
+++ b/cartography/intel/github/users.py
@@ -4,7 +4,6 @@ from cartography.intel.github.util import fetch_all
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/cartography/intel/github/users.py
+++ b/cartography/intel/github/users.py
@@ -1,7 +1,9 @@
 import logging
 
 from cartography.intel.github.util import fetch_all
+from cartography.util import run_cleanup_job
 from cartography.util import timeit
+
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +85,7 @@ def load_organization_users(neo4j_session, user_data, org_data, update_tag):
 
 @timeit
 def sync(neo4j_session, common_job_parameters, github_api_key, github_url, organization):
-    logger.debug("Syncing GitHub users")
+    logger.info("Syncing GitHub users")
     user_data, org_data = get(github_api_key, github_url, organization)
     load_organization_users(neo4j_session, user_data, org_data, common_job_parameters['UPDATE_TAG'])
+    run_cleanup_job('github_users_cleanup.json', neo4j_session, common_job_parameters)

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -27,7 +27,7 @@ def call_github_api(query, variables, token, api_url):
         )
     except requests.exceptions.Timeout:
         # Add context and re-raise for callers to handle
-        logger.warning(f"GitHub: requests.get('{api_url}') timed out.")
+        logger.warning("GitHub: requests.get('%s') timed out.", api_url)
         raise
     response.raise_for_status()
     return response.json()
@@ -77,8 +77,8 @@ def fetch_all(token, api_url, organization, query, resource_type, field_name):
             resp = fetch_page(token, api_url, organization, query, cursor)
         except requests.exceptions.Timeout:
             logger.warning(
-                f"GitHub: Could not retrieve page of resource `{resource_type}` due to API timeout;"
-                f"continuing with incomplete data",
+                "GitHub: Could not retrieve page of resource %s due to API timeout; continuing with incomplete data",
+                resource_type,
             )
             break
         resource = resp['data']['organization'][resource_type]


### PR DESCRIPTION
- Splits up the original GitHub cleanup job into two parts: one for users and one for repos.
- Only runs a cleanup job when a sync completes.
- Ensure object sent to logger is a string -  hopefully this fixes the silent failures