### PR TITLE
Fix #448, #450: Use generator when iterating over vulnerable ECR images

### DIFF
--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -77,7 +77,7 @@ def get_ecr_image_scan_findings(boto3_session, region, repository_name, reposito
                     }],
                 )
             except boto3_session.client.exceptions.ImageNotFoundException:
-                logger.warning("Image not found: %s", str(image))
+                logger.warning("Image not found: %s", str(image), exc_info=True)
                 continue
             if describe_images_resp['imageDetails'][0].get('imageScanStatus', {}).get('status', None) == "COMPLETE":
                 image_vuln = {}

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -1,5 +1,9 @@
+import json
 import logging
 from itertools import chain
+from typing import Dict
+from typing import Iterator
+from typing import List
 
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
@@ -10,11 +14,11 @@ logger = logging.getLogger(__name__)
 
 @timeit
 @aws_handle_regions
-def get_ecr_repositories(boto3_session, region):
+def get_ecr_repositories(boto3_session, region) -> List[Dict]:
     logger.info("Getting ECR repositories for region '%s'.", region)
     client = boto3_session.client('ecr', region_name=region)
     paginator = client.get_paginator('describe_repositories')
-    ecr_repositories = []
+    ecr_repositories: List[Dict] = []
     for page in paginator.paginate():
         ecr_repositories.extend(page['repositories'])
     return ecr_repositories
@@ -22,11 +26,11 @@ def get_ecr_repositories(boto3_session, region):
 
 @timeit
 @aws_handle_regions
-def get_ecr_repository_images(boto3_session, region, repository_name):
+def get_ecr_repository_images(boto3_session, region, repository_name) -> List[Dict]:
     logger.info("Getting ECR images in repository '%s' for region '%s'.", repository_name, region)
     client = boto3_session.client('ecr', region_name=region)
     paginator = client.get_paginator('list_images')
-    ecr_repository_images = []
+    ecr_repository_images: List[Dict] = []
     for page in paginator.paginate(repositoryName=repository_name):
         ecr_repository_images.extend(page['imageIds'])
     return ecr_repository_images
@@ -34,7 +38,7 @@ def get_ecr_repository_images(boto3_session, region, repository_name):
 
 @timeit
 @aws_handle_regions
-def get_ecr_image_scan_findings(boto3_session, region, repository_name, repository_images):
+def get_ecr_image_scan_findings(boto3_session, region, repository_name, repository_images) -> Iterator[Dict]:
     """
     Returned data shape = [{
         'image_tag': 'TAG',
@@ -59,7 +63,6 @@ def get_ecr_image_scan_findings(boto3_session, region, repository_name, reposito
     """
     logger.info("Getting ECR image scan findings in repository '%s' for region '%s'.", repository_name, region)
     client = boto3_session.client('ecr', region_name=region)
-    image_finding_list = []
     for image in repository_images:
         image_tag = image.get('imageTag', None)
 
