### PR TITLE
Fix the default value of requested_syncs to RESOURCE_FUNCTIONS.keys()

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -189,7 +189,7 @@ def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             ),
         )
 
-    requested_syncs: List[str] = []
+    requested_syncs: List[str] = RESOURCE_FUNCTIONS.keys()
     if config.aws_requested_syncs:
         requested_syncs = parse_and_validate_aws_requested_syncs(config.aws_requested_syncs)
 

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -189,7 +189,7 @@ def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             ),
         )
 
-    requested_syncs: List[str] = RESOURCE_FUNCTIONS.keys()
+    requested_syncs: List[str] = list(RESOURCE_FUNCTIONS.keys())
     if config.aws_requested_syncs:
         requested_syncs = parse_and_validate_aws_requested_syncs(config.aws_requested_syncs)
 


### PR DESCRIPTION
Currently, if the `--aws-requested-syncs` param is not specified then no AWS resource is synced rather than the intended functionality where all the AWS resources should be synced.