### PR TITLE
Fix signature for sync() for permission_relationship and taggingapi

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -65,11 +65,11 @@ def _sync_one_account(
 
     # MAP IAM permissions
     if 'permission_relationships' in aws_requested_syncs:
-        RESOURCE_FUNCTIONS['permission_relationships'](**sync_args)
+        RESOURCE_FUNCTIONS['permission_relationships'](neo4j_session, current_aws_account_id, update_tag, common_job_parameters)
 
     # AWS Tags - Must always be last.
     if 'resourcegroupstaggingapi' in aws_requested_syncs:
-        RESOURCE_FUNCTIONS['resourcegroupstaggingapi'](**sync_args)
+        RESOURCE_FUNCTIONS['resourcegroupstaggingapi'](neo4j_session, boto3_session, regions, update_tag, common_job_parameters)
 
 
 def _autodiscover_account_regions(boto3_session: boto3.session.Session, account_id: str) -> List[str]:

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -65,11 +65,11 @@ def _sync_one_account(
 
     # MAP IAM permissions
     if 'permission_relationships' in aws_requested_syncs:
-        RESOURCE_FUNCTIONS['permission_relationships'](neo4j_session, current_aws_account_id, update_tag, common_job_parameters)
+        RESOURCE_FUNCTIONS['permission_relationships'](**sync_args)
 
     # AWS Tags - Must always be last.
     if 'resourcegroupstaggingapi' in aws_requested_syncs:
-        RESOURCE_FUNCTIONS['resourcegroupstaggingapi'](neo4j_session, boto3_session, regions, update_tag, common_job_parameters)
+        RESOURCE_FUNCTIONS['resourcegroupstaggingapi'](**sync_args)
 
 
 def _autodiscover_account_regions(boto3_session: boto3.session.Session, account_id: str) -> List[str]:

--- a/cartography/intel/aws/permission_relationships.py
+++ b/cartography/intel/aws/permission_relationships.py
@@ -8,7 +8,6 @@ from typing import List
 from typing import Pattern
 from typing import Tuple
 
-import boto3
 import neo4j
 import yaml
 
@@ -355,8 +354,7 @@ def is_valid_rpr(rpr: Dict) -> bool:
 
 @timeit
 def sync(
-    neo4j_session: neo4j.Session, boto3_session: boto3.session.Session, regions: List[str], current_aws_account_id: str,
-    update_tag: int, common_job_parameters: Dict,
+    neo4j_session: neo4j.Session, current_aws_account_id: str, update_tag: int, common_job_parameters: Dict,
 ) -> None:
     logger.info("Syncing Permission Relationships for account '%s'.", current_aws_account_id)
     principals = get_principals_for_account(neo4j_session, current_aws_account_id)

--- a/cartography/intel/aws/permission_relationships.py
+++ b/cartography/intel/aws/permission_relationships.py
@@ -8,6 +8,7 @@ from typing import List
 from typing import Pattern
 from typing import Tuple
 
+import boto3
 import neo4j
 import yaml
 
@@ -354,7 +355,8 @@ def is_valid_rpr(rpr: Dict) -> bool:
 
 @timeit
 def sync(
-    neo4j_session: neo4j.Session, current_aws_account_id: str, update_tag: int, common_job_parameters: Dict,
+    neo4j_session: neo4j.Session, boto3_session: boto3.session.Session, regions: List[str], current_aws_account_id: str,
+    update_tag: int, common_job_parameters: Dict,
 ) -> None:
     logger.info("Syncing Permission Relationships for account '%s'.", current_aws_account_id)
     principals = get_principals_for_account(neo4j_session, current_aws_account_id)

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -126,6 +126,7 @@ def compute_resource_id(tag_mapping: Dict, resource_type: str) -> str:
 def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
     run_cleanup_job('aws_import_tags_cleanup.json', neo4j_session, common_job_parameters)
 
+
 @timeit
 def sync(
     neo4j_session: neo4j.Session,

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -126,12 +126,12 @@ def compute_resource_id(tag_mapping: Dict, resource_type: str) -> str:
 def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
     run_cleanup_job('aws_import_tags_cleanup.json', neo4j_session, common_job_parameters)
 
+
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
     boto3_session: boto3.session.Session,
     regions: List[str],
-    current_aws_account_id: str,
     update_tag: int,
     common_job_parameters: Dict,
     tag_resource_type_mappings: Dict = TAG_RESOURCE_TYPE_MAPPINGS,

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -126,12 +126,12 @@ def compute_resource_id(tag_mapping: Dict, resource_type: str) -> str:
 def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
     run_cleanup_job('aws_import_tags_cleanup.json', neo4j_session, common_job_parameters)
 
-
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
     boto3_session: boto3.session.Session,
     regions: List[str],
+    current_aws_account_id: str,
     update_tag: int,
     common_job_parameters: Dict,
     tag_resource_type_mappings: Dict = TAG_RESOURCE_TYPE_MAPPINGS,

--- a/tests/integration/cartography/intel/aws/test_iam.py
+++ b/tests/integration/cartography/intel/aws/test_iam.py
@@ -4,6 +4,7 @@ import tests.data.aws.iam
 from cartography.cli import CLI
 from cartography.config import Config
 from cartography.sync import build_default_sync
+from unittest import mock
 
 TEST_ACCOUNT_ID = '000000000000'
 TEST_REGION = 'us-east-1'
@@ -136,6 +137,8 @@ def test_map_permissions(neo4j_session):
 
     cartography.intel.aws.permission_relationships.sync(
         neo4j_session,
+        mock.MagicMock,
+        [TEST_REGION],
         TEST_ACCOUNT_ID,
         TEST_UPDATE_TAG, {
             "permission_relationships_file": "cartography/data/permission_relationships.yaml",

--- a/tests/integration/cartography/intel/aws/test_iam.py
+++ b/tests/integration/cartography/intel/aws/test_iam.py
@@ -1,10 +1,11 @@
+from unittest import mock
+
 import cartography.intel.aws.iam
 import cartography.intel.aws.permission_relationships
 import tests.data.aws.iam
 from cartography.cli import CLI
 from cartography.config import Config
 from cartography.sync import build_default_sync
-from unittest import mock
 
 TEST_ACCOUNT_ID = '000000000000'
 TEST_REGION = 'us-east-1'


### PR DESCRIPTION
While standardizing AWS intel in https://github.com/lyft/cartography/pull/530, by passing`**sync_args` to `sync()` in `permission_relationship.py` and `resourcegroupstaggingapi.py` few extra parameters were passed which was not complying with the signature of the `sync()`

Earlier (before the https://github.com/lyft/cartography/pull/530), `neo4j_session, account_id, sync_tag, common_job_parameters` and `neo4j_session, boto3_session, regions, sync_tag, common_job_parameters` were passed to `sync()` of `permission_relationship.py` and  `resourcegroupstaggingapi.py`. However, now we are passing `neo4j_session, boto3_session, regions, account_id, sync_tag, common_job_parameters` 
https://github.com/lyft/cartography/blob/08d60586831b40376d60d00ae5fb0e611eb56590/cartography/intel/aws/__init__.py#L64-L67