### PR TITLE
Make run_analysis_job and run_cleanup_job read location configurable

### DIFF
--- a/cartography/util.py
+++ b/cartography/util.py
@@ -15,22 +15,22 @@ else:
 logger = logging.getLogger(__name__)
 
 
-def run_analysis_job(filename, neo4j_session, common_job_parameters):
+def run_analysis_job(filename, neo4j_session, common_job_parameters, package='cartography.data.jobs.analysis'):
     GraphJob.run_from_json(
         neo4j_session,
         read_text(
-            'cartography.data.jobs.analysis',
+            package,
             filename,
         ),
         common_job_parameters,
     )
 
 
-def run_cleanup_job(filename, neo4j_session, common_job_parameters):
+def run_cleanup_job(filename, neo4j_session, common_job_parameters, package='cartography.data.jobs.cleanup'):
     GraphJob.run_from_json(
         neo4j_session,
         read_text(
-            'cartography.data.jobs.cleanup',
+            package,
             filename,
         ),
         common_job_parameters,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pre-commit
 pytest>=4.6
+pytest-mock
 pytest-cov

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -1,0 +1,15 @@
+from cartography import util
+
+
+def test_run_analysis_job_default_package(mocker):
+    mocker.patch('cartography.util.GraphJob')
+    read_text_mock = mocker.patch('cartography.util.read_text')
+    util.run_analysis_job('test.json', mocker.Mock(), mocker.Mock())
+    read_text_mock.assert_called_once_with('cartography.data.jobs.analysis', 'test.json')
+
+
+def test_run_analysis_job_custom_package(mocker):
+    mocker.patch('cartography.util.GraphJob')
+    read_text_mock = mocker.patch('cartography.util.read_text')
+    util.run_analysis_job('test.json', mocker.Mock(), mocker.Mock(), package='a.b.c')
+    read_text_mock.assert_called_once_with('a.b.c', 'test.json')


### PR DESCRIPTION
When creating custom intel modules, it would be ideal to also be able to run analysis and cleanup jobs from a custom location as well.

This change updates the utils for running cleanup jobs and analysis jobs to add a package argument that will be passed into read_text. The default paths are kept as a default for the argument.