### PR TITLE
Add scoped stats client

### DIFF
--- a/cartography/scoped_stats_client.py
+++ b/cartography/scoped_stats_client.py
@@ -19,6 +19,10 @@ class ScopedStatsClient(object):
         self._scope_prefix = prefix
 
     def get_scoped_stats_client(self, scope: str):
+        """
+        This method returns a new proxy to the same client
+        which will prefix all calls to underlying methods with the scoped prefix
+        """
         if not self._scope_prefix:
             prefix = scope
         else:
@@ -28,11 +32,25 @@ class ScopedStatsClient(object):
     def is_enabled(self) -> bool:
         return self._client is not None
 
-    def incr(self, stat: str, count: int = 1, rate: float = 1.0):
+    def incr(self, stat: str, count: int = 1, rate: float = 1.0) -> None:
+        """
+        This method uses statsd to increment a counter.
+        :param stat: the name of the counter metric stat (string) to increment
+        :param count: the amount (integer) to increment by. May be negative
+        :param rate: a sample rate, a float between 0 and 1. Will only send data this percentage of the time.
+                             The statsd server will take the sample rate into account for counters
+        """
         if self.is_enabled():
             self._client.incr(self._scope_prefix + "." + stat, count, rate)
 
     def timer(self, stat: str, rate: float = 1.0) -> Timer:
+        """
+        This method uses statsd to retrieve a timer.
+        When Timer.stop() is called, a timing stat will automatically be sent to statsd
+        :param stat: the name of the timer metric stat (string) to report
+        :param rate: a sample rate, a float between 0 and 1. Will only send data this percentage of the time.
+                             The statsd server will take the sample rate into account for counters
+        """
         if self.is_enabled():
             return self._client.timer(stat, rate)
         return None

--- a/cartography/scoped_stats_client.py
+++ b/cartography/scoped_stats_client.py
@@ -1,0 +1,38 @@
+from statsd import StatsClient
+from statsd.client.timer import Timer
+
+
+class ScopedStatsClient(object):
+    """
+    A Proxy object for an underlying statsd client.
+    Adds a new call, get_scoped_stats_client(scope), which returns a new proxy to the same
+    client which will prefix all calls to underlying methods with the scoped prefix:
+    new_client = client.get_scoped_stats_client('a')
+    new_client.incr('b') # Metric name = a.b
+    This can be nested:
+    newer_client = new_client.get_scoped_stats_client('subsystem')
+    newer_client.incr('bad') # Metric name = a.subsystem.bad
+    """
+
+    def __init__(self, client: StatsClient, prefix: str = None):
+        self._client = client
+        self._scope_prefix = prefix
+
+    def get_scoped_stats_client(self, scope: str):
+        if not self._scope_prefix:
+            prefix = scope
+        else:
+            prefix = self._scope_prefix + "." + scope
+        return ScopedStatsClient(self._client, prefix)
+
+    def is_enabled(self) -> bool:
+        return self._client is not None
+
+    def incr(self, stat: str, count: int = 1, rate: float = 1.0):
+        if self.is_enabled():
+            self._client.incr(self._scope_prefix + "." + stat, count, rate)
+
+    def timer(self, stat: str, rate: float = 1.0) -> Timer:
+        if self.is_enabled():
+            return self._client.timer(stat, rate)
+        return None

--- a/cartography/scoped_stats_client.py
+++ b/cartography/scoped_stats_client.py
@@ -2,7 +2,7 @@ from statsd import StatsClient
 from statsd.client.timer import Timer
 
 
-class ScopedStatsClient(object):
+class ScopedStatsClient:
     """
     A Proxy object for an underlying statsd client.
     Adds a new call, get_scoped_stats_client(scope), which returns a new proxy to the same

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -100,7 +100,7 @@ def run_with_config(sync, config):
                 host=config.statsd_host,
                 port=config.statsd_port,
                 prefix=config.statsd_prefix,
-            )
+            ),
         )
 
     neo4j_auth = None

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -16,7 +16,7 @@ import cartography.intel.gcp
 import cartography.intel.github
 import cartography.intel.gsuite
 import cartography.intel.okta
-
+from cartography.scoped_stats_client import ScopedStatsClient
 
 logger = logging.getLogger(__name__)
 
@@ -95,10 +95,12 @@ def run_with_config(sync, config):
     """
     # Initialize statsd client if enabled
     if config.statsd_enabled:
-        cartography.util.stats_client = StatsClient(
-            host=config.statsd_host,
-            port=config.statsd_port,
-            prefix=config.statsd_prefix,
+        cartography.util.stats_client = ScopedStatsClient(
+            StatsClient(
+                host=config.statsd_host,
+                port=config.statsd_port,
+                prefix=config.statsd_prefix,
+            )
         )
 
     neo4j_auth = None

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -4,8 +4,8 @@ from functools import wraps
 
 import botocore
 
-from cartography.scoped_stats_client import ScopedStatsClient
 from cartography.graph.job import GraphJob
+from cartography.scoped_stats_client import ScopedStatsClient
 
 if sys.version_info >= (3, 7):
     from importlib.resources import open_binary, read_text


### PR DESCRIPTION
Summary of changes:
1. Added scoped stats client which will allow us to nest metric names. If statsd is not enabled, these methods will do nothing
2. Added incr method which lets us increment counter metrics
3. Changed timeit to use timer method of scoped stats client. The method stays as is. 