### PR TITLE
Fix error return codes when connection to Neo4J DB fails

### DIFF
--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -117,7 +117,7 @@ def run_with_config(sync, config):
             config.neo4j_uri,
             e,
         )
-        return
+        return 1
     except neobolt.exceptions.AuthError as e:
         logger.debug("Error occurred during Neo4j auth.", exc_info=True)
         if not neo4j_auth:
@@ -138,7 +138,7 @@ def run_with_config(sync, config):
                 ),
                 e,
             )
-        return
+        return 1
     default_update_tag = int(time.time())
     if not config.update_tag:
         config.update_tag = default_update_tag


### PR DESCRIPTION
Added return code of 1 to the two errors that can occur when initially connecting to the neo4j DB. Not returning an error code has caused issues when running as a K8s cronjob as the job is seen as successfully completing with a zero return code when it has failed to connect to the DB. This fixes that and returns a 1 return code if cartography fails to connect to the DB. 