### PR TITLE
Constrain ECR cleanup job to current AWS account

### DIFF
--- a/cartography/data/jobs/cleanup/aws_import_ecr_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_ecr_cleanup.json
@@ -1,22 +1,22 @@
 {
   "statements": [
   {
-    "query": "MATCH (n:Risk)-[:AFFECTS]->(:Package)-[:DEPLOYED]->(:ECRImage) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:Risk)-[:AFFECTS]->(:Package)-[:DEPLOYED]->(:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:Risk)-[r:AFFECTS]->(:Package)-[:DEPLOYED]->(:ECRImage) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:Risk)-[r:AFFECTS]->(:Package)-[:DEPLOYED]->(:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:Risk)-[:AFFECTS]->(n:Package)-[:DEPLOYED]->(:ECRImage) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:Risk)-[:AFFECTS]->(n:Package)-[:DEPLOYED]->(:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:Risk)-[:AFFECTS]->(:Package)-[r:DEPLOYED]->(img:ECRImage) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:Risk)-[:AFFECTS]->(:Package)-[r:DEPLOYED]->(img:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },

--- a/cartography/data/jobs/cleanup/aws_import_ecr_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_ecr_cleanup.json
@@ -1,22 +1,22 @@
 {
   "statements": [
   {
-    "query": "MATCH (n:Risk)-[:AFFECTS]->(:Package)-[:DEPLOYED]->(:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:Risk)-[:AFFECTS]->(:Package)-[:DEPLOYED]->(:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:Risk)-[r:AFFECTS]->(:Package)-[:DEPLOYED]->(:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:Risk)-[r:AFFECTS]->(:Package)-[:DEPLOYED]->(:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:Risk)-[:AFFECTS]->(n:Package)-[:DEPLOYED]->(:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:Risk)-[:AFFECTS]->(n:Package)-[:DEPLOYED]->(:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:Risk)-[:AFFECTS]->(:Package)-[r:DEPLOYED]->(img:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:Risk)-[:AFFECTS]->(:Package)-[r:DEPLOYED]->(img:ECRImage)<-[:IMAGE]-(:ECRRepositoryImage)<-[:REPO_IMAGE]-(:ECRRepository)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },


### PR DESCRIPTION
We want to scope ECR cleanup jobs to the current AWS account.