### PR TITLE
Add Tag support for LoadBalancer & LoadBalancerV2

### DIFF
--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -41,12 +41,14 @@ def get_short_id_from_elb_arn(alb_arn: str) -> str:
     """
     return alb_arn.split('/')[-1]
 
-def get_short_id_from_alb_arn(alb_arn: str) -> str:
+
+def get_short_id_from_lb2_arn(alb_arn: str) -> str:
     """
-    Return the ALB name from the ARN
+    Return the (A|N)LB name from the ARN
     For example, for arn:aws:elasticloadbalancing:::loadbalancer/app/foo/ab123", return 'foo'.
-    :param arn: The ALB's full ARN
-    :return: The ALB's name
+    For example, for arn:aws:elasticloadbalancing:::loadbalancer/net/foo/ab123", return 'foo'.
+    :param arn: The (N|A)LB's full ARN
+    :return: The (N|A)LB's name
     """
     return alb_arn.split('/')[-2]
 
@@ -67,7 +69,8 @@ TAG_RESOURCE_TYPE_MAPPINGS: Dict = {
     'ec2:transit-gateway': {'label': 'AWSTransitGateway', 'property': 'id'},
     'ec2:transit-gateway-attachment': {'label': 'AWSTransitGatewayAttachment', 'property': 'id'},
     'elasticloadbalancing:loadbalancer': {'label': 'LoadBalancer', 'property': 'name', 'id_func': get_short_id_from_elb_arn},
-    'elasticloadbalancing:loadbalancer/app': {'label': 'LoadBalancerV2', 'property': 'name', 'id_func': get_short_id_from_alb_arn},
+    'elasticloadbalancing:loadbalancer/app': {'label': 'LoadBalancerV2', 'property': 'name', 'id_func': get_short_id_from_lb2_arn},
+    'elasticloadbalancing:loadbalancer/net': {'label': 'LoadBalancerV2', 'property': 'name', 'id_func': get_short_id_from_lb2_arn},
     'es:domain': {'label': 'ESDomain', 'property': 'id'},
     'redshift:cluster': {'label': 'RedshiftCluster', 'property': 'id'},
     'rds:db': {'label': 'RDSInstance', 'property': 'id'},

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -32,6 +32,24 @@ def get_bucket_name_from_arn(bucket_arn: str) -> str:
     """
     return bucket_arn.split(':')[-1]
 
+def get_short_id_from_elb_arn(alb_arn: str) -> str:
+    """
+    Return the ELB name from the ARN
+    For example, for arn:aws:elasticloadbalancing:::loadbalancer/foo", return 'foo'.
+    :param arn: The ELB's full ARN
+    :return: The ELB's name
+    """
+    return alb_arn.split('/')[-1]
+
+def get_short_id_from_alb_arn(alb_arn: str) -> str:
+    """
+    Return the ALB name from the ARN
+    For example, for arn:aws:elasticloadbalancing:::loadbalancer/app/foo/ab123", return 'foo'.
+    :param arn: The ALB's full ARN
+    :return: The ALB's name
+    """
+    return alb_arn.split('/')[-2]
+
 
 # We maintain a mapping from AWS resource types to their associated labels and unique identifiers.
 # label: the node label used in cartography for this resource type
