### PR TITLE
Handle NoSuchBucket and AllAccessDisabled in AWS S3 get_bucket_location()

### DIFF
--- a/cartography/intel/aws/s3.py
+++ b/cartography/intel/aws/s3.py
@@ -26,6 +26,12 @@ def get_s3_bucket_list(boto3_session):
                 logger.warning("get_bucket_location(bucket='{}') AccessDenied, skipping.".format(bucket['Name']))
                 bucket['Region'] = None
                 continue
+            elif "NoSuchBucket" in e.args[0]:
+                logger.warning("get_bucket_location({}) threw NoSuchBucket exception, skipping".format(bucket['Name']))
+                bucket['Region'] = None
+                continue
+            elif "AllAccessDisabled" in e.args[0]:
+                logger.warning("get_bucket_location({}) failed - bucket is disabled, skipping".format(bucket['Name']))
             else:
                 raise
     return buckets


### PR DESCRIPTION
Had another crash last night when `get_bucket_location()` was called for a bucket that no longer exists (I guess our environment changes very frequently). This PR is a bandaid to handle that and other errors that we've seen in this module.

I would use a more clever way to be less repetitive with the exception handling, but all the ways I tried ended up making the code difficult to read.