### PR TITLE
Incorrect path to ImageNotFound exception fixed

### DIFF
--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -76,7 +76,7 @@ def get_ecr_image_scan_findings(boto3_session, region, repository_name, reposito
                         'imageTag': image_tag,
                     }],
                 )
-            except boto3_session.client.exceptions.ImageNotFoundException:
+            except client.exceptions.ImageNotFoundException:
                 logger.warning("Image not found: %s", str(image), exc_info=True)
                 continue
             if describe_images_resp['imageDetails'][0].get('imageScanStatus', {}).get('status', None) == "COMPLETE":


### PR DESCRIPTION
Quickly fixed this typo on the except line which was trying to access the exception through the boto session. As we already have reference to the client we can instead access more simply.
This matches other cases in cartography as well on how they import Exceptions.