### PR TITLE
--neo4j-max-connection-lifetime config param, improve GraphStatement.run()

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -87,6 +87,17 @@ class CLI:
                 'supersedes other methods of supplying a Neo4j password.'
             ),
         )
+        parser.add_argument(
+            '--neo4j-max-connection-lifetime',
+            type=int,
+            default=None,
+            help=(
+                'Time in seconds for the Neo4j driver to consider a TCP connection alive. cartography default = None, '
+                'which results in the neo4j driver picking a default value of 3600s (1 hour). See '
+                'https://neo4j.com/docs/driver-manual/1.7/client-applications/#driver-config-connection-pool-management'
+                '.'
+            ),
+        )
         # TODO add the below parameters to a 'sync' subparser
         parser.add_argument(
             '--update-tag',

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -90,10 +90,10 @@ class CLI:
         parser.add_argument(
             '--neo4j-max-connection-lifetime',
             type=int,
-            default=None,
+            default=3600,
             help=(
-                'Time in seconds for the Neo4j driver to consider a TCP connection alive. cartography default = None, '
-                'which results in the neo4j driver picking a default value of 3600s (1 hour). See '
+                'Time in seconds for the Neo4j driver to consider a TCP connection alive. cartography default = 3600, '
+                'which is the same as the Neo4j driver default. See '
                 'https://neo4j.com/docs/driver-manual/1.7/client-applications/#driver-config-connection-pool-management'
                 '.'
             ),

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -13,8 +13,8 @@ class Config:
     :type neo4j_password: string
     :param neo4j_password: Password for a Neo4j graph database service. Optional.
     :type neo4j_max_connection_lifetime: int
-    :param neo4j_max_connection_lifetime: Time in seconds for Neo4j driver to consider a TCP connection alive. Default =
-        3600 (1 hour). See https://neo4j.com/docs/driver-manual/1.7/client-applications/. Optional.
+    :param neo4j_max_connection_lifetime: Time in seconds for Neo4j driver to consider a TCP connection alive.
+        See https://neo4j.com/docs/driver-manual/1.7/client-applications/. Optional.
     :type update_tag: int
     :param update_tag: Update tag for a cartography sync run. Optional.
     :type aws_sync_all_profiles: bool

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -12,6 +12,9 @@ class Config:
     :param neo4j_user: User name for a Neo4j graph database service. Optional.
     :type neo4j_password: string
     :param neo4j_password: Password for a Neo4j graph database service. Optional.
+    :type neo4j_max_connection_lifetime: int
+    :param neo4j_max_connection_lifetime: Time in seconds for Neo4j driver to consider a TCP connection alive. Default =
+        3600 (1 hour). See https://neo4j.com/docs/driver-manual/1.7/client-applications/. Optional.
     :type update_tag: int
     :param update_tag: Update tag for a cartography sync run. Optional.
     :type aws_sync_all_profiles: bool
@@ -52,6 +55,7 @@ class Config:
         neo4j_uri,
         neo4j_user=None,
         neo4j_password=None,
+        neo4j_max_connection_lifetime=None,
         update_tag=None,
         aws_sync_all_profiles=False,
         analysis_job_directory=None,
@@ -73,6 +77,7 @@ class Config:
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user
         self.neo4j_password = neo4j_password
+        self.neo4j_max_connection_lifetime = neo4j_max_connection_lifetime
         self.update_tag = update_tag
         self.aws_sync_all_profiles = aws_sync_all_profiles
         self.analysis_job_directory = analysis_job_directory

--- a/cartography/graph/statement.py
+++ b/cartography/graph/statement.py
@@ -78,17 +78,18 @@ class GraphStatement:
         """
         self.parameters["LIMIT_SIZE"] = self.iterationsize
 
-        total_completed = -1
-        while total_completed != 0:
+        while True:
             result: neo4j.StatementResult = self._run(tx)
-
             record: neo4j.Record = result.single()
+
             # TODO: use the BoltStatementResultSummary object to determine the number of items processed
             total_completed = int(record['TotalCompleted'])
             logger.debug("Processed %d items", total_completed)
 
             # Ensure network buffers are cleared
             result.consume()
+            if total_completed == 0:
+                break
 
     @classmethod
     def create_from_json(cls, json_obj):

--- a/cartography/graph/statement.py
+++ b/cartography/graph/statement.py
@@ -63,7 +63,7 @@ class GraphStatement:
         """
         Non-iterative statement execution.
         """
-        return session.run(self.query, self.parameters)
+        return session.run(self.query, self.parameters).consume()
 
     def _run_iterative(self, session):
         """
@@ -77,9 +77,10 @@ class GraphStatement:
         done = False
         while not done:
             results = self._run(session)
-            done = False
             for r in results:
-                if int(r['TotalCompleted']) == 0:
+                total_deleted = int(r['TotalCompleted'])
+                logger.debug("Deleted %d items", total_deleted)
+                if total_deleted == 0:
                     done = True
 
                 break

--- a/cartography/graph/statement.py
+++ b/cartography/graph/statement.py
@@ -78,13 +78,14 @@ class GraphStatement:
         """
         self.parameters["LIMIT_SIZE"] = self.iterationsize
 
-        total_deleted = -1
-        while total_deleted != 0:
+        total_completed = -1
+        while total_completed != 0:
             result: neo4j.StatementResult = self._run(tx)
 
             record: neo4j.Record = result.single()
-            total_deleted = int(record['TotalCompleted'])
-            logger.debug("Deleted %d items", total_deleted)
+            # TODO: use the BoltStatementResultSummary object to determine the number of items processed
+            total_completed = int(record['TotalCompleted'])
+            logger.debug("Processed %d items", total_completed)
 
             # Ensure network buffers are cleared
             result.consume()

--- a/cartography/graph/statement.py
+++ b/cartography/graph/statement.py
@@ -77,9 +77,14 @@ class GraphStatement:
 
         total_deleted = -1
         while total_deleted != 0:
-            result: neo4j.Record = self._run(session).single()
+            result: neo4j.BoltStatementResult = self._run(session)\
+
+            record: neo4j.Record = result.single()
             total_deleted = int(result['TotalCompleted'])
             logger.debug("Deleted %d items", total_deleted)
+
+            # Ensure network buffers are cleared
+            result.consume()
 
     @classmethod
     def create_from_json(cls, json_obj):

--- a/cartography/graph/statement.py
+++ b/cartography/graph/statement.py
@@ -77,10 +77,10 @@ class GraphStatement:
 
         total_deleted = -1
         while total_deleted != 0:
-            result: neo4j.BoltStatementResult = self._run(session)\
+            result: neo4j.BoltStatementResult = self._run(session)
 
             record: neo4j.Record = result.single()
-            total_deleted = int(result['TotalCompleted'])
+            total_deleted = int(record['TotalCompleted'])
             logger.debug("Deleted %d items", total_deleted)
 
             # Ensure network buffers are cleared

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -106,6 +106,7 @@ def run_with_config(sync, config):
         neo4j_driver = GraphDatabase.driver(
             config.neo4j_uri,
             auth=neo4j_auth,
+            max_connection_lifetime=config.neo4j_max_connection_lifetime,
         )
     except neobolt.exceptions.ServiceUnavailable as e:
         logger.debug("Error occurred during Neo4j connect.", exc_info=True)


### PR DESCRIPTION
## Background
When migrating our single compute instance cartography+neo4j setup to K8s, we observed `ServiceUnavailable` exceptions on many different occasions. In our setup, the Neo4j DB was fronted by an AWS NLB. After much debugging, I found that

> Elastic Load Balancing sets the idle timeout value for TCP flows to 350 seconds. You cannot modify this value."

([AWS ELB+NLB docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout))

As mentioned in https://github.com/neo4j/neo4j-python-driver/issues/205, the Neo4j driver maintains a pool of TCP connections for speed, setting a default max connection lifetime value for 1 hour before it considers a connection dead.

> NLBs have an idle timeout of 350 seconds which cannot be changed. When connections expire through idle timeout, NLBs terminate the connections silently. An application that is not aware of this timeout would attempt to send data to the same socket. At that point, the NLB would notify the application that the connection has been terminated by sending it an RST packet.

([tenable blog](https://medium.com/tenable-techblog/lessons-from-aws-nlb-timeouts-5028a8f65dda#))

In our case, a default neo4j driver config communicating with an AWS NLB would attempt to use a TCP connection from its connection pool that is actually stale, resulting in a RST.

## What this PR does
- Exposes a --neo4j-max-connection-lifetime parameter for cartography clients that need to specify connection lifetimes other than the default 1 hour. See https://neo4j.com/docs/driver-manual/1.7/client-applications/#driver-config-connection-pool-management.
- (Unrelated) Modifies `GraphStatement.run()` to use explicit neo4j transactions. This function is currently used for analysis and cleanup jobs, and is a good fit for explicit transactions.

I have tested this change and it has resolved at least one network connectivity issue that I previously reported. I'm really excited about testing this on the other connectivity issues I've submitted.