### PR TITLE
AWS KMS policy - log and skip failures

### DIFF
--- a/cartography/intel/aws/kms.py
+++ b/cartography/intel/aws/kms.py
@@ -61,14 +61,13 @@ def get_kms_key_details(
 @timeit
 def get_policy(key: Dict, client: botocore.client.BaseClient) -> Any:
     """
-    Gets the KMS Key policy. Returns policy string or None if no policy
+    Gets the KMS Key policy. Returns policy string or None if we are unable to retrieve it.
     """
     try:
         policy = client.get_key_policy(KeyId=key["KeyId"], PolicyName='default')
-    except ClientError as e:
+    except ClientError:
         policy = None
-        logger.warning("Failed to retrieve Key Policy for key id - {}. Error - {}".format(key["KeyId"], e))
-        raise
+        logger.warning(f"Failed to retrieve Key Policy for key id - {key['KeyId']}, skipping.", exc_info=True)
 
     return policy
 


### PR DESCRIPTION
If we fail to retrieve KMS key policies, log a warning and continue the sync.

The way the code was originally written with `policy = None` seems to  indicate that the intended behavior is to return this value, rather than `raise`.