### PR TITLE
Type hints, only enforced  for eks initially

### DIFF
--- a/cartography/intel/aws/eks.py
+++ b/cartography/intel/aws/eks.py
@@ -1,4 +1,10 @@
 import logging
+from typing import Any
+from typing import Dict
+from typing import List
+
+import boto3
+import neo4j
 
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
@@ -9,9 +15,9 @@ logger = logging.getLogger(__name__)
 
 @timeit
 @aws_handle_regions
-def get_eks_clusters(boto3_session, region):
+def get_eks_clusters(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
     client = boto3_session.client('eks', region_name=region)
-    clusters = []
+    clusters: List[Dict] = []
     paginator = client.get_paginator('list_clusters')
     for page in paginator.paginate():
         clusters.extend(page['clusters'])
@@ -19,15 +25,18 @@ def get_eks_clusters(boto3_session, region):
 
 
 @timeit
-def get_eks_describe_cluster(boto3_session, region, cluster_name):
+def get_eks_describe_cluster(boto3_session: boto3.session.Session, region: str, cluster_name: str) -> Dict:
     client = boto3_session.client('eks', region_name=region)
     response = client.describe_cluster(name=cluster_name)
     return response['cluster']
 
 
 @timeit
-def load_eks_clusters(neo4j_session, cluster_data, region, current_aws_account_id, aws_update_tag):
-    query = """
+def load_eks_clusters(
+    neo4j_session: neo4j.Session, cluster_data: Dict, region: str, current_aws_account_id: str,
+    aws_update_tag: str,
+) -> None:
+    query: str = """
     MERGE (cluster:EKSCluster{id: {ClusterArn}})
     ON CREATE SET cluster.firstseen = timestamp(),
                 cluster.arn = {ClusterArn},
@@ -69,31 +78,34 @@ def load_eks_clusters(neo4j_session, cluster_data, region, current_aws_account_i
         )
 
 
-def _process_logging(cluster):
+def _process_logging(cluster: Dict) -> bool:
     """
     Parse cluster.logging.clusterLogging to verify if
     at least one entry has audit logging set to Enabled.
     """
-    logging = False
-    cluster_logging = cluster.get('logging', {}).get('clusterLogging')
+    logging: bool = False
+    cluster_logging: Any = cluster.get('logging', {}).get('clusterLogging')
     if cluster_logging:
-        logging = any(filter(lambda x: 'audit' in x['types'] and x['enabled'], cluster_logging))
+        logging = any(filter(lambda x: 'audit' in x['types'] and x['enabled'], cluster_logging))  # type: ignore
     return logging
 
 
 @timeit
-def cleanup(neo4j_session, common_job_parameters):
+def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
     run_cleanup_job('aws_import_eks_cleanup.json', neo4j_session, common_job_parameters)
 
 
 @timeit
-def sync(neo4j_session, boto3_session, regions, current_aws_account_id, aws_update_tag, common_job_parameters):
+def sync(
+    neo4j_session: neo4j.Session, boto3_session: boto3.session.Session, regions: str, current_aws_account_id: str,
+    aws_update_tag: int, common_job_parameters: Dict,
+) -> None:
     for region in regions:
         logger.info("Syncing EKS for region '%s' in account '%s'.", region, current_aws_account_id)
 
-        clusters = get_eks_clusters(boto3_session, region)
+        clusters: List[Dict] = get_eks_clusters(boto3_session, region)
 
-        cluster_data = {}
+        cluster_data: Dict = {}
         for cluster_name in clusters:
             cluster_data[cluster_name] = get_eks_describe_cluster(boto3_session, region, cluster_name)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,11 @@ max-line-length = 120
 
 [pep8]
 max-line-length = 120
+
+[mypy]
+check_untyped_defs = true
+disallow_untyped_defs = true
+ignore_errors = true
+
+[mypy-cartography.intel.aws.eks]
+ignore_errors = false


### PR DESCRIPTION
I've applied this only to EKS:

```
[mypy-cartography.intel.aws.eks]
ignore_errors = false
```

Note: I ignored the hint for `logging = any(filter(lambda x: 'audit' in x['types'] and x['enabled'], cluster_logging))  # type: ignore`. No idea what that is supposed to be!