### PR TITLE
Add attribute to config class, for custom intel module configuration

### DIFF
--- a/cartography/config.py
+++ b/cartography/config.py
@@ -64,6 +64,8 @@ class Config:
     :param statsd_host: If statsd_enabled is True, send metrics to this host. Optional.
     :type: statsd_port: int
     :param statsd_port: If statsd_enabled is True, send metrics to this port on statsd_host. Optional.
+    :type: custom_config: dict
+    :param custom_config: For use to pass in configuration data to custom intel modules. Optional.
     """
 
     def __init__(
@@ -96,6 +98,7 @@ class Config:
         statsd_prefix=None,
         statsd_host=None,
         statsd_port=None,
+        custom_config=None,
     ):
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user
@@ -125,3 +128,4 @@ class Config:
         self.statsd_prefix = statsd_prefix
         self.statsd_host = statsd_host
         self.statsd_port = statsd_port
+        self.custom_config = custom_config


### PR DESCRIPTION
This change adds an attribute to the Config class that can be used by custom intel modules.

Though it's possible to inject attributes into an existing object, mypy will (rightly) complain that the attribute doesn't exist in the class. To support this more directly, I've added a dict attribute that can be use for custom intel modules, where cartography is configured through a custom script runner.