### PR TITLE
Fix #447: GCP: Only query for active projects

### DIFF
--- a/cartography/intel/gcp/crm.py
+++ b/cartography/intel/gcp/crm.py
@@ -58,7 +58,7 @@ def get_gcp_projects(crm_v1):
     """
     try:
         projects = []
-        req = crm_v1.projects().list()
+        req = crm_v1.projects().list(filter="lifecycleState:ACTIVE")
         while req is not None:
             res = req.execute()
             page = res.get('projects', [])


### PR DESCRIPTION
This reduces ingestion processing time by skipping projects that have been marked for deletion and are no longer active.

Project filter parameters docs: https://cloud.google.com/resource-manager/reference/rest/v1/projects/list#query-parameters
`lifecycleState` enum options: https://cloud.google.com/resource-manager/reference/rest/v1/projects#lifecyclestate

Fixes #447