### PR TITLE
Fix #434 - Add EC2PrivateIp index, perf improvements to netinf sync

### DIFF
--- a/cartography/data/indexes.cypher
+++ b/cartography/data/indexes.cypher
@@ -33,6 +33,7 @@ CREATE INDEX ON :EC2Instance(id);
 CREATE INDEX ON :EC2Instance(instanceid);
 CREATE INDEX ON :EC2Instance(publicdnsname);
 CREATE INDEX ON :EC2KeyPair(id);
+CREATE INDEX ON :EC2PrivateIp(id);
 CREATE INDEX ON :EC2Reservation(reservationid);
 CREATE INDEX ON :EC2SecurityGroup(groupid);
 CREATE INDEX ON :EC2SecurityGroup(id);

--- a/cartography/data/jobs/cleanup/aws_ingest_network_interfaces_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_network_interfaces_cleanup.json
@@ -29,6 +29,16 @@
       "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:PART_OF_SUBNET]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
       "iterationsize": 100,
       "iterative": true
+    },
+    {
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:NetworkInterface) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[r:RESOURCE]->(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
     }
   ],
   "name": "cleanup NetworkInterface"

--- a/cartography/data/jobs/cleanup/aws_ingest_network_interfaces_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_network_interfaces_cleanup.json
@@ -19,6 +19,16 @@
       "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:MEMBER_OF_AWS_VPC]-(:EC2Subnet)<-[r:PART_OF_SUBNET]-(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
       "iterationsize": 100,
       "iterative": true
+    },
+    {
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:PART_OF_SUBNET]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterationsize": 100,
+      "iterative": true
+    },
+    {
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:PART_OF_SUBNET]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterationsize": 100,
+      "iterative": true
     }
   ],
   "name": "cleanup NetworkInterface"

--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -22,7 +22,192 @@ def get_network_interface_data(boto3_session, region):
 
 @timeit
 def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_update_tag):
+    ingest_network_interfaces = """
+    UNWIND {network_interfaces} AS network_interface
+        MERGE (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId})
+        ON CREATE SET netinf.firstseen = timestamp()
+        SET netinf.lastupdated = {aws_update_tag},
+            netinf.mac_address = network_interface.MacAddress,
+            netinf.description = network_interface.Description,
+            netinf.private_ip_address = network_interface.PrivateIpAddress,
+            netinf.id = network_interface.NetworkInterfaceId,
+            netinf.private_dns_name = network_interface.PrivateDnsName,
+            netinf.status = network_interface.Status,
+            netinf.subnetid = network_interface.SubnetId,
+            netinf.interface_type = network_interface.InterfaceType,
+            netinf.requester_managed = network_interface.RequesterManaged,
+            netinf.source_dest_check = network_interface.SourceDestCheck,
+            netinf.requester_id = network_interface.RequesterId,
+            netinf.public_ip = network_interface.Association.PublicIp
+    """
+    neo4j_session.run(
+        ingest_network_interfaces, network_interfaces=data, aws_update_tag=aws_update_tag,
+        region=region, aws_account_id=aws_account_id,
+    )
 