@@ -48,6 +66,8 @@ TAG_RESOURCE_TYPE_MAPPINGS: Dict = {
     'ec2:vpc': {'label': 'AWSVpc', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:transit-gateway': {'label': 'AWSTransitGateway', 'property': 'id'},
     'ec2:transit-gateway-attachment': {'label': 'AWSTransitGatewayAttachment', 'property': 'id'},
+    'elasticloadbalancing:loadbalancer': {'label': 'LoadBalancer', 'property': 'name', 'id_func': get_short_id_from_elb_arn},
+    'elasticloadbalancing:loadbalancer/app': {'label': 'LoadBalancerV2', 'property': 'name', 'id_func': get_short_id_from_alb_arn},
     'es:domain': {'label': 'ESDomain', 'property': 'id'},
     'redshift:cluster': {'label': 'RedshiftCluster', 'property': 'id'},
     'rds:db': {'label': 'RDSInstance', 'property': 'id'},

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -32,6 +32,7 @@ def get_bucket_name_from_arn(bucket_arn: str) -> str:
     """
     return bucket_arn.split(':')[-1]
 
+
 def get_short_id_from_elb_arn(alb_arn: str) -> str:
     """
     Return the ELB name from the ARN
@@ -68,9 +69,18 @@ TAG_RESOURCE_TYPE_MAPPINGS: Dict = {
     'ec2:vpc': {'label': 'AWSVpc', 'property': 'id', 'id_func': get_short_id_from_ec2_arn},
     'ec2:transit-gateway': {'label': 'AWSTransitGateway', 'property': 'id'},
     'ec2:transit-gateway-attachment': {'label': 'AWSTransitGatewayAttachment', 'property': 'id'},
-    'elasticloadbalancing:loadbalancer': {'label': 'LoadBalancer', 'property': 'name', 'id_func': get_short_id_from_elb_arn},
-    'elasticloadbalancing:loadbalancer/app': {'label': 'LoadBalancerV2', 'property': 'name', 'id_func': get_short_id_from_lb2_arn},
-    'elasticloadbalancing:loadbalancer/net': {'label': 'LoadBalancerV2', 'property': 'name', 'id_func': get_short_id_from_lb2_arn},
+    'elasticloadbalancing:loadbalancer': {
+        'label': 'LoadBalancer', 'property':
+        'name', 'id_func': get_short_id_from_elb_arn,
+    },
+    'elasticloadbalancing:loadbalancer/app': {
+        'label': 'LoadBalancerV2',
+        'property': 'name', 'id_func': get_short_id_from_lb2_arn,
+    },
+    'elasticloadbalancing:loadbalancer/net': {
+        'label': 'LoadBalancerV2',
+        'property': 'name', 'id_func': get_short_id_from_lb2_arn,
+    },
     'es:domain': {'label': 'ESDomain', 'property': 'id'},
     'redshift:cluster': {'label': 'RedshiftCluster', 'property': 'id'},
     'rds:db': {'label': 'RDSInstance', 'property': 'id'},

--- a/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -26,13 +26,16 @@ def test_get_short_id_from_ec2_arn():
     arn = 'arn:aws:ec2:us-east-1:test_account:instance/i-1337'
     assert 'i-1337' == rgta.get_short_id_from_ec2_arn(arn)
 
+
 def test_get_short_id_from_elb_arn():
     arn = 'arn:aws:elasticloadbalancing:::loadbalancer/foo'
     assert 'foo' == rgta.get_short_id_from_elb_arn(arn)
 
+
 def test_get_short_id_from_alb_arn():
     arn = 'arn:aws:elasticloadbalancing:::loadbalancer/app/foo/abdc123'
     assert 'foo' == rgta.get_short_id_from_alb_arn(arn)
+
 
 def test_transform_tags():
     assert 'resource_id' not in test_data.GET_RESOURCES_RESPONSE[0]

--- a/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -32,9 +32,9 @@ def test_get_short_id_from_elb_arn():
     assert 'foo' == rgta.get_short_id_from_elb_arn(arn)
 
 
-def test_get_short_id_from_alb_arn():
+def test_get_short_id_from_lb2_arn():
     arn = 'arn:aws:elasticloadbalancing:::loadbalancer/app/foo/abdc123'
-    assert 'foo' == rgta.get_short_id_from_alb_arn(arn)
+    assert 'foo' == rgta.get_short_id_from_lb2_arn(arn)
 
 
 def test_transform_tags():

--- a/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -26,6 +26,13 @@ def test_get_short_id_from_ec2_arn():
     arn = 'arn:aws:ec2:us-east-1:test_account:instance/i-1337'
     assert 'i-1337' == rgta.get_short_id_from_ec2_arn(arn)
 
+def test_get_short_id_from_elb_arn():
+    arn = 'arn:aws:elasticloadbalancing:::loadbalancer/foo'
+    assert 'foo' == rgta.get_short_id_from_elb_arn(arn)
+
+def test_get_short_id_from_alb_arn():
+    arn = 'arn:aws:elasticloadbalancing:::loadbalancer/app/foo/abdc123'
+    assert 'foo' == rgta.get_short_id_from_alb_arn(arn)
 
 def test_transform_tags():
     assert 'resource_id' not in test_data.GET_RESOURCES_RESPONSE[0]


### PR DESCRIPTION
Extend the `resourcegroupstaggingapi` intel module with support for Load Balancer(V2) <> Tag relationships 
