### PR TITLE
Raise required neo4j driver from 1.7.0 to 1.7.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "boto3>=1.15.1",
         "botocore>=1.18.1",
         "dnspython>=1.15.0",
-        "neo4j>=1.7.0,<4.0.0",
+        "neo4j>=1.7.6,<4.0.0",
         "neobolt>=1.7.0,<4.0.0",
         "policyuniverse>=1.1.0.0",
         "google-api-python-client>=1.7.8",


### PR DESCRIPTION
Possibly help with #434. In any case, we're probably due for a driver update.