### PR TITLE
Revert "Temporary fix for #460 - TravisCI issue"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,3 @@ deploy:
     tags: true
     distributions: sdist bdist_wheel
     repo: lyft/cartography
-  edge:
-    source: 'native-api/dpl'
-    branch: 'pip_fix_upgrade_deps'


### PR DESCRIPTION
Reverts lyft/cartography#461: Looks like https://github.com/travis-ci/dpl/pull/1221 and https://github.com/travis-ci/dpl/pull/1208 have now been merged so I should be able to revert this.