### PR TITLE
Add missing attributes to AWSIpv6CidrBlock

### DIFF
--- a/cartography/intel/aws/ec2/vpc.py
+++ b/cartography/intel/aws/ec2/vpc.py
@@ -27,6 +27,8 @@ def _get_cidr_association_statement(block_type):
         new_block.cidr_block = block_data.$block_cidr,
         new_block.block_state = block_data.$state_name.State,
         new_block.block_state_message = block_data.$state_name.StatusMessage,
+        new_block.ipv6_pool = block_data.Ipv6Pool,
+        new_block.network_border_group = block_data.NetworkBorderGroup,
         new_block.lastupdated = {aws_update_tag}
         WITH vpc, new_block
         MERGE (vpc)-[r:BLOCK_ASSOCIATION]->(new_block)

--- a/docs/schema/aws.md
+++ b/docs/schema/aws.md
@@ -158,6 +158,8 @@ type for `AWSIpv4CidrBlock` and `AWSIpv6CidrBlock`
 |firstseen| Timestamp of when a sync job discovered this node|
 |cidr\_block| The CIDR block|
 |block\_state| The state of the block|
+|ipv6\_pool| The ID of the IPv6 address pool from which the IPv6 CIDR block is allocated|
+|network\_border\_group| The name of the unique set of Availability Zones, Local Zones, or Wavelength Zones from which AWS advertises IP addresses|
 |association\_id| the association id if the block is associated to a VPC
 |lastupdated| Timestamp of the last time the node was updated|
 |**id**| Unique identifier defined with the VPC association and the cidr\_block


### PR DESCRIPTION
Fix: #515 

Adds the following attributes to the AWSIpv6CidrBlock
- ipv6_pool
- network_border_group