### PR TITLE
#503 aws-keep-unseen-accounts

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -114,6 +114,14 @@ class CLI:
             ),
         )
         parser.add_argument(
+            '--aws-keep-unseen-accounts',
+            action='store_true',
+            help=(
+                'Keep AWS account data in the database which are not synced in the actual run. This is useful if you'
+                'want to run the sync job in parallel for multiple AWS accounts.'
+            ),
+        )
+        parser.add_argument(
             '--crxcavator-api-base-uri',
             type=str,
             default='https://api.crxcavator.io/v1',

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -17,6 +17,9 @@ class Config:
     :type aws_sync_all_profiles: bool
     :param aws_sync_all_profiles: If True, AWS sync will run for all non-default profiles in the AWS_CONFIG_FILE. If
         False (default), AWS sync will run using the default credentials only. Optional.
+    :type aws_keep_unseen_accounts: bool
+    :param aws_keep_unseen_accounts: If True, AWS account cleanup job won't be executed. If False (default), AWS
+        accounts will be cleaned up after sync. Optional.
     :type crxcavator_api_base_uri: str
     :param crxcavator_api_base_uri: URI for CRXcavator API. Optional.
     :type crxcavator_api_key: str
@@ -54,6 +57,7 @@ class Config:
         neo4j_password=None,
         update_tag=None,
         aws_sync_all_profiles=False,
+        aws_keep_unseen_accounts=False,
         analysis_job_directory=None,
         crxcavator_api_base_uri=None,
         crxcavator_api_key=None,
@@ -75,6 +79,7 @@ class Config:
         self.neo4j_password = neo4j_password
         self.update_tag = update_tag
         self.aws_sync_all_profiles = aws_sync_all_profiles
+        self.aws_keep_unseen_accounts = aws_keep_unseen_accounts
         self.analysis_job_directory = analysis_job_directory
         self.crxcavator_api_base_uri = crxcavator_api_base_uri
         self.crxcavator_api_key = crxcavator_api_key

--- a/cartography/data/jobs/cleanup/aws_account_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_account_cleanup.json
@@ -3,7 +3,8 @@
     {
       "query": "MATCH (n:AWSAccount) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
       "iterative": true,
-      "iterationsize": 100
+      "iterationsize": 100,
+      "skip_on_keep_unseen_accounts": true
   }],
   "name": "cleanup AWS Accounts"
 }

--- a/cartography/data/jobs/cleanup/aws_dns_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_dns_cleanup.json
@@ -6,7 +6,7 @@
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:NameServer) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:NameServer)-[:NAMESERVER]->(:DNSZone)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
       "iterative": true,
       "iterationsize": 100
     },
@@ -40,7 +40,7 @@
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSDNSZone)<-[r:SUBZONE]-(:AWSDNSZone) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSDNSZone)<-[r:SUBZONE]-(:AWSDNSZone)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_account_access_key_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_account_access_key_cleanup.json
@@ -2,7 +2,8 @@
   "statements": [{
     "query": "MATCH (n:AccountAccessKey)<-[:AWS_ACCESS_KEY]-(:AWSUser)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
-    "iterationsize": 100
+    "iterationsize": 100,
+    "skip_on_keep_unseen_accounts": true
   }],
   "name": "cleanup AccountAccessKey"
 }

--- a/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
@@ -1,52 +1,52 @@
 {
     "statements": [
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Instance) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:NetworkInterface) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:NetworkInterface)-[:PART_OF_SUBNET]->(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:NetworkInterface)-[:PART_OF_SUBNET]->(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2SecurityGroup) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Subnet) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:AWSVpc) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:AWSVpc) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
@@ -56,47 +56,47 @@
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:ESDomain) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:ESDomain)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RedshiftCluster) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RedshiftCluster) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RDSInstance) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RDSInstance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:DBSubnetGroup) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:DBSubnetGroup)-[:RESOURCE]->(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:DBSubnetGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:DBSubnetGroup)-[:RESOURCE]->(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:S3Bucket) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:S3Bucket) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         }

