### PR TITLE
Fix #377: correctly parse GKE errors

### DIFF
--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -126,7 +126,9 @@ def _services_enabled_on_project(serviceusage, project_id):
             return {}
     except googleapiclient.discovery.HttpError as http_error:
         http_error = json.loads(http_error.content.decode('utf-8'))
-        logger.warning(
+        # This is set to log-level `info` because Google creates many projects under the hood that cartography cannot
+        # audit (e.g. adding a script to a Google spreadsheet) and we don't need to emit a warning for these projects.
+        logger.info(
             f"HttpError when trying to get enabled services on project {project_id}. "
             f"Code: {http_error['error']['code']}, Message: {http_error['error']['message']}. "
             f"Skipping.",

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -127,7 +127,8 @@ def _services_enabled_on_project(serviceusage, project_id):
     except googleapiclient.discovery.HttpError as http_error:
         http_error = json.loads(http_error.content.decode('utf-8'))
         # This is set to log-level `info` because Google creates many projects under the hood that cartography cannot
-        # audit (e.g. adding a script to a Google spreadsheet) and we don't need to emit a warning for these projects.
+        # audit (e.g. adding a script to a Google spreadsheet causes a project to get created) and we don't need to emit
+        # a warning for these projects.
         logger.info(
             f"HttpError when trying to get enabled services on project {project_id}. "
             f"Code: {http_error['error']['code']}, Message: {http_error['error']['message']}. "

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -902,6 +902,7 @@ def sync_gcp_instances(neo4j_session, compute, project_id, zones, gcp_update_tag
     instance_responses = get_gcp_instance_responses(project_id, zones, compute)
     instance_list = transform_gcp_instances(instance_responses)
     load_gcp_instances(neo4j_session, instance_list, gcp_update_tag)
+    # TODO scope the cleanup to the current project - https://github.com/lyft/cartography/issues/381
     cleanup_gcp_instances(neo4j_session, common_job_parameters)
 
 
@@ -919,6 +920,7 @@ def sync_gcp_vpcs(neo4j_session, compute, project_id, gcp_update_tag, common_job
     vpc_res = get_gcp_vpcs(project_id, compute)
     vpcs = transform_gcp_vpcs(vpc_res)
     load_gcp_vpcs(neo4j_session, vpcs, gcp_update_tag)
+    # TODO scope the cleanup to the current project - https://github.com/lyft/cartography/issues/381
     cleanup_gcp_vpcs(neo4j_session, common_job_parameters)
 
 
@@ -928,6 +930,7 @@ def sync_gcp_subnets(neo4j_session, compute, project_id, regions, gcp_update_tag
         subnet_res = get_gcp_subnets(project_id, r, compute)
         subnets = transform_gcp_subnets(subnet_res)
         load_gcp_subnets(neo4j_session, subnets, gcp_update_tag)
+        # TODO scope the cleanup to the current project - https://github.com/lyft/cartography/issues/381
         cleanup_gcp_subnets(neo4j_session, common_job_parameters)
 
 
@@ -944,6 +947,7 @@ def sync_gcp_firewall_rules(neo4j_session, compute, project_id, gcp_update_tag, 
     fw_response = get_gcp_firewall_ingress_rules(project_id, compute)
     fw_list = transform_gcp_firewall(fw_response)
     load_gcp_ingress_firewalls(neo4j_session, fw_list, gcp_update_tag)
+    # TODO scope the cleanup to the current project - https://github.com/lyft/cartography/issues/381
     cleanup_gcp_firewall_rules(neo4j_session, common_job_parameters)
 
 

--- a/cartography/intel/gcp/gke.py
+++ b/cartography/intel/gcp/gke.py
@@ -28,13 +28,12 @@ def get_gke_clusters(container, project_id):
         res = req.execute()
         return res
     except HttpError as e:
-        err_as_dict = json.loads(e.content.decode('utf-8'))
-        status = err_as_dict['error']['status']
-        if status == 'PERMISSION_DENIED':
+        err = json.loads(e.content.decode('utf-8'))['error']
+        if err['status'] == 'PERMISSION_DENIED':
             logger.warning(
                 (
                     "Could not retrieve GKE clusters on project %s due to permissions issue. Code: %s, Message: %s"
-                ), project_id, err_as_dict['error']['code'], err_as_dict['error']['message'],
+                ), project_id, err['code'], err['message'],
             )
             return {}
         else:

--- a/cartography/intel/gcp/gke.py
+++ b/cartography/intel/gcp/gke.py
@@ -1,8 +1,8 @@
+import json
 import logging
 
 from googleapiclient.discovery import HttpError
 
-from cartography.intel.gcp import compute
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 @timeit
 def get_gke_clusters(container, project_id):
     """
-    Returns a list of GKE clusters within some given project.
+    Returns a GCP response object containing a list of GKE clusters within the given project.
 
     :type container: The GCP Container resource object
     :param container: The Container resource object created by googleapiclient.discovery.build()
@@ -28,38 +28,29 @@ def get_gke_clusters(container, project_id):
         res = req.execute()
         return res
     except HttpError as e:
-        reason = compute._get_error_reason(e)
-        if reason == 'invalid':
+        err_as_dict = json.loads(e.content.decode('utf-8'))
+        status = err_as_dict['error']['status']
+        if status == 'PERMISSION_DENIED':
             logger.warning(
                 (
-                    "The project %s is invalid - returned a 400 invalid error."
-                    "Full details: %s"
-                ),
-                project_id,
-                e,
+                    "Could not retrieve GKE clusters on project %s due to permissions issue. Code: %s, Message: %s"
+                ), project_id, err_as_dict['error']['code'], err_as_dict['error']['message'],
             )
-            return {}
-        elif reason == 'forbidden':
-            logger.warning(
-                (
-                    "You do not have container.projects.zones.clusters.list access to the project %s. "
-                    "Full details: %s"
-                ), project_id, e, )
             return {}
         else:
             raise
 
 
 @timeit
-def load_gke_clusters(neo4j_session, gke_list, project_id, gcp_update_tag):
+def load_gke_clusters(neo4j_session, cluster_resp, project_id, gcp_update_tag):
     """
     Ingest GCP GKE Clusters to Neo4j
 
     :type neo4j_session: Neo4j session object
     :param neo4j session: The Neo4j session object
 
-    :type gke_list: list
-    :param gke_list: List of GCP GKE Clusters to inject
+    :type cluster_resp: Dict
+    :param cluster_resp: A cluster response object from the GKE API
 
     :type gcp_update_tag: timestamp
     :param gcp_update_tag: The timestamp value to set our new Neo4j nodes with
@@ -106,7 +97,7 @@ def load_gke_clusters(neo4j_session, gke_list, project_id, gcp_update_tag):
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = {gcp_update_tag}
     """
-    for cluster in gke_list.get('clusters', []):
+    for cluster in cluster_resp.get('clusters', []):
         neo4j_session.run(
             query,
             ProjectId=project_id,
@@ -196,4 +187,5 @@ def sync_gke_clusters(neo4j_session, container, project_id, gcp_update_tag, comm
     logger.info("Syncing Compute objects for project %s.", project_id)
     gke_res = get_gke_clusters(container, project_id)
     load_gke_clusters(neo4j_session, gke_res, project_id, gcp_update_tag)
+    # TODO scope the cleanup to the current project - https://github.com/lyft/cartography/issues/381
     cleanup_gke_clusters(neo4j_session, common_job_parameters)

--- a/cartography/intel/gcp/storage.py
+++ b/cartography/intel/gcp/storage.py
@@ -240,4 +240,5 @@ def sync_gcp_buckets(neo4j_session, storage, project_id, gcp_update_tag, common_
     storage_res = get_gcp_buckets(storage, project_id)
     bucket_list = transform_gcp_buckets(storage_res)
     load_gcp_buckets(neo4j_session, bucket_list, gcp_update_tag)
+    # TODO scope the cleanup to the current project - https://github.com/lyft/cartography/issues/381
     cleanup_gcp_buckets(neo4j_session, common_job_parameters)


### PR DESCRIPTION
Implements error parsing specific to the GKE sync; for some reason the GCP APIs have different error objects returned depending on the resource type.

Tested this end-to-end and it survived my sync.

Proof that this logs a warning but does not crash:
![image](https://user-images.githubusercontent.com/46503781/89069149-777baa80-d327-11ea-808d-11f37b18cab0.png)
