### PR TITLE
fix #431 boto version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
     },
     dependency_links=[],
     install_requires=[
-        "boto3>=1.7.0",
-        "botocore>=1.12.0",
+        "boto3>=1.15.1",
+        "botocore>=1.18.1",
         "dnspython>=1.15.0",
         "neo4j>=1.7.0,<4.0.0",
         "neobolt>=1.7.0,<4.0.0",


### PR DESCRIPTION
`make test_lint` updated `tests/integration/cartography/intel/aws/test_ecr.py` as well. (Some commas were missing.) 

I wonder if I should push that too.