+
+@timeit
+def load_network_interface_security_group_relations(
+    neo4j_session, data, region, aws_account_id, aws_update_tag,
+):
+    ingest_network_interface_security_group_relations = """
+    UNWIND {network_interfaces} AS network_interface
+        UNWIND network_interface.Groups AS security_group
+            MATCH (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId}),
+                (sg:EC2SecurityGroup{id: security_group.GroupId})
+            MERGE (netinf)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(sg)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.lastupdated = {aws_update_tag}
+    """
+    neo4j_session.run(
+        ingest_network_interface_security_group_relations, network_interfaces=data, aws_update_tag=aws_update_tag,
+        region=region, aws_account_id=aws_account_id,
+    )
+
+
+@timeit
+def load_network_interface_subnet_relations(neo4j_session, data, region, aws_account_id, aws_update_tag):
+    ingest_network_interface_subnet_relations = """
+    UNWIND {network_interfaces} AS network_interface
+        MATCH (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId}),
+            (snet:EC2Subnet{subnetid: network_interface.SubnetId})
+        MERGE (netinf)-[r:PART_OF_SUBNET]->(snet)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
+    """
+    neo4j_session.run(
+        ingest_network_interface_subnet_relations, network_interfaces=data, aws_update_tag=aws_update_tag,
+        region=region, aws_account_id=aws_account_id,
+    )
+
+
+@timeit
+def load_network_interface_instance_relations(
+    neo4j_session, instance_associations, region, aws_account_id, aws_update_tag,
+):
+    ingest_network_interface_instance_relations = """
+    UNWIND {instance_associations} AS instance_association
+        MATCH (netinf:NetworkInterface{id: instance_association.netinf_id}),
+            (instance:EC2Instance{id: instance_association.instance_id})
+        MERGE (instance)-[r:NETWORK_INTERFACE]->(netinf)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
+    """
+    neo4j_session.run(
+        ingest_network_interface_instance_relations, instance_associations=instance_associations,
+        aws_update_tag=aws_update_tag, region=region, aws_account_id=aws_account_id,
+    )
+
+
+@timeit
+def load_network_interface_elb_relations(neo4j_session, elb_associations, region, aws_account_id, aws_update_tag):
+    ingest_network_interface_elb_relations = """
+    UNWIND {elb_associations} AS elb_association
+        MATCH (netinf:NetworkInterface{id: elb_association.netinf_id}),
+            (elb:LoadBalancer{name: elb_association.elb_name})
+        MERGE (elb)-[r:NETWORK_INTERFACE]->(netinf)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
+    """
+    neo4j_session.run(
+        ingest_network_interface_elb_relations, elb_associations=elb_associations,
+        aws_update_tag=aws_update_tag, region=region, aws_account_id=aws_account_id,
+    )
+
+
+@timeit
+def load_network_interface_elbv2_relations(neo4j_session, elb_associations_v2, region, aws_account_id, aws_update_tag):
+    ingest_network_interface_elb2_relations = """
+    UNWIND {elb_associations} AS elb_association
+        MATCH (netinf:NetworkInterface{id: elb_association.netinf_id}),
+            (elb:LoadBalancerV2{id: elb_association.elb_id})
+        MERGE (elb)-[r:NETWORK_INTERFACE]->(netinf)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
+    """
+    neo4j_session.run(
+        ingest_network_interface_elb2_relations, elb_associations=elb_associations_v2,
+        aws_update_tag=aws_update_tag, region=region, aws_account_id=aws_account_id,
+    )
+
+
+@timeit
+def load_private_ip_addresses(neo4j_session, data, region, aws_account_id, aws_update_tag):
+    ingest_private_ip_addresses = """
+    UNWIND {network_interfaces} AS network_interface
+        UNWIND network_interface.PrivateIpAddresses AS private_ip_address
+            MERGE (private_ip:EC2PrivateIp{id: network_interface.NetworkInterfaceId + ':'
+                + private_ip_address.PrivateIpAddress})
+            ON CREATE SET private_ip.firstseen = timestamp()
+            SET private_ip.lastupdated = {aws_update_tag},
+                private_ip.network_interface_id = network_interface.NetworkInterfaceId,
+                private_ip.primary = private_ip_address.Primary,
+                private_ip.private_ip_address = private_ip_address.PrivateIpAddress,
+                private_ip.public_ip = private_ip_address.Association.PublicIp,
+                private_ip.ip_owner_id = private_ip_address.Association.IpOwnerId
+    """
+    neo4j_session.run(
+        ingest_private_ip_addresses, network_interfaces=data, aws_update_tag=aws_update_tag,
+        region=region, aws_account_id=aws_account_id,
+    )
+
+    ingest_private_ip_addresses_network_interface_relations = """
+    UNWIND {network_interfaces} AS network_interface
+        UNWIND network_interface.PrivateIpAddresses AS private_ip_address
+            MATCH (private_ip:EC2PrivateIp{id: network_interface.NetworkInterfaceId + ':'
+                + private_ip_address.PrivateIpAddress}),
+                (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId})
+            MERGE (netinf)-[r:PRIVATE_IP_ADDRESS]->(private_ip)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.lastupdated = {aws_update_tag}
+    """
+    neo4j_session.run(
+        ingest_private_ip_addresses_network_interface_relations, network_interfaces=data,
+        aws_update_tag=aws_update_tag, region=region, aws_account_id=aws_account_id,
+    )
+
+
+@timeit
+def load_network_interface_instance_to_subnet_relations(neo4j_session, aws_update_tag):
+    ingest_network_interface_instance_relations = """
+    MATCH (i:EC2Instance)-[:NETWORK_INTERFACE]-(interface:NetworkInterface)-[:PART_OF_SUBNET]-(s:EC2Subnet)
+    MERGE (i)-[r:PART_OF_SUBNET]->(s)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = {aws_update_tag}
+    """
+    neo4j_session.run(
+        ingest_network_interface_instance_relations, aws_update_tag=aws_update_tag,
+    )
+
+
+@timeit
+def load_network_interface_load_balancer_relations(neo4j_session, aws_update_tag):
+    ingest_network_interface_loadbalancer_relations = """
+    MATCH (i:LoadBalancer)-[:NETWORK_INTERFACE]-(interface:NetworkInterface)-[:PART_OF_SUBNET]-(s:EC2Subnet)
+    MERGE (i)-[r:PART_OF_SUBNET]->(s)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = {aws_update_tag}
+    """
+    neo4j_session.run(
+        ingest_network_interface_loadbalancer_relations, aws_update_tag=aws_update_tag,
+    )
+
+
+@timeit
+def load_network_interface_load_balancer_v2_relations(neo4j_session, aws_update_tag):
+    ingest_network_interface_loadbalancerv2_relations = """
+    MATCH (i:LoadBalancerV2)-[:NETWORK_INTERFACE]-(interface:NetworkInterface)-[:PART_OF_SUBNET]-(s:EC2Subnet)
+    MERGE (i)-[r:PART_OF_SUBNET]->(s)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = {aws_update_tag}
+    """
+    neo4j_session.run(
+        ingest_network_interface_loadbalancerv2_relations, aws_update_tag=aws_update_tag,
+    )
+
+
+@timeit
+def load(neo4j_session, data, region, aws_account_id, aws_update_tag):
     elb_associations = []
     elb_associations_v2 = []
     instance_associations = []
