### PR TITLE
Only cleanup AWS principals w/o accounts

### DIFF
--- a/cartography/data/jobs/cleanup/aws_post_ingestion_principals_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_post_ingestion_principals_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (n:AWSPrincipal) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AWSPrincipal) WHERE NOT (n)<-[:RESOURCE]-(:AWSAccount) AND n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
     "iterative": true,
     "iterationsize": 100
   }],


### PR DESCRIPTION
Restricts AWS post ingestion cleanup job to only delete nodes that are unattached to accounts. Previously this would delete _all_ principals that did not match the current update tag, which was too aggressive.