### PR TITLE
Modify statsclient so that incr works

### DIFF
--- a/cartography/stats.py
+++ b/cartography/stats.py
@@ -1,9 +1,4 @@
-import logging
-
 from statsd import StatsClient
-
-
-logger = logging.getLogger(__name__)
 
 
 class _StatsClientWrapper:
@@ -61,7 +56,6 @@ class ScopedStatsClient:
         if self.is_enabled():
             if self._scope_prefix:
                 stat = f"{self._scope_prefix}.{stat}"
-            logger.info(f"Stat being incremented is {stat}")
             self._client.get_client().incr(stat, count, rate)
 
     def timer(self, stat: str, rate: float = 1.0):

--- a/cartography/stats.py
+++ b/cartography/stats.py
@@ -40,7 +40,9 @@ class ScopedStatsClient:
                              The statsd server will take the sample rate into account for counters
         """
         if self.is_enabled():
-            self._client.incr(self._scope_prefix + "." + stat, count, rate)
+            if self._scope_prefix:
+                stat = f"{self._scope_prefix}.{stat}"
+            self._client.incr(stat, count, rate)
 
     def timer(self, stat: str, rate: float = 1.0):
         """
@@ -51,6 +53,8 @@ class ScopedStatsClient:
                              The statsd server will take the sample rate into account for counters
         """
         if self.is_enabled():
+            if self._scope_prefix:
+                stat = f"{self._scope_prefix}.{stat}"
             return self._client.timer(stat, rate)
         return None
 

--- a/cartography/stats.py
+++ b/cartography/stats.py
@@ -6,6 +6,20 @@ from statsd import StatsClient
 logger = logging.getLogger(__name__)
 
 
+class _StatsClientWrapper:
+    def __init__(self, client: StatsClient):
+        self._client = client
+
+    def set_client(self, client: StatsClient) -> None:
+        self._client = client
+
+    def get_client(self) -> StatsClient:
+        return self._client
+
+    def is_enabled(self) -> bool:
+        return self._client is not None
+
+
 class ScopedStatsClient:
     """
     A Proxy object for an underlying statsd client.
@@ -18,7 +32,7 @@ class ScopedStatsClient:
     newer_client.incr('bad') # Metric name = a.subsystem.bad
     """
 
-    def __init__(self, client: StatsClient, prefix: str = None):
+    def __init__(self, client: _StatsClientWrapper, prefix: str = None):
         self._client = client
         self._scope_prefix = prefix
 
@@ -30,11 +44,11 @@ class ScopedStatsClient:
         if not self._scope_prefix:
             prefix = scope
         else:
-            prefix = self._scope_prefix + "." + scope
+            prefix = f"{self._scope_prefix}.{scope}"
         return ScopedStatsClient(self._client, prefix)
 
     def is_enabled(self) -> bool:
-        return self._client is not None
+        return self._client.is_enabled()
 
     def incr(self, stat: str, count: int = 1, rate: float = 1.0) -> None:
         """
@@ -48,7 +62,7 @@ class ScopedStatsClient:
             if self._scope_prefix:
                 stat = f"{self._scope_prefix}.{stat}"
             logger.info(f"Stat being incremented is {stat}")
-            self._client.incr(stat, count, rate)
+            self._client.get_client().incr(stat, count, rate)
 
     def timer(self, stat: str, rate: float = 1.0):
         """
@@ -61,13 +75,16 @@ class ScopedStatsClient:
         if self.is_enabled():
             if self._scope_prefix:
                 stat = f"{self._scope_prefix}.{stat}"
-            return self._client.timer(stat, rate)
+            return self._client.get_client().timer(stat, rate)
         return None
+
+    def set_stats_client(self, stats_client: StatsClient) -> None:
+        self._client.set_client(stats_client)
 
 
 # Global _scoped_stats_client
 # Will be set when cartography.config.statsd_enabled is True
-_scoped_stats_client: ScopedStatsClient = ScopedStatsClient(None)
+_scoped_stats_client: ScopedStatsClient = ScopedStatsClient(_StatsClientWrapper(None))
 
 
 def set_stats_client(stats_client: StatsClient) -> None:
@@ -75,7 +92,7 @@ def set_stats_client(stats_client: StatsClient) -> None:
     This is used to set the module level stats client configured to talk with a statsd host
     """
     global _scoped_stats_client
-    _scoped_stats_client._client = stats_client
+    _scoped_stats_client.set_stats_client(stats_client)
 
 
 def get_stats_client(prefix: str) -> ScopedStatsClient:

--- a/cartography/stats.py
+++ b/cartography/stats.py
@@ -67,7 +67,7 @@ class ScopedStatsClient:
 
 # Global _scoped_stats_client
 # Will be set when cartography.config.statsd_enabled is True
