### PR TITLE
Allow AWS tag sync to accept custom mappings

### DIFF
--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -121,7 +121,12 @@ def cleanup(neo4j_session, common_job_parameters):
 
 @timeit
 def sync(
-    neo4j_session, boto3_session, regions, aws_update_tag, common_job_parameters, tag_resource_type_mappings=TAG_RESOURCE_TYPE_MAPPINGS,
+    neo4j_session,
+    boto3_session,
+    regions,
+    aws_update_tag,
+    common_job_parameters,
+    tag_resource_type_mappings=TAG_RESOURCE_TYPE_MAPPINGS,
 ):
     for region in regions:
         logger.info("Syncing AWS tags for region '%s'.", region)

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -120,10 +120,10 @@ def cleanup(neo4j_session, common_job_parameters):
 
 
 @timeit
-def sync(neo4j_session, boto3_session, regions, aws_update_tag, common_job_parameters):
+def sync(neo4j_session, boto3_session, regions, aws_update_tag, common_job_parameters, tag_resource_type_mappings=TAG_RESOURCE_TYPE_MAPPINGS):
     for region in regions:
         logger.info("Syncing AWS tags for region '%s'.", region)
-        for resource_type in TAG_RESOURCE_TYPE_MAPPINGS.keys():
+        for resource_type in tag_resource_type_mappings.keys():
             tag_data = get_tags(boto3_session, [resource_type], region)
             transform_tags(tag_data, resource_type)
             load_tags(neo4j_session, tag_data, resource_type, region, aws_update_tag)

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -120,7 +120,9 @@ def cleanup(neo4j_session, common_job_parameters):
 
 
 @timeit
-def sync(neo4j_session, boto3_session, regions, aws_update_tag, common_job_parameters, tag_resource_type_mappings=TAG_RESOURCE_TYPE_MAPPINGS):
+def sync(
+    neo4j_session, boto3_session, regions, aws_update_tag, common_job_parameters, tag_resource_type_mappings=TAG_RESOURCE_TYPE_MAPPINGS,
+):
     for region in regions:
         logger.info("Syncing AWS tags for region '%s'.", region)
         for resource_type in tag_resource_type_mappings.keys():


### PR DESCRIPTION
Callers to resourcegrouptaggingapi.sync() can now specify an optional parameter for custom tag-to-resourcetype mappings. This allows them to run the AWS tag sync with a subset of the mappings if desired.

The default behavior of this sync (using the `TAG_RESOURCE_TYPE_MAPPINGS` dict) is unaffected by this PR.