### PR TITLE
Fix IAM sync node label interpretation by adding missing `:`

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -621,7 +621,7 @@ def sync_role_inline_policies(current_aws_account_id, boto3_session, data, neo4j
 @timeit
 def sync_group_memberships(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.debug("Syncing IAM group membership for account '%s'.", current_aws_account_id)
-    query = "MATCH (group:AWSGroup)<-[:RESOURCE]-(AWSAccount{id: {AWS_ACCOUNT_ID}}) " \
+    query = "MATCH (group:AWSGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ACCOUNT_ID}}) " \
             "return group.name as name, group.arn as arn;"
     groups = neo4j_session.run(query, AWS_ACCOUNT_ID=current_aws_account_id)
     groups_membership = {group["arn"]: get_group_membership_data(boto3_session, group["name"]) for group in groups}
@@ -636,7 +636,7 @@ def sync_group_memberships(neo4j_session, boto3_session, current_aws_account_id,
 @timeit
 def sync_user_access_keys(neo4j_session, boto3_session, current_aws_account_id, aws_update_tag, common_job_parameters):
     logger.debug("Syncing IAM user access keys for account '%s'.", current_aws_account_id)
-    query = "MATCH (user:AWSUser)<-[:RESOURCE]-(AWSAccount{id: {AWS_ACCOUNT_ID}}) return user.name as name"
+    query = "MATCH (user:AWSUser)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ACCOUNT_ID}}) return user.name as name"
     result = neo4j_session.run(query, AWS_ACCOUNT_ID=current_aws_account_id)
     usernames = [r['name'] for r in result]
     for name in usernames:


### PR DESCRIPTION
Adding the missing `:` before a node label (e.g. adding `:` in `:AWSAccount`) makes a difference in Cypher because it now interprets the node as a node label and can perform a fast NodeIndexSeek instead of a slower NodeByLabelScan.

Slower:
![image](https://user-images.githubusercontent.com/46503781/96218298-4d568380-0f39-11eb-9cce-1aab60964dfb.png)

Better:
![image](https://user-images.githubusercontent.com/46503781/96218324-59dadc00-0f39-11eb-9c51-d3f36a89d1eb.png)

I'm not expecting earth-shattering performance differences here, but this is an easy win.