### PR TITLE
Fix for an Azure authentication bug when using a Service Principal

### DIFF
--- a/cartography/intel/azure/util/credentials.py
+++ b/cartography/intel/azure/util/credentials.py
@@ -153,11 +153,9 @@ class Authenticator:
                 resource='https://graph.windows.net',
             )
 
-            profile = get_cli_profile()
-
             return Credentials(
                 arm_credentials, aad_graph_credentials, tenant_id=tenant_id,
-                current_user=profile.get_current_account_user(),
+                current_user=client_id,
             )
 
         except HttpResponseError as e:


### PR DESCRIPTION
When using Service Principal authentication in the Azure intel module, there is a call to get the CLI profile (https://github.com/lyft/cartography/blob/1583dbe6e08ad5402012714db9b2a652506f2b76/cartography/intel/azure/util/credentials.py#L156) which doesn't exist for a Service Principal. When run in an environment that has not been used to authenticate at the command line (e.g. using az cmd line utility) the call will error and fail the Azure intel run even if correct Service Principal credentials have been passed to Cartography. This fix allows Service Principal authentication to work in a fresh environment, e.g. K8s CronJob. 

A quick way to replicate the issue this PR addresses is to delete the ~/.azure directory and then run with ServicePrincipal authentication. 