### PR TITLE
Fix #440: ConnectionResetError - consume results in ECR sync

### DIFF
--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -128,7 +128,7 @@ def load_ecr_repositories(neo4j_session, data, region, current_aws_account_id, a
             Region=region,
             aws_update_tag=aws_update_tag,
             AWS_ACCOUNT_ID=current_aws_account_id,
-        )
+        ).consume()  # See issue #440
 
 
 @timeit
@@ -169,7 +169,7 @@ def load_ecr_repository_images(neo4j_session, data, region, aws_update_tag):
                 RepositoryUri=repo_uri,
                 aws_update_tag=aws_update_tag,
                 Region=region,
-            )
+            ).consume()  # See issue #440
 
 
 @timeit
@@ -212,7 +212,7 @@ def load_ecr_image_scan_findings(neo4j_session, data, aws_update_tag):
         Risks=data['findings'],
         ImageDigest=data['imageDigest'],
         aws_update_tag=aws_update_tag,
-    )
+    ).consume()  # See issue #440
 
 
 def cleanup(neo4j_session, common_job_parameters):


### PR DESCRIPTION
Deals with ServiceUnavailable exceptions thrown from the Neo4j driver. Also see https://github.com/lyft/cartography/pull/171/.