@@ -49,168 +234,17 @@ def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_upd
                 'instance_id': network_interface['Attachment']['InstanceId'],
             })
 
-    ingest_network_interfaces = """
-    UNWIND {network_interfaces} AS network_interface
-        MERGE (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId})
-        ON CREATE SET netinf.firstseen = timestamp()
-        SET netinf.lastupdated = {aws_update_tag},
-            netinf.mac_address = network_interface.MacAddress,
-            netinf.description = network_interface.Description,
-            netinf.private_ip_address = network_interface.PrivateIpAddress,
-            netinf.id = network_interface.NetworkInterfaceId,
-            netinf.private_dns_name = network_interface.PrivateDnsName,
-            netinf.status = network_interface.Status,
-            netinf.subnetid = network_interface.SubnetId,
-            netinf.interface_type = network_interface.InterfaceType,
-            netinf.requester_managed = network_interface.RequesterManaged,
-            netinf.source_dest_check = network_interface.SourceDestCheck,
-            netinf.requester_id = network_interface.RequesterId,
-            netinf.public_ip = network_interface.Association.PublicIp
-    """
-
-    neo4j_session.run(
-        ingest_network_interfaces, network_interfaces=data, aws_update_tag=aws_update_tag,
-        region=region, aws_account_id=aws_account_id,
+    load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_update_tag)
+    load_network_interface_security_group_relations(neo4j_session, data, region, aws_account_id, aws_update_tag)
+    load_network_interface_subnet_relations(neo4j_session, data, region, aws_account_id, aws_update_tag)
+    load_network_interface_instance_relations(
+        neo4j_session, instance_associations, region, aws_account_id, aws_update_tag,
     )
