### PR TITLE
Load ecr repository images in batches to resolve timeouts

### DIFF
--- a/cartography/util.py
+++ b/cartography/util.py
@@ -95,5 +95,8 @@ def into_batches(items, batch_size):
 
     See also: https://stackoverflow.com/a/22045226
     """
+    if len(items) <= batch_size:
+        return items
+
     items_iter = iter(items)
     return iter(lambda: list(islice(items_iter, batch_size)), ())

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from itertools import islice
 
 import botocore
 
@@ -85,3 +86,14 @@ def aws_handle_regions(func):
             else:
                 raise
     return inner_function
+
+
+def into_batches(items, batch_size):
+    """
+    Take the given items and chunk them into batches of the given batch size.
+    Returns a new iterator of tuples over the provided items.
+
+    See also: https://stackoverflow.com/a/22045226
+    """
+    items_iter = iter(items)
+    return iter(lambda: list(islice(items_iter, batch_size)), ())


### PR DESCRIPTION
Attempts to fix #522 by batching the data to minimize transaction size. Should resolve network errors due to unresponsive Neo4j server when under too much memory pressure.

I chose the batch size arbitrarily, but given it's creating nodes as well as relationships to highly dense nodes, it shouldn't be set too high without knowing the characteristics of the database host.

In general, this batching approach can be used in other parts of the codebase, so I put it in the common `util` package.