### PR TITLE
Hotfix: Typo in gh-action-pypi-publish

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -29,7 +29,7 @@ jobs:
           .
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
See https://github.com/pypa/gh-action-pypi-publish#customizing-target-package-dists-directory.

The Action currently fails with 

```
Unable to resolve action `pypa/gh-action-pypi-publish@v1`, unable to find version `v1`
```