@@ -87,11 +90,12 @@ def get_ecr_image_scan_findings(boto3_session, region, repository_name, reposito
                                                                           .get('imageScanCompletedAt', [])
                 image_vuln['findings_count'] = describe_image_scan_resp.get('imageScanFindings', {}) \
                                                                        .get('findingSeverityCounts', [])
-                image_finding_list.append(image_vuln)
-    return image_finding_list
+                yield image_vuln
+        else:
+            logger.warning("Image does not have tag: %s", str(json.loads(image)))
 
 
-def transform_ecr_scan_finding_attributes(vuln_data):
+def transform_ecr_scan_finding_attributes(vuln_data) -> Dict:
     """
     Transforms each finding returned from `get_ecr_image_scan_findings()` so that we flatten the  `attributes` list
     to make it easier to load to the graph.
@@ -136,7 +140,7 @@ def load_ecr_repositories(neo4j_session, data, region, current_aws_account_id, a
 
 
 @timeit
-def load_ecr_repository_images(neo4j_session, data, region, aws_update_tag):
+def load_ecr_repository_images(neo4j_session, repo_data, region, aws_update_tag):
     query = """
     MERGE (repo_image:ECRRepositoryImage{id: {RepositoryImageUri}})
     ON CREATE SET repo_image.firstseen = timestamp()
@@ -160,7 +164,7 @@ def load_ecr_repository_images(neo4j_session, data, region, aws_update_tag):
     SET r2.lastupdated = {aws_update_tag}
     """
     logger.info("Loading ECR repository images for region '%s' into graph.", region)
-    for repo_uri, repo_images in data.items():
+    for repo_uri, repo_images in repo_data.items():
         for repo_image in repo_images:
             image_tag = repo_image.get('imageTag', '')
             # TODO this assumes image tags and uris are immutable
@@ -229,13 +233,11 @@ def cleanup(neo4j_session, common_job_parameters):
 def sync(neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag, common_job_parameters):
     for region in regions:
         logger.info("Syncing ECR for region '%s' in account '%s'.", region, current_aws_account_id)
-        repository_data = get_ecr_repositories(boto3_session, region)
-
         image_data = {}
         images_with_vulns = iter(())
-        for repo in repository_data:
+        repositories = get_ecr_repositories(boto3_session, region)
+        for repo in repositories:
             repo_image_obj = get_ecr_repository_images(boto3_session, region, repo['repositoryName'])
-
             image_data[repo['repositoryUri']] = repo_image_obj
             image_vulns = get_ecr_image_scan_findings(
                 boto3_session, region, repo['repositoryName'], repo_image_obj,
@@ -246,7 +248,7 @@ def sync(neo4j_session, boto3_session, regions, current_aws_account_id, aws_upda
             ) if image_vulns else iter(())
             images_with_vulns = chain(images_with_vulns, transformed_attrs)
 
-        load_ecr_repositories(neo4j_session, repository_data, region, current_aws_account_id, aws_update_tag)
+        load_ecr_repositories(neo4j_session, repositories, region, current_aws_account_id, aws_update_tag)
         load_ecr_repository_images(neo4j_session, image_data, region, aws_update_tag)
         for image_vuln_data in images_with_vulns:
             load_ecr_image_scan_findings(neo4j_session, image_vuln_data, aws_update_tag)

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -97,8 +97,7 @@ def transform_ecr_scan_finding_attributes(vuln_data):
     to make it easier to load to the graph.
     """
     logger.info("Transforming ECR image scan findings.")
-    working_copy = vuln_data.copy()
-    for finding in working_copy.get('findings', []):
+    for finding in vuln_data.get('findings', []):
         for attrib in finding.get('attributes'):
             if attrib['key'] == 'package_version':
                 finding['package_version'] = attrib['value']
@@ -106,7 +105,7 @@ def transform_ecr_scan_finding_attributes(vuln_data):
                 finding['package_name'] = attrib['value']
             elif attrib['key'] == 'CVSS2_SCORE':
                 finding['CVSS2_SCORE'] = attrib['value']
-    return working_copy
+    return vuln_data
 
 
 @timeit

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from itertools import chain
 from typing import Dict
@@ -78,7 +77,7 @@ def get_ecr_image_scan_findings(boto3_session, region, repository_name, reposito
                     }],
                 )
             except boto3_session.client.exceptions.ImageNotFoundException:
-                logger.warning("Image not found: %s", str(json.loads(image)))
+                logger.warning("Image not found: %s", str(image))
                 continue
             if describe_images_resp['imageDetails'][0].get('imageScanStatus', {}).get('status', None) == "COMPLETE":
                 image_vuln = {}
@@ -86,7 +85,7 @@ def get_ecr_image_scan_findings(boto3_session, region, repository_name, reposito
                 if 'imageDigest' in image:
                     image_vuln['imageDigest'] = image['imageDigest']
                 else:
-                    logger.warning("Image does not have 'imageDigest': %s", str(json.loads(image)))
+                    logger.warning("Image does not have 'imageDigest': %s", str(image))
                     continue
                 describe_image_scan_resp = client.describe_image_scan_findings(
                     repositoryName=repository_name,
@@ -102,7 +101,7 @@ def get_ecr_image_scan_findings(boto3_session, region, repository_name, reposito
                                                                        .get('findingSeverityCounts', [])
                 yield image_vuln
         else:
-            logger.warning("Image does not have tag: %s", str(json.loads(image)))
+            logger.warning("Image does not have tag: %s", str(image))
             continue
 
 

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -83,6 +83,11 @@ def get_ecr_image_scan_findings(boto3_session, region, repository_name, reposito
             if describe_images_resp['imageDetails'][0].get('imageScanStatus', {}).get('status', None) == "COMPLETE":
                 image_vuln = {}
                 image_vuln['image_tag'] = image_tag
+                if 'imageDigest' in image:
+                    image_vuln['imageDigest'] = image['imageDigest']
+                else:
+                    logger.warning("Image does not have 'imageDigest': %s", str(json.loads(image)))
+                    continue
                 describe_image_scan_resp = client.describe_image_scan_findings(
                     repositoryName=repository_name,
                     imageId={


### PR DESCRIPTION
Creating the entire list of scan findings from all images in a region could become prohibitively memory-intensive for large organizations. This change swaps the `images_with_vulns` list with a generator to mitigate this issue.