-
-    ingest_network_interface_security_group_relations = """
-    UNWIND {network_interfaces} AS network_interface
-        UNWIND network_interface.Groups AS security_group
-            MATCH (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId}),
-                (sg:EC2SecurityGroup{id: security_group.GroupId})
-            MERGE (netinf)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(sg)
-            ON CREATE SET r.firstseen = timestamp()
-            SET r.lastupdated = {aws_update_tag}
-    """
-
-    neo4j_session.run(
-        ingest_network_interface_security_group_relations, network_interfaces=data, aws_update_tag=aws_update_tag,
-        region=region, aws_account_id=aws_account_id,
-    )
-
-    ingest_network_interface_subnet_relations = """
-    UNWIND {network_interfaces} AS network_interface
-        MATCH (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId}),
-            (snet:EC2Subnet{subnetid: network_interface.SubnetId})
-        MERGE (netinf)-[r:PART_OF_SUBNET]->(snet)
-        ON CREATE SET r.firstseen = timestamp()
-        SET r.lastupdated = {aws_update_tag}
-    """
-
-    neo4j_session.run(
-        ingest_network_interface_subnet_relations, network_interfaces=data, aws_update_tag=aws_update_tag,
-        region=region, aws_account_id=aws_account_id,
-    )
-
-    ingest_network_interface_instance_relations = """
-    UNWIND {instance_associations} AS instance_association
-        MATCH (netinf:NetworkInterface{id: instance_association.netinf_id}),
-            (instance:EC2Instance{id: instance_association.instance_id})
-        MERGE (instance)-[r:NETWORK_INTERFACE]->(netinf)
-        ON CREATE SET r.firstseen = timestamp()
-        SET r.lastupdated = {aws_update_tag}
-    """
-
-    neo4j_session.run(
-        ingest_network_interface_instance_relations, instance_associations=instance_associations,
-        aws_update_tag=aws_update_tag, region=region, aws_account_id=aws_account_id,
-    )
-
-    ingest_network_interface_elb_relations = """
-    UNWIND {elb_associations} AS elb_association
-        MATCH (netinf:NetworkInterface{id: elb_association.netinf_id}),
-            (elb:LoadBalancer{name: elb_association.elb_name})
-        MERGE (elb)-[r:NETWORK_INTERFACE]->(netinf)
-        ON CREATE SET r.firstseen = timestamp()
-        SET r.lastupdated = {aws_update_tag}
-    """
-
-    neo4j_session.run(
-        ingest_network_interface_elb_relations, elb_associations=elb_associations,
-        aws_update_tag=aws_update_tag, region=region, aws_account_id=aws_account_id,
-    )
-
-    ingest_network_interface_elb2_relations = """
-    UNWIND {elb_associations} AS elb_association
-        MATCH (netinf:NetworkInterface{id: elb_association.netinf_id}),
-            (elb:LoadBalancerV2{id: elb_association.elb_id})
-        MERGE (elb)-[r:NETWORK_INTERFACE]->(netinf)
-        ON CREATE SET r.firstseen = timestamp()
-        SET r.lastupdated = {aws_update_tag}
-    """
-
-    neo4j_session.run(
-        ingest_network_interface_elb2_relations, elb_associations=elb_associations_v2,
-        aws_update_tag=aws_update_tag, region=region, aws_account_id=aws_account_id,
-    )
-
-    ingest_private_ip_addresses = """
-    UNWIND {network_interfaces} AS network_interface
-        UNWIND network_interface.PrivateIpAddresses AS private_ip_address
-            MERGE (private_ip:EC2PrivateIp{id: network_interface.NetworkInterfaceId + ':'
-                + private_ip_address.PrivateIpAddress})
-            ON CREATE SET private_ip.firstseen = timestamp()
-            SET private_ip.lastupdated = {aws_update_tag},
-                private_ip.network_interface_id = network_interface.NetworkInterfaceId,
-                private_ip.primary = private_ip_address.Primary,
-                private_ip.private_ip_address = private_ip_address.PrivateIpAddress,
-                private_ip.public_ip = private_ip_address.Association.PublicIp,
-                private_ip.ip_owner_id = private_ip_address.Association.IpOwnerId
-    """
-
-    neo4j_session.run(
-        ingest_private_ip_addresses, network_interfaces=data, aws_update_tag=aws_update_tag,
-        region=region, aws_account_id=aws_account_id,
-    )
-
-    ingest_private_ip_addresses_network_interface_relations = """
-    UNWIND {network_interfaces} AS network_interface
-        UNWIND network_interface.PrivateIpAddresses AS private_ip_address
-            MATCH (private_ip:EC2PrivateIp{id: network_interface.NetworkInterfaceId + ':'
-                + private_ip_address.PrivateIpAddress}),
-                (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId})
-            MERGE (netinf)-[r:PRIVATE_IP_ADDRESS]->(private_ip)
-            ON CREATE SET r.firstseen = timestamp()
-            SET r.lastupdated = {aws_update_tag}
-    """
-
-    neo4j_session.run(
-        ingest_private_ip_addresses_network_interface_relations, network_interfaces=data,
-        aws_update_tag=aws_update_tag, region=region, aws_account_id=aws_account_id,
-    )
-
-    ingest_network_interface_instance_relations = """
-    MATCH (i:EC2Instance)-[:NETWORK_INTERFACE]-(interface:NetworkInterface)-[:PART_OF_SUBNET]-(s:EC2Subnet)
-    MERGE (i)-[r:PART_OF_SUBNET]->(s)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
-    """
-
-    neo4j_session.run(
-        ingest_network_interface_instance_relations, aws_update_tag=aws_update_tag,
-    )
-
-    ingest_network_interface_loadbalancer_relations = """
-    MATCH (i:LoadBalancer)-[:NETWORK_INTERFACE]-(interface:NetworkInterface)-[:PART_OF_SUBNET]-(s:EC2Subnet)
-    MERGE (i)-[r:PART_OF_SUBNET]->(s)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
-    """
-
-    neo4j_session.run(
-        ingest_network_interface_loadbalancer_relations, aws_update_tag=aws_update_tag,
-    )
-
-    ingest_network_interface_loadbalancerv2_relations = """
-    MATCH (i:LoadBalancerV2)-[:NETWORK_INTERFACE]-(interface:NetworkInterface)-[:PART_OF_SUBNET]-(s:EC2Subnet)
-    MERGE (i)-[r:PART_OF_SUBNET]->(s)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
-    """
-
-    neo4j_session.run(
-        ingest_network_interface_loadbalancerv2_relations, aws_update_tag=aws_update_tag,
-    )
+    load_network_interface_elb_relations(neo4j_session, elb_associations, region, aws_account_id, aws_update_tag)
+    load_network_interface_elbv2_relations(neo4j_session, elb_associations_v2, region, aws_account_id, aws_update_tag)
+    load_private_ip_addresses(neo4j_session, data, region, aws_account_id, aws_update_tag)
+    load_network_interface_instance_to_subnet_relations(neo4j_session, aws_update_tag)
+    load_network_interface_load_balancer_relations(neo4j_session, aws_update_tag)
 
 
 @timeit
@@ -224,7 +258,7 @@ def sync_network_interfaces(
     common_job_parameters,
 ):
     for region in regions:
