### PR TITLE
Fix #561: Add publish-to-PyPI GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,19 +14,19 @@ jobs:
         with:
           python-version: 3.6
       - name: Install pypa/build
-          run: >-
-            python -m
-            pip install
-            build
-            --user
-            - name: Build a binary wheel and a source tarball
-              run: >-
-                python -m
-                build
-                --sdist
-                --wheel
-                --outdir dist/
-                .
+        run: >-
+          python -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python -m
+          build
+          --sdist
+          --wheel
+          --outdir dist/
+          .
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Set up Python 3.6
         uses: actions/setup-python@v1
         with:
@@ -29,6 +29,7 @@ jobs:
           .
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@v1
         with:
+          user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,34 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on:
+  release:
+    types: [published]
+jobs:
+  build-and-publish-to-pypi:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install pypa/build
+          run: >-
+            python -m
+            pip install
+            build
+            --user
+            - name: Build a binary wheel and a source tarball
+              run: >-
+                python -m
+                build
+                --sdist
+                --wheel
+                --outdir dist/
+                .
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Intent: When I hit 'Draft Release' in the GitHub UI and complete the release, a cartography release should be built and sent to PyPI.

As noted in #561, we lost this functionality when we moved from TravisCI to GitHub Actions and now need to implement this.

Relevant links
--------------
- https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release
- The old TravisCI flow is here: https://github.com/lyft/cartography/blob/0c9a662672cf4925ac8214b44451b1c50374aa97/.travis.yml#L23-L31