--- a/cartography/data/jobs/cleanup/aws_import_tgw_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tgw_cleanup.json
@@ -1,22 +1,42 @@
 {
   "statements": [
   {
-    "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-() WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DETACH DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DETACH DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:RESOURCE|ATTACHED_TO]-() WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-() WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:RESOURCE|ATTACHED_TO]-() WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  },
+  {
+    "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  },
+  {
+    "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  },
+  {
+    "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:ATTACHED_TO]->(:AWSTransitGateway)-[:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  },
+  {
+    "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:ATTACHED_TO]->(:AWSTransitGateway)-[:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_vpc_peering_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_vpc_peering_cleanup.json
@@ -1,33 +1,57 @@
 {
-  "statements": [{
-    "query": "MATCH (n:AWSCidrBlock)<-[:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+  "statements": [ {
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:ACCEPTER_VPC]-(n:PeeringConnection) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
+  },
+  {
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:REQUESTER_VPC]-(n:PeeringConnection) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  },
+  {
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSVpc) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+    },
+  {
+    "query": "MATCH (n:AWSCidrBlock)<-[:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100,
+    "skip_on_keep_unseen_accounts": true
   },
   {
     "query": "MATCH (:AWSCidrBlock)<-[r:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
-    "iterationsize": 100
+    "iterationsize": 100,
+    "skip_on_keep_unseen_accounts": true
   },
   {
     "query": "MATCH (n:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
-    "iterationsize": 100
+    "iterationsize": 100,
+    "skip_on_keep_unseen_accounts": true
   },
   {
     "query": "MATCH (:AWSVpc)<-[r:RESOURCE]-(:AWSAccount{foreign: true}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
-    "iterationsize": 100
+    "iterationsize": 100,
+    "skip_on_keep_unseen_accounts": true
   },
   {
     "query": "MATCH (:AWSVpc)-[r:VPC_PEERING]-(:AWSVpc) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
     "iterative": true,
-    "iterationsize": 100
+    "iterationsize": 100,
+    "skip_on_keep_unseen_accounts": true
+
   },
   {
     "query": "MATCH (n:AWSAccount{foreign: true}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
-    "iterationsize": 100
-  }],
-  "name": "cleanup AWS VPC information"
+    "iterationsize": 100,
+    "skip_on_keep_unseen_accounts": true
+  }
+
+],
+  "name": "cleanup AWS VPC peering information"
 }

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -91,7 +91,15 @@ def _sync_multiple_accounts(neo4j_session, accounts, sync_tag, common_job_parame
     for profile_name, account_id in accounts.items():
         logger.info("Syncing AWS account with ID '%s' using configured profile '%s'.", account_id, profile_name)
         common_job_parameters["AWS_ID"] = account_id
-        boto3_session = boto3.Session(profile_name=profile_name)
+
+        boto3_session = None
+        try:
+            boto3_session = boto3.Session(profile_name=profile_name)
+        except botocore.exceptions.ProfileNotFound:
+            logger.info("profile error '%s', trying to intitialize session without explicit profile.", profile_name)
+
+        if not boto3_session:
+            boto3_session = boto3.Session()
 
         _autodiscover_accounts(neo4j_session, boto3_session, account_id, sync_tag, common_job_parameters)
 
@@ -99,13 +107,20 @@ def _sync_multiple_accounts(neo4j_session, accounts, sync_tag, common_job_parame
 
     del common_job_parameters["AWS_ID"]
 
-    # There may be orphan Principals which point outside of known AWS accounts. This job cleans
-    # up those nodes after all AWS accounts have been synced.
-    run_cleanup_job('aws_post_ingestion_principals_cleanup.json', neo4j_session, common_job_parameters)
+    # jobs below can only be run if all accounts have been synced
+    # (we cannot decide if we face orphans or resoures for unsynced acccounts)
 
-    # There may be orphan DNS entries that point outside of known AWS zones. This job cleans
-    # up those entries after all AWS accounts have been synced.
-    run_cleanup_job('aws_post_ingestion_dns_cleanup.json', neo4j_session, common_job_parameters)
+    if common_job_parameters['aws_sync_all_profiles']:
+
+        # There may be orphan Principals which point outside of known AWS accounts. This job cleans
+        # up those nodes after all AWS accounts have been synced.
+
+        run_cleanup_job('aws_post_ingestion_principals_cleanup.json', neo4j_session, common_job_parameters)
+
+        # There may be orphan DNS entries that point outside of known AWS zones. This job cleans
+        # up those entries after all AWS accounts have been synced.
+
+        run_cleanup_job('aws_post_ingestion_dns_cleanup.json', neo4j_session, common_job_parameters)
 
 
 @timeit
@@ -113,6 +128,8 @@ def start_aws_ingestion(neo4j_session, config):
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,
         "permission_relationships_file": config.permission_relationships_file,
+        "aws_keep_unseen_accounts": config.aws_keep_unseen_accounts,
+        "aws_sync_all_profiles": config.aws_sync_all_profiles,
     }
     try:
         boto3_session = boto3.Session()

--- a/cartography/intel/aws/ec2/tgw.py
+++ b/cartography/intel/aws/ec2/tgw.py
@@ -79,7 +79,6 @@ def load_transit_gateways(neo4j_session, data, region, current_aws_account_id, a
     tgw.region = {Region},
     tgw.lastupdated = {aws_update_tag}
 
-    WITH tgw
     MERGE (ownerAccount)-[r:RESOURCE]->(tgw)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = {aws_update_tag}

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import sys
 
@@ -25,14 +26,49 @@ def run_analysis_job(filename, neo4j_session, common_job_parameters):
 
 
 def run_cleanup_job(filename, neo4j_session, common_job_parameters):
+
+    job_text = read_text(
+        'cartography.data.jobs.cleanup',
+        filename,
+    )
+    job = json.loads(job_text)
+
+    new_job = {
+        'name': job.get('name', 'Neo4j job'),
+        'statements': [],
+    }
+
+    for statement in job['statements']:
+        logger.debug('Running cleanup job {}'.format(statement['query']))
+
+        logger.debug(
+            'skip_on_keep_unseen_accounts',
+            ' {}'.format(statement.get('skip_on_keep_unseen_accounts', False)),
+            'common_job_parameters.aws_keep_unseen_accounts',
+            ' {}'.format(common_job_parameters.get('aws_keep_unseen_accounts', False)),
+        )
+
+        if statement.get('skip_on_keep_unseen_accounts', False) and \
+                common_job_parameters.get('aws_keep_unseen_accounts', False):
+            logger.debug('Skipping...')
+            continue
+
+        new_job['statements'].append(statement)
+
     GraphJob.run_from_json(
         neo4j_session,
-        read_text(
-            'cartography.data.jobs.cleanup',
-            filename,
-        ),
+        json.dumps(new_job),
         common_job_parameters,
     )
+
+    if logger.level == logging.DEBUG:
+        results = neo4j_session.run('match (n:AWSAccount) return count(n) as c')
+        for record in results:
+            logger.debug('AWS account count {}'.format(record['c']))
+
+        results = neo4j_session.run('match (n) return count(n) as c')
+        for record in results:
+            logger.debug('Total count {}'.format(record['c']))
 
 
 def load_resource_binary(package, resource_name):


### PR DESCRIPTION
This PR implements the `--aws-keep-unseen-accounts` cli parameter and fixes the issues encountered during syncing several accounts independently to the same Neo4j database. (Bug report/feature request #503)