### PR TITLE
Temporary fix for #460 - TravisCI issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,6 @@ deploy:
     tags: true
     distributions: sdist bdist_wheel
     repo: lyft/cartography
+  edge:
+    source: 'native/api/dpl'
+    branch: 'pip_fix_upgrade_deps'

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ deploy:
     distributions: sdist bdist_wheel
     repo: lyft/cartography
   edge:
-    source: 'native/api/dpl'
+    source: 'native-api/dpl'
     branch: 'pip_fix_upgrade_deps'


### PR DESCRIPTION
See #460 and https://travis-ci.community/t/cant-deploy-to-pypi-anymore-pkg-resources-contextualversionconflict-importlib-metadata-0-18/10494/10. We will need to undo this when Travis pushes a release with this fix.