-       logger.info("Syncing EC2 network interfaces for region '%s' in account '%s'.", region, current_aws_account_id)
-       data = get_network_interface_data(boto3_session, region)
-       load_network_interfaces(neo4j_session, data, region, current_aws_account_id, aws_update_tag)
+        logger.info("Syncing EC2 network interfaces for region '%s' in account '%s'.", region, current_aws_account_id)
+        data = get_network_interface_data(boto3_session, region)
+        load(neo4j_session, data, region, current_aws_account_id, aws_update_tag)
     cleanup_network_interfaces(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -51,16 +51,21 @@ def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_upd
 
     ingest_network_interfaces = """
     UNWIND {network_interfaces} AS network_interface
-    MERGE (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId})
-    ON CREATE SET netinf.firstseen = timestamp()
-    SET netinf.lastupdated = {aws_update_tag},  netinf.mac_address = network_interface.MacAddress,
-    netinf.description = network_interface.Description, netinf.private_ip_address = network_interface.PrivateIpAddress,
-    netinf.id = network_interface.NetworkInterfaceId, netinf.private_dns_name = network_interface.PrivateDnsName,
-    netinf.status = network_interface.Status, netinf.subnetid = network_interface.SubnetId,
-    netinf.interface_type = network_interface.InterfaceType,
-    netinf.requester_managed = network_interface.RequesterManaged,
-    netinf.source_dest_check = network_interface.SourceDestCheck,
-    netinf.requester_id = network_interface.RequesterId, netinf.public_ip = network_interface.Association.PublicIp
+        MERGE (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId})
+        ON CREATE SET netinf.firstseen = timestamp()
+        SET netinf.lastupdated = {aws_update_tag},
+            netinf.mac_address = network_interface.MacAddress,
+            netinf.description = network_interface.Description,
+            netinf.private_ip_address = network_interface.PrivateIpAddress,
+            netinf.id = network_interface.NetworkInterfaceId,
+            netinf.private_dns_name = network_interface.PrivateDnsName,
+            netinf.status = network_interface.Status,
+            netinf.subnetid = network_interface.SubnetId,
+            netinf.interface_type = network_interface.InterfaceType,
+            netinf.requester_managed = network_interface.RequesterManaged,
+            netinf.source_dest_check = network_interface.SourceDestCheck,
+            netinf.requester_id = network_interface.RequesterId,
+            netinf.public_ip = network_interface.Association.PublicIp
     """
 
     neo4j_session.run(
@@ -70,12 +75,12 @@ def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_upd
 
     ingest_network_interface_security_group_relations = """
     UNWIND {network_interfaces} AS network_interface
-    UNWIND network_interface.Groups AS security_group
-    MATCH (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId}),
-        (sg:EC2SecurityGroup{id: security_group.GroupId})
-    MERGE (netinf)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(sg)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
+        UNWIND network_interface.Groups AS security_group
+            MATCH (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId}),
+                (sg:EC2SecurityGroup{id: security_group.GroupId})
+            MERGE (netinf)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(sg)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.lastupdated = {aws_update_tag}
     """
 
     neo4j_session.run(
@@ -85,11 +90,11 @@ def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_upd
 
     ingest_network_interface_subnet_relations = """
     UNWIND {network_interfaces} AS network_interface
-    MATCH (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId}),
-        (snet:EC2Subnet{subnetid: network_interface.SubnetId})
-    MERGE (netinf)-[r:PART_OF_SUBNET]->(snet)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
+        MATCH (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId}),
+            (snet:EC2Subnet{subnetid: network_interface.SubnetId})
+        MERGE (netinf)-[r:PART_OF_SUBNET]->(snet)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
     """
 
     neo4j_session.run(
@@ -99,11 +104,11 @@ def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_upd
 
     ingest_network_interface_instance_relations = """
     UNWIND {instance_associations} AS instance_association
-    MATCH (netinf:NetworkInterface{id: instance_association.netinf_id}),
-        (instance:EC2Instance{id: instance_association.instance_id})
-    MERGE (instance)-[r:NETWORK_INTERFACE]->(netinf)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
+        MATCH (netinf:NetworkInterface{id: instance_association.netinf_id}),
+            (instance:EC2Instance{id: instance_association.instance_id})
+        MERGE (instance)-[r:NETWORK_INTERFACE]->(netinf)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
     """
 
     neo4j_session.run(
@@ -113,11 +118,11 @@ def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_upd
 
     ingest_network_interface_elb_relations = """
     UNWIND {elb_associations} AS elb_association
-    MATCH (netinf:NetworkInterface{id: elb_association.netinf_id}),
-        (elb:LoadBalancer{name: elb_association.elb_name})
-    MERGE (elb)-[r:NETWORK_INTERFACE]->(netinf)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
+        MATCH (netinf:NetworkInterface{id: elb_association.netinf_id}),
+            (elb:LoadBalancer{name: elb_association.elb_name})
+        MERGE (elb)-[r:NETWORK_INTERFACE]->(netinf)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
     """
 
     neo4j_session.run(
@@ -127,11 +132,11 @@ def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_upd
 
     ingest_network_interface_elb2_relations = """
     UNWIND {elb_associations} AS elb_association
-    MATCH (netinf:NetworkInterface{id: elb_association.netinf_id}),
-        (elb:LoadBalancerV2{id: elb_association.elb_id})
-    MERGE (elb)-[r:NETWORK_INTERFACE]->(netinf)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
+        MATCH (netinf:NetworkInterface{id: elb_association.netinf_id}),
+            (elb:LoadBalancerV2{id: elb_association.elb_id})
+        MERGE (elb)-[r:NETWORK_INTERFACE]->(netinf)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
     """
 
     neo4j_session.run(
@@ -141,16 +146,16 @@ def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_upd
 
     ingest_private_ip_addresses = """
     UNWIND {network_interfaces} AS network_interface
-    UNWIND network_interface.PrivateIpAddresses AS private_ip_address
-    MERGE (private_ip:EC2PrivateIp{id: network_interface.NetworkInterfaceId + ':'
-        + private_ip_address.PrivateIpAddress})
-    ON CREATE SET private_ip.firstseen = timestamp()
-    SET private_ip.lastupdated = {aws_update_tag},
-    private_ip.network_interface_id = network_interface.NetworkInterfaceId,
-    private_ip.primary = private_ip_address.Primary,
-    private_ip.private_ip_address = private_ip_address.PrivateIpAddress,
-    private_ip.public_ip  = private_ip_address.Association.PublicIp,
-    private_ip.ip_owner_id = private_ip_address.Association.IpOwnerId
+        UNWIND network_interface.PrivateIpAddresses AS private_ip_address
+            MERGE (private_ip:EC2PrivateIp{id: network_interface.NetworkInterfaceId + ':'
+                + private_ip_address.PrivateIpAddress})
+            ON CREATE SET private_ip.firstseen = timestamp()
+            SET private_ip.lastupdated = {aws_update_tag},
+                private_ip.network_interface_id = network_interface.NetworkInterfaceId,
+                private_ip.primary = private_ip_address.Primary,
+                private_ip.private_ip_address = private_ip_address.PrivateIpAddress,
+                private_ip.public_ip = private_ip_address.Association.PublicIp,
+                private_ip.ip_owner_id = private_ip_address.Association.IpOwnerId
     """
 
     neo4j_session.run(
@@ -160,12 +165,13 @@ def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_upd
 
     ingest_private_ip_addresses_network_interface_relations = """
     UNWIND {network_interfaces} AS network_interface
-    UNWIND network_interface.PrivateIpAddresses AS private_ip_address
-    MATCH (private_ip:EC2PrivateIp{id: network_interface.NetworkInterfaceId + ':'
-        + private_ip_address.PrivateIpAddress}), (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId})
-    MERGE (netinf)-[r:PRIVATE_IP_ADDRESS]->(private_ip)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = {aws_update_tag}
+        UNWIND network_interface.PrivateIpAddresses AS private_ip_address
+            MATCH (private_ip:EC2PrivateIp{id: network_interface.NetworkInterfaceId + ':'
+                + private_ip_address.PrivateIpAddress}),
+                (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId})
+            MERGE (netinf)-[r:PRIVATE_IP_ADDRESS]->(private_ip)
+            ON CREATE SET r.firstseen = timestamp()
+            SET r.lastupdated = {aws_update_tag}
     """
 
     neo4j_session.run(
@@ -218,7 +224,7 @@ def sync_network_interfaces(
     common_job_parameters,
 ):
     for region in regions:
-        logger.info("Syncing EC2 network interfaces for region '%s' in account '%s'.", region, current_aws_account_id)
-        data = get_network_interface_data(boto3_session, region)
-        load_network_interfaces(neo4j_session, data, region, current_aws_account_id, aws_update_tag)
+       logger.info("Syncing EC2 network interfaces for region '%s' in account '%s'.", region, current_aws_account_id)
+       data = get_network_interface_data(boto3_session, region)
+       load_network_interfaces(neo4j_session, data, region, current_aws_account_id, aws_update_tag)
     cleanup_network_interfaces(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -152,7 +152,6 @@ def load_network_interface_instance_to_subnet_relations(neo4j_session, aws_updat
     Creates (:EC2Instance)-[:PART_OF_SUBNET]->(:EC2Subnet) if
     (:EC2Instance)--(:NetworkInterface)--(:EC2Subnet).
     """
-    # TODO - cleanup?
     ingest_network_interface_instance_relations = """
     MATCH (i:EC2Instance)-[:NETWORK_INTERFACE]-(interface:NetworkInterface)-[:PART_OF_SUBNET]-(s:EC2Subnet)
     MERGE (i)-[r:PART_OF_SUBNET]->(s)
@@ -171,7 +170,6 @@ def load_network_interface_load_balancer_relations(neo4j_session, aws_update_tag
     Creates (:LoadBalancer)-[:PART_OF_SUBNET]->(:EC2Subnet) if
     (:LoadBalancer)--(:NetworkInterface)--(:EC2Subnet).
     """
-    #  TODO - cleanup?
     ingest_network_interface_loadbalancer_relations = """
     MATCH (i:LoadBalancer)-[:NETWORK_INTERFACE]-(interface:NetworkInterface)-[:PART_OF_SUBNET]-(s:EC2Subnet)
     MERGE (i)-[r:PART_OF_SUBNET]->(s)

--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -22,6 +22,9 @@ def get_network_interface_data(boto3_session, region):
 
 @timeit
 def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_update_tag):
+    """
+    Creates (:NetworkInterface)
+    """
     ingest_network_interfaces = """
     UNWIND {network_interfaces} AS network_interface
         MERGE (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId})
@@ -47,9 +50,10 @@ def load_network_interfaces(neo4j_session, data, region, aws_account_id, aws_upd
 
 
 @timeit
-def load_network_interface_security_group_relations(
-    neo4j_session, data, region, aws_account_id, aws_update_tag,
-):
+def load_network_interface_security_group_relations(neo4j_session, data, region, aws_account_id, aws_update_tag):
+    """
+    Creates (:NetworkInterface)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)
+    """
     ingest_network_interface_security_group_relations = """
     UNWIND {network_interfaces} AS network_interface
         UNWIND network_interface.Groups AS security_group
@@ -67,6 +71,9 @@ def load_network_interface_security_group_relations(
 
 @timeit
 def load_network_interface_subnet_relations(neo4j_session, data, region, aws_account_id, aws_update_tag):
+    """
+    Creates (:NetworkInterface)-[:PART_OF_SUBNET]->(:EC2Subnet)
+    """
     ingest_network_interface_subnet_relations = """
     UNWIND {network_interfaces} AS network_interface
         MATCH (netinf:NetworkInterface{id: network_interface.NetworkInterfaceId}),
@@ -85,6 +92,9 @@ def load_network_interface_subnet_relations(neo4j_session, data, region, aws_acc
 def load_network_interface_instance_relations(
     neo4j_session, instance_associations, region, aws_account_id, aws_update_tag,
 ):
+    """
+    Creates (:EC2Instance)-[:NETWORK_INTERFACE]->(:NetworkInterface)
+    """
     ingest_network_interface_instance_relations = """
     UNWIND {instance_associations} AS instance_association
         MATCH (netinf:NetworkInterface{id: instance_association.netinf_id}),
@@ -101,6 +111,9 @@ def load_network_interface_instance_relations(
 
 @timeit
 def load_network_interface_elb_relations(neo4j_session, elb_associations, region, aws_account_id, aws_update_tag):
+    """
+    Creates (:LoadBalancer)-[:NETWORK_INTERFACE]->(:NetworkInterface)
+    """
     ingest_network_interface_elb_relations = """
     UNWIND {elb_associations} AS elb_association
         MATCH (netinf:NetworkInterface{id: elb_association.netinf_id}),
@@ -117,6 +130,9 @@ def load_network_interface_elb_relations(neo4j_session, elb_associations, region
 
 @timeit
 def load_network_interface_elbv2_relations(neo4j_session, elb_associations_v2, region, aws_account_id, aws_update_tag):
+    """
+    Creates (:LoadBalancerV2)-[:NETWORK_INTERFACE]->(:NetworkInterface)
+    """
     ingest_network_interface_elb2_relations = """
     UNWIND {elb_associations} AS elb_association
         MATCH (netinf:NetworkInterface{id: elb_association.netinf_id}),
@@ -133,6 +149,9 @@ def load_network_interface_elbv2_relations(neo4j_session, elb_associations_v2, r
 
 @timeit
 def load_private_ip_addresses(neo4j_session, data, region, aws_account_id, aws_update_tag):
+    """
+    Creates (:PrivateIpAddress) and (:NetworkInterface)-[:PRIVATE_IP_ADDRESS]->(:PrivateIpAddress)
+    """
     ingest_private_ip_addresses = """
     UNWIND {network_interfaces} AS network_interface
         UNWIND network_interface.PrivateIpAddresses AS private_ip_address
@@ -169,6 +188,9 @@ def load_private_ip_addresses(neo4j_session, data, region, aws_account_id, aws_u
 
 @timeit
 def load_network_interface_instance_to_subnet_relations(neo4j_session, aws_update_tag):
+    """
+    Creates (:EC2Instance)-[:PART_OF_SUBNET]->(:EC2Subnet)
+    """
     ingest_network_interface_instance_relations = """
     MATCH (i:EC2Instance)-[:NETWORK_INTERFACE]-(interface:NetworkInterface)-[:PART_OF_SUBNET]-(s:EC2Subnet)
     MERGE (i)-[r:PART_OF_SUBNET]->(s)
@@ -182,6 +204,9 @@ def load_network_interface_instance_to_subnet_relations(neo4j_session, aws_updat
 
 @timeit
 def load_network_interface_load_balancer_relations(neo4j_session, aws_update_tag):
+    """
+    Creates (:LoadBalancer)-[:PART_OF_SUBNET]->(:EC2Subnet)
+    """
     ingest_network_interface_loadbalancer_relations = """
     MATCH (i:LoadBalancer)-[:NETWORK_INTERFACE]-(interface:NetworkInterface)-[:PART_OF_SUBNET]-(s:EC2Subnet)
     MERGE (i)-[r:PART_OF_SUBNET]->(s)
@@ -195,6 +220,9 @@ def load_network_interface_load_balancer_relations(neo4j_session, aws_update_tag
 
 @timeit
 def load_network_interface_load_balancer_v2_relations(neo4j_session, aws_update_tag):
+    """
+    Creates (:LoadBalancerV2)-[:PART_OF_SUBNET]->(:EC2Subnet)
+    """
     ingest_network_interface_loadbalancerv2_relations = """
     MATCH (i:LoadBalancerV2)-[:NETWORK_INTERFACE]-(interface:NetworkInterface)-[:PART_OF_SUBNET]-(s:EC2Subnet)
     MERGE (i)-[r:PART_OF_SUBNET]->(s)

--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -147,6 +147,7 @@ def load_network_interface_elbv2_relations(neo4j_session, elb_associations_v2, r
         ON CREATE SET r.firstseen = timestamp()
         SET r.lastupdated = {aws_update_tag}
     """
+    logger.debug("Attaching %d ELB V2s to network interfaces in %s.", len(elb_associations_v2), region)
     neo4j_session.run(
         ingest_network_interface_elb2_relations, elb_associations=elb_associations_v2,
         aws_update_tag=aws_update_tag, region=region, aws_account_id=aws_account_id,

--- a/docs/schema/aws.md
+++ b/docs/schema/aws.md
@@ -1530,6 +1530,10 @@ Representation of a generic Network Interface.  Currently however, we only creat
 
 ### Relationships
 
+-  EC2 Network Interfaces belong to AWS accounts.
+
+        (NetworkInterface)<-[:RESOURCE]->(:AWSAccount)
+
 - Network interfaces can be connected to EC2Subnets.
 
         ```

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_network_interfaces.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_network_interfaces.py
@@ -62,7 +62,7 @@ def test_ec2_private_ips(neo4j_session):
 
 def test_network_interface_relationships(neo4j_session):
     data = tests.data.aws.ec2.network_interfaces.DESCRIBE_NETWORK_INTERFACES
-    cartography.intel.aws.ec2.network_interfaces.load_network_interfaces(
+    cartography.intel.aws.ec2.network_interfaces.load(
         neo4j_session,
         data,
         TEST_REGION,

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_network_interfaces.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_network_interfaces.py
@@ -9,7 +9,7 @@ TEST_UPDATE_TAG = 123456789
 
 def test_load_network_interfaces(neo4j_session):
     data = tests.data.aws.ec2.network_interfaces.DESCRIBE_NETWORK_INTERFACES
-    cartography.intel.aws.ec2.network_interfaces.load_network_interfaces(
+    cartography.intel.aws.ec2.network_interfaces.load(
         neo4j_session,
         data,
         TEST_REGION,
@@ -35,7 +35,7 @@ def test_load_network_interfaces(neo4j_session):
 
 def test_ec2_private_ips(neo4j_session):
     data = tests.data.aws.ec2.network_interfaces.DESCRIBE_NETWORK_INTERFACES
-    cartography.intel.aws.ec2.network_interfaces.load_network_interfaces(
+    cartography.intel.aws.ec2.network_interfaces.load(
         neo4j_session,
         data,
         TEST_REGION,
@@ -81,6 +81,38 @@ def test_network_interface_relationships(neo4j_session):
     result = neo4j_session.run(
         """
         MATCH (n1:NetworkInterface)-[:PRIVATE_IP_ADDRESS]->(n2:EC2PrivateIp) RETURN n1.id, n2.id;
+        """,
+    )
+    actual = {
+        (r['n1.id'], r['n2.id']) for r in result
+    }
+
+    assert actual == expected_nodes
+
+
+def test_network_interface_to_account(neo4j_session):
+    neo4j_session.run('MERGE (:AWSAccount{id:{ACC_ID}})', ACC_ID=TEST_ACCOUNT_ID)
+
+    data = tests.data.aws.ec2.network_interfaces.DESCRIBE_NETWORK_INTERFACES
+    cartography.intel.aws.ec2.network_interfaces.load(
+        neo4j_session,
+        data,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    expected_nodes = {
+        ('eni-0e106a07c15ff7d14', TEST_ACCOUNT_ID),
+        ('eni-0d9877f559c240362', TEST_ACCOUNT_ID),
+        ('eni-04b4289e1be7634e4', TEST_ACCOUNT_ID),
+        ('eni-04b4289e1be7634e4', TEST_ACCOUNT_ID),
+    }
+
+    # Fetch relationships
+    result = neo4j_session.run(
+        """
+        MATCH (n1:NetworkInterface)<-[:RESOURCE]-(n2:AWSAccount) RETURN n1.id, n2.id;
         """,
     )
     actual = {


### PR DESCRIPTION
Fixes deadlock/slow performance of network interface sync seen in issue #434.

Root cause: Not including an index for `:EC2PrivateIp` resulted in very unpredictable behavior on both my Linux server and my Mac laptop where the network interface sync would randomly deadlock during ingestion or in the cleanup job.

This was very difficult to trace but now the deadlock is gone and loading 20,000 network interfaces (and thus creating 200,000 nodes) now takes under a minute instead of 3+ days.

Wow. Lesson here is indexes are important!