-_scoped_stats_client: ScopedStatsClient = None
+_scoped_stats_client: ScopedStatsClient = ScopedStatsClient(None)
 
 
 def set_stats_client(stats_client: StatsClient) -> None:

--- a/cartography/stats.py
+++ b/cartography/stats.py
@@ -30,14 +30,13 @@ class ScopedStatsClient:
         else:
             prefix = f"{self._scope_prefix}.{scope}"
 
-        scoped_stats_client = ScopedStatsClient(prefix)
-        scoped_stats_client._parent = self
+        scoped_stats_client = ScopedStatsClient(prefix, self._root)
         return scoped_stats_client
 
+    @staticmethod
     def get_root_client() -> 'ScopedStatsClient':
         client = ScopedStatsClient()
         client._root = client
-
         return client
 
     def is_enabled(self) -> bool:

--- a/cartography/stats.py
+++ b/cartography/stats.py
@@ -74,7 +74,7 @@ def set_stats_client(stats_client: StatsClient) -> None:
     """
     This is used to set the module level stats client configured to talk with a statsd host
     """
-    global _stats_client1
+    global _stats_client
     _stats_client = stats_client
 
 

--- a/cartography/stats.py
+++ b/cartography/stats.py
@@ -65,17 +65,17 @@ class ScopedStatsClient:
         return None
 
 
-# Global _stats_client
+# Global _scoped_stats_client
 # Will be set when cartography.config.statsd_enabled is True
-_stats_client: StatsClient = None
+_scoped_stats_client: ScopedStatsClient = None
 
 
 def set_stats_client(stats_client: StatsClient) -> None:
     """
     This is used to set the module level stats client configured to talk with a statsd host
     """
-    global _stats_client
-    _stats_client = stats_client
+    global _scoped_stats_client
+    _scoped_stats_client._client = stats_client
 
 
 def get_stats_client(prefix: str) -> ScopedStatsClient:
@@ -83,4 +83,4 @@ def get_stats_client(prefix: str) -> ScopedStatsClient:
     Returns a ScopedStatsClient object, which is a simple wrapper over statsd.client.Statsclient
     that allows one to scope down the metric as needed
     """
-    return ScopedStatsClient(_stats_client, prefix)
+    return _scoped_stats_client.get_stats_client(prefix)

--- a/cartography/stats.py
+++ b/cartography/stats.py
@@ -1,4 +1,9 @@
+import logging
+
 from statsd import StatsClient
+
+
+logger = logging.getLogger(__name__)
 
 
 class ScopedStatsClient:
@@ -42,6 +47,7 @@ class ScopedStatsClient:
         if self.is_enabled():
             if self._scope_prefix:
                 stat = f"{self._scope_prefix}.{stat}"
+            logger.info(f"Stat being incremented is {stat}")
             self._client.incr(stat, count, rate)
 
     def timer(self, stat: str, rate: float = 1.0):
@@ -68,7 +74,7 @@ def set_stats_client(stats_client: StatsClient) -> None:
     """
     This is used to set the module level stats client configured to talk with a statsd host
     """
-    global _stats_client
+    global _stats_client1
     _stats_client = stats_client
 
 


### PR DESCRIPTION
Problem: 
Currently in an intelmodule we add two lines 
`from cartography.stats import get_stats_client`
`stat_handler = get_stats_client(__name__)`
When this is done, the base stats client points to None, and hence the stats_client pointed to by the stat_handler is also None
Later when the sync config initializes a new StatsClient, the base stats stats client now points to this object, however, the stats_client pointed to by the stat_handler is still None. 

Point to note: the timeit util function is always called after the sync config  initializes a new StatsClient, and it uses the base stats client, hence those metrics are being published as is.

However, incr doesn't work in the intelmodule.


Existing approach 

Part1 in the screenshot below:
Part 2 in the screenshot below shows why a slightly different approach doesn't work as well
![Image from iOS (3)](https://user-images.githubusercontent.com/77367521/113943501-afd95f80-97b7-11eb-8aee-ce320fe37715.jpg)

New approach which works

1. Base static ScopedStatsClient object is created (underlying StatsClient is None, _root is self, prefix is None)
2. When the intelmodule calls stats.get_stats_client, the returned ScopedStatsClient has prefix "intelmodule", _root is object from 1, underlying StatsClient is None
3. When the sync config is applied, and statsd is enabled, the underlying StatsClient for object (_client) from 1 is set to an actual StatsClient object configured to collect metrics
4. When the intelmodule is calling incr on object from 2, the ScopedStatsClient uses _root._client (_root is object from 1 and _root._client was set in step 3), and calls the StatsClient.incr (StatsClient is set! woohoo so the counter metric is published)

I've tested the change in Staging with our internal project, and publishing counter metrics works as expected.



