### PR TITLE
#587, #503 - run AWS cleanup jobs only for current account

### DIFF
--- a/cartography/data/jobs/cleanup/aws_dns_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_dns_cleanup.json
@@ -6,7 +6,7 @@
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:NameServer) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:NameServer)-[:NAMESERVER]->(:DNSZone)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
       "iterative": true,
       "iterationsize": 100
     },
@@ -35,12 +35,22 @@
       "__comment__": "Clean up AWSDNSRecords pointing to NameServers within the current AWS account"
     },
     {
-      "query": "MATCH (:AWSDNSZone)-[r:NAMESERVER]->(:NameServer) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSDNSZone)-[r:NAMESERVER]->(:NameServer)-[:NAMESERVER]->(:DNSZone)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSDNSZone)<-[r:SUBZONE]-(:AWSDNSZone) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSDNSZone)<-[r:SUBZONE]-(:AWSDNSZone)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:ESDomain)<-[r:DNS_POINTS_TO]-(:DNSRecord)-[:MEMBER_OF_DNS_ZONE]->(:AWSDNSZone)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:Ip)<-[r:DNS_POINTS_TO]-(:AWSDNSRecord)-[:MEMBER_OF_DNS_ZONE]->(:AWSDNSZone)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_lambda_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_lambda_cleanup.json
@@ -11,7 +11,7 @@
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSLambda)-[r:STS_ASSUME_ROLE_ALLOW]->(:AWSPrincipal) WITH r LIMIT {LIMIT_SIZE} DELETE r return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSLambda)-[r:STS_ASSUME_ROLE_ALLOW]->(:AWSPrincipal) WITH r LIMIT {LIMIT_SIZE} DELETE r return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         }

--- a/cartography/data/jobs/cleanup/aws_import_s3_acl_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_s3_acl_cleanup.json
@@ -6,7 +6,7 @@
       "iterationsize": 100
     },
     {
-      "query": "MATCH (a:S3Acl) WHERE NOT (a)-[:APPLIES_TO]->(:S3Bucket) WITH a LIMIT {LIMIT_SIZE} DETACH DELETE (a) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:S3Bucket)<-[r:APPLIES_TO]-(:S3Acl) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
@@ -1,62 +1,62 @@
 {
     "statements": [
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Instance) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:NetworkInterface) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:NetworkInterface)-[:PART_OF_SUBNET]->(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:NetworkInterface)-[:PART_OF_SUBNET]->(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2SecurityGroup) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Subnet) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:AWSVpc) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:AWSVpc) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:ESDomain) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:ESDomain)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:ESDomain) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:ESDomain)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
@@ -66,37 +66,37 @@
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RedshiftCluster) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RDSInstance) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RDSInstance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:DBSubnetGroup) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:DBSubnetGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:S3Bucket) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:S3Bucket) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         }

--- a/cartography/data/jobs/cleanup/aws_import_tgw_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tgw_cleanup.json
@@ -1,24 +1,44 @@
 {
   "statements": [
-  {
-    "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-() WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DETACH DELETE (r) return COUNT(*) as TotalCompleted",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:RESOURCE|ATTACHED_TO]-() WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-() WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:RESOURCE|ATTACHED_TO]-() WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n) return COUNT(*) as TotalCompleted",
-    "iterative": true,
-    "iterationsize": 100
-  }],
+    {
+      "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DETACH DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:ATTACHED_TO]->(:AWSTransitGateway)-[:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:ATTACHED_TO]->(:AWSTransitGateway)-[:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    }],
   "name": "cleanup AWS Transit Gateway information"
 }

--- a/cartography/data/jobs/cleanup/aws_ingest_subnets_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_subnets_cleanup.json
@@ -3,6 +3,10 @@
     "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[r:MEMBER_OF_AWS_VPC]-(n:EC2Subnet) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
+  },{
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[r:MEMBER_OF_AWS_VPC]-(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
   }
   ],
   "name": "cleanup Subnet"


### PR DESCRIPTION
First stab at fixing #587 and #503 by making sure AWS cleanup jobs only delete nodes tied to the current account.

A future PR will address the cleanup behaviors of `cartography.intel.aws.sync_multiple_accounts`.

Thanks to @krisek in #533 for doing a lot of the work here.