### PR TITLE
#605: AWS APIGateway: fixed bad placement of policy regexp

### DIFF
--- a/cartography/intel/aws/apigateway.py
+++ b/cartography/intel/aws/apigateway.py
@@ -329,9 +329,9 @@ def parse_policy(api_id: str, policy: Policy) -> Optional[Dict[Any, Any]]:
     Uses PolicyUniverse to parse API Gateway REST API policy and returns the internet accessibility results
     """
 
-    # unescape doubly escapped JSON
-    policy = policy.replace("\\", "")
     if policy is not None:
+        # unescape doubly escapped JSON
+        policy = policy.replace("\\", "")
         try:
             policy = Policy(json.loads(policy))
             if policy.is_internet_accessible():

--- a/tests/unit/cartography/intel/aws/test_apigateway.py
+++ b/tests/unit/cartography/intel/aws/test_apigateway.py
@@ -10,5 +10,8 @@ def test_parse_policy():
     assert(res['internet_accessible']) is not None
     assert(res['accessible_actions']) is not None
 
+
 def test_none_policy():
     res = parse_policy(None, None)
+
+    assert(res) is None

--- a/tests/unit/cartography/intel/aws/test_apigateway.py
+++ b/tests/unit/cartography/intel/aws/test_apigateway.py
@@ -9,3 +9,6 @@ def test_parse_policy():
     assert(res['api_id']) is not None
     assert(res['internet_accessible']) is not None
     assert(res['accessible_actions']) is not None
+
+def test_none_policy():
+    res = parse_policy(None, None)


### PR DESCRIPTION
In response to https://github.com/lyft/cartography/issues/605#issuecomment-828762272.

Fixed when policy is `None` and added unit test with this condition.