### PR TITLE
Speed up AWS ECR repo images sync with UNWIND

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,3 @@ deploy:
     tags: true
     distributions: sdist bdist_wheel
     repo: lyft/cartography
-  edge:
-    source: 'native-api/dpl'
-    branch: 'pip_fix_upgrade_deps'

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -72,7 +72,11 @@ def transform_ecr_repository_images(repo_data):
             if 'imageDigest' in img and img['imageDigest']:
                 filtered_imgs.append(img)
             else:
-                logger.warning("Repo %s has an image that has no imageDigest; skipping.", repo_uri)
+                logger.warning(
+                    "Repo %s has an image that has no imageDigest. Its tag is %s. Continuing on.",
+                    repo_uri,
+                    img.get('imageTag'),
+                )
 
         repo_images_list.append({
             'repo_uri': repo_uri,

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -63,44 +63,47 @@ def load_ecr_repositories(neo4j_session, data, region, current_aws_account_id, a
 @timeit
 def load_ecr_repository_images(neo4j_session, repo_data, region, aws_update_tag):
     query = """
-    MERGE (repo_image:ECRRepositoryImage{id: {RepositoryImageUri}})
-    ON CREATE SET repo_image.firstseen = timestamp()
-    SET repo_image.lastupdated = {aws_update_tag}, repo_image.tag = {ImageTag},
-        repo_image.uri = {RepositoryImageUri}
-    WITH repo_image
+    UNWIND {RepoList} as repo_item
+        UNWIND repo_item.repo_images as repo_img
+            MERGE (ri:ECRRepositoryImage{id: repo_item.repo_uri + ":" + repo_img.imageTag})
+            ON CREATE SET ri.firstseen = timestamp()
+            SET ri.lastupdated = {aws_update_tag},
+            ri.tag = repo_img.imageTag,
+            ri.uri = repo_item.repo_uri + ":" + repo_img.imageTag
+            WITH ri, repo_img, repo_item
 
-    MERGE (image:ECRImage{id: {ImageDigest}})
-    ON CREATE SET image.firstseen = timestamp(), image.digest = {ImageDigest}
-    SET image.lastupdated = {aws_update_tag},
-    image.region = {Region}
-    WITH repo_image, image
-    MERGE (repo_image)-[r1:IMAGE]->(image)
-    ON CREATE SET r1.firstseen = timestamp()
-    SET r1.lastupdated = {aws_update_tag}
-    WITH repo_image
+            MERGE (img:ECRImage{id: repo_img.imageDigest})
+            ON CREATE SET img.firstseen = timestamp(),
+            img.digest = repo_img.imageDigest
+            SET img.lastupdated = {aws_update_tag},
+            img.region = {Region}
+            WITH ri, img, repo_img, repo_item
 
-    MATCH (repo:ECRRepository{uri: {RepositoryUri}})
-    MERGE (repo)-[r2:REPO_IMAGE]->(repo_image)
-    ON CREATE SET r2.firstseen = timestamp()
-    SET r2.lastupdated = {aws_update_tag}
+            MERGE (ri)-[r1:IMAGE]->(img)
+            ON CREATE SET r1.firstseen = timestamp()
+            SET r1.lastupdated = {aws_update_tag}
+            WITH ri, repo_img, repo_item
+
+            MATCH (repo:ECRRepository{uri: repo_item.repo_uri})
+            MERGE (repo)-[r2:REPO_IMAGE]->(ri)
+            ON CREATE SET r2.firstseen = timestamp()
+            SET r2.lastupdated = {aws_update_tag}
     """
     logger.debug("Loading ECR repository images for region '%s' into graph.", region)
-    for repo_uri, repo_images in repo_data.items():
-        for repo_image in repo_images:
-            image_tag = repo_image.get('imageTag', '')
-            # TODO this assumes image tags and uris are immutable
-            repo_image_uri = f"{repo_uri}:{image_tag}" if image_tag else repo_uri
-            neo4j_session.run(
-                query,
-                RepositoryImageUri=repo_image_uri,
-                ImageDigest=repo_image['imageDigest'],
-                ImageTag=image_tag,
-                RepositoryUri=repo_uri,
-                aws_update_tag=aws_update_tag,
-                Region=region,
-            ).consume()  # See issue #440
+    repo_images_list = [
+        {
+            'repo_uri': repo_uri, 'repo_images': repo_images,
+        } for repo_uri, repo_images in repo_data.items()
+    ]
+    neo4j_session.run(
+        query,
+        RepoList=repo_images_list,
+        aws_update_tag=aws_update_tag,
+        Region=region,
+    ).consume()  # See issue #440
 
 
+@timeit
 def cleanup(neo4j_session, common_job_parameters):
     logger.debug("Running ECR cleanup job.")
     run_cleanup_job('aws_import_ecr_cleanup.json', neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -67,7 +67,13 @@ def transform_ecr_repository_images(repo_data):
     """
     repo_images_list = []
     for repo_uri, repo_images in repo_data.items():
-        filtered_imgs = [img for img in repo_images if 'imageDigest' in img and img['imageDigest']]
+        filtered_imgs = []
+        for img in repo_images:
+            if 'imageDigest' in img and img['imageDigest']:
+                filtered_imgs.append(img)
+            else:
+                logger.warning("Repo %s tried to ingest an image that has no imageDigest; skipping.", repo_uri)
+
         repo_images_list.append({
             'repo_uri': repo_uri,
             'repo_images': filtered_imgs,
@@ -89,7 +95,7 @@ def load_ecr_repository_images(neo4j_session, repo_images_list, region, aws_upda
 
             MERGE (img:ECRImage{id: repo_img.imageDigest})
             ON CREATE SET img.firstseen = timestamp(),
-            img.digest = repo_img.imageDigest
+                img.digest = repo_img.imageDigest
             SET img.lastupdated = {aws_update_tag},
                 img.region = {Region}
             WITH ri, img, repo_item

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -72,7 +72,7 @@ def transform_ecr_repository_images(repo_data):
             if 'imageDigest' in img and img['imageDigest']:
                 filtered_imgs.append(img)
             else:
-                logger.warning("Repo %s tried to ingest an image that has no imageDigest; skipping.", repo_uri)
+                logger.warning("Repo %s has an image that has no imageDigest; skipping.", repo_uri)
 
         repo_images_list.append({
             'repo_uri': repo_uri,

--- a/tests/data/aws/ecr.py
+++ b/tests/data/aws/ecr.py
@@ -60,5 +60,13 @@ LIST_REPOSITORY_IMAGES = {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000021',
             'imageTag': '1',
         },
+        # Item without an imageDigest: will get filtered out and not ingested.
+        {
+            'imageTag': '1',
+        },
+        # Item without an imageTag
+        {
+            'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000031',
+        },
     ],
 }

--- a/tests/integration/cartography/intel/aws/test_ecr.py
+++ b/tests/integration/cartography/intel/aws/test_ecr.py
@@ -17,18 +17,6 @@ def _ensure_local_neo4j_has_test_ecr_repo_data(neo4j_session):
     )
 
 
-def _ensure_local_neo4j_has_test_repo_and_image_data(neo4j_session):
-    _ensure_local_neo4j_has_test_ecr_repo_data(neo4j_session)
-
-    data = tests.data.aws.ecr.LIST_REPOSITORY_IMAGES
-    cartography.intel.aws.ecr.load_ecr_repository_images(
-        neo4j_session,
-        data,
-        TEST_REGION,
-        TEST_UPDATE_TAG,
-    )
-
-
 def test_load_ecr_repositories(neo4j_session):
     _ensure_local_neo4j_has_test_ecr_repo_data(neo4j_session)
 
@@ -54,9 +42,10 @@ def test_load_ecr_repository_images(neo4j_session):
     _ensure_local_neo4j_has_test_ecr_repo_data(neo4j_session)
 
     data = tests.data.aws.ecr.LIST_REPOSITORY_IMAGES
+    repo_images_list = cartography.intel.aws.ecr.transform_ecr_repository_images(data)
     cartography.intel.aws.ecr.load_ecr_repository_images(
         neo4j_session,
-        data,
+        repo_images_list,
         TEST_REGION,
         TEST_UPDATE_TAG,
     )
@@ -92,9 +81,10 @@ def test_load_ecr_images(neo4j_session):
     _ensure_local_neo4j_has_test_ecr_repo_data(neo4j_session)
 
     data = tests.data.aws.ecr.LIST_REPOSITORY_IMAGES
+    repo_images_list = cartography.intel.aws.ecr.transform_ecr_repository_images(data)
     cartography.intel.aws.ecr.load_ecr_repository_images(
         neo4j_session,
-        data,
+        repo_images_list,
         TEST_REGION,
         TEST_UPDATE_TAG,
     )


### PR DESCRIPTION
This batches up the write operations in one go rather than calling `neo4j_session.run()` potentially thousands of times.