### PR TITLE
Fix 416: Replace AWSUser with AWSPrincipal

### DIFF
--- a/cartography/data/jobs/cleanup/aws_import_account_access_key_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_account_access_key_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (n:AccountAccessKey)<-[:AWS_ACCESS_KEY]-(:AWSUser)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AccountAccessKey)<-[:AWS_ACCESS_KEY]-(:AWSPrincipal)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   }],


### PR DESCRIPTION
As discussed in #416, this diff replaces `AWSUser` with `AWSPrincipal` in the cleanup job for AWS Access Keys