### PR TITLE
Hotfix: incorrect query parameter name in ec2/vpc.py

### DIFF
--- a/cartography/intel/aws/ec2/vpc.py
+++ b/cartography/intel/aws/ec2/vpc.py
@@ -32,11 +32,11 @@ def _get_cidr_association_statement(block_type: str) -> str:
         new_block.cidr_block = block_data.$block_cidr,
         new_block.block_state = block_data.$state_name.State,
         new_block.block_state_message = block_data.$state_name.StatusMessage,
-        new_block.lastupdated = {aws_update_tag}
+        new_block.lastupdated = {update_tag}
         WITH vpc, new_block
         MERGE (vpc)-[r:BLOCK_ASSOCIATION]->(new_block)
         ON CREATE SET r.firstseen = timestamp()
-        SET r.lastupdated = {aws_update_tag}""")
+        SET r.lastupdated = {update_tag}""")
 
     BLOCK_CIDR = "CidrBlock"
     STATE_NAME = "CidrBlockState"


### PR DESCRIPTION
Thanks to @cpollard0 for catching this [here](https://github.com/lyft/cartography/pull/556#discussion_r589066118).

When standardizing parameter names in #530, I decided to use `update_tag` over `aws_update_tag`, at least for `sync_*` functions. This introduced a bug for ec2/vpc.py, which has some special parsing logic where query params are substituted in outside of a `load` function.

I did a quick scan and this is the only case where this bug is present. In future it might be worth renaming the other instances of this parameter, but for now I will avoid breaking anything else; it's good enough to just have the `sync*` entrypoint params be standardized.