### PR TITLE
Fix #406 - get_role_manage_policy_data NoSuchEntityException

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -117,7 +117,12 @@ def get_role_policy_data(boto3_session, role_list):
         name = role["RoleName"]
         arn = role["Arn"]
         resource_role = resource_client.Role(name)
-        policies[arn] = {p.name: p.policy_document["Statement"] for p in resource_role.policies.all()}
+        try:
+            policies[arn] = {p.name: p.policy_document["Statement"] for p in resource_role.policies.all()}
+        except resource_client.meta.client.exceptions.NoSuchEntityException:
+            logger.warning(
+                f"Could not get policies for role {name} due to NoSuchEntityException; skipping.",
+            )
     return policies
 
 


### PR DESCRIPTION
Handled exceptions as done for get_role_managed_policy_data

Fixes: https://github.com/lyft/cartography/issues/406