### PR TITLE
Add support for AWS Secrets Manager Secrets

### DIFF
--- a/cartography/data/indexes.cypher
+++ b/cartography/data/indexes.cypher
@@ -136,6 +136,7 @@ CREATE INDEX ON :S3Acl(id);
 CREATE INDEX ON :S3Bucket(id);
 CREATE INDEX ON :S3Bucket(name);
 CREATE INDEX ON :S3Bucket(arn);
+CREATE INDEX ON :SecretsManagerSecret(id);
 CREATE INDEX ON :User(arn);
 CREATE INDEX ON :AzureTenant(id);
 CREATE INDEX ON :AzurePrincipal(email);

--- a/cartography/data/jobs/cleanup/aws_import_secrets_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_secrets_cleanup.json
@@ -1,0 +1,8 @@
+{
+  "statements": [{
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(s:SecretsManagerSecret) WHERE s.lastupdated <> {UPDATE_TAG} WITH s LIMIT {LIMIT_SIZE} DETACH DELETE (s) return COUNT(*) as TotalCompleted",
+    "iterative": true,
+    "iterationsize": 100
+  }],
+  "name": "cleanup SecretsManagerSecret"
+}

--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -2,29 +2,16 @@ import logging
 from typing import Any
 from typing import Dict
 from typing import List
-from typing import Optional
 
 import boto3
 import neo4j
 
 from cartography.util import aws_handle_regions
+from cartography.util import dict_value_to_str
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
-
-
-@timeit
-def _dict_value_to_str(obj: Dict, key: str) -> Optional[str]:
-    """
-    Convert the value referenced by the key in the dict to a string, if it exists, and return it. If it doesn't exist,
-    return None.
-    """
-    value = obj.get(key)
-    if value is not None:
-        return str(value)
-    else:
-        return None
 
 
 @timeit
@@ -103,10 +90,10 @@ def load_rds_clusters(
         # TODO: track security groups
         # TODO: track subnet groups
 
-        cluster['EarliestRestorableTime'] = _dict_value_to_str(cluster, 'EarliestRestorableTime')
-        cluster['LatestRestorableTime'] = _dict_value_to_str(cluster, 'LatestRestorableTime')
-        cluster['ClusterCreateTime'] = _dict_value_to_str(cluster, 'ClusterCreateTime')
-        cluster['EarliestBacktrackTime'] = _dict_value_to_str(cluster, 'EarliestBacktrackTime')
+        cluster['EarliestRestorableTime'] = dict_value_to_str(cluster, 'EarliestRestorableTime')
+        cluster['LatestRestorableTime'] = dict_value_to_str(cluster, 'LatestRestorableTime')
+        cluster['ClusterCreateTime'] = dict_value_to_str(cluster, 'ClusterCreateTime')
+        cluster['EarliestBacktrackTime'] = dict_value_to_str(cluster, 'EarliestBacktrackTime')
         cluster['ScalingConfigurationInfoMinCapacity'] = cluster.get('ScalingConfigurationInfo', {}).get('MinCapacity')
         cluster['ScalingConfigurationInfoMaxCapacity'] = cluster.get('ScalingConfigurationInfo', {}).get('MaxCapacity')
         cluster['ScalingConfigurationInfoAutoPause'] = cluster.get('ScalingConfigurationInfo', {}).get('AutoPause')
@@ -207,8 +194,8 @@ def load_rds_instances(
         if rds.get('DBSubnetGroup'):
             subnets.append(rds)
 
-        rds['InstanceCreateTime'] = _dict_value_to_str(rds, 'InstanceCreateTime')
-        rds['LatestRestorableTime'] = _dict_value_to_str(rds, 'LatestRestorableTime')
+        rds['InstanceCreateTime'] = dict_value_to_str(rds, 'InstanceCreateTime')
+        rds['LatestRestorableTime'] = dict_value_to_str(rds, 'LatestRestorableTime')
         rds['EndpointAddress'] = ep.get('Address')
         rds['EndpointHostedZoneId'] = ep.get('HostedZoneId')
         rds['EndpointPort'] = ep.get('Port')

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -88,6 +88,7 @@ TAG_RESOURCE_TYPE_MAPPINGS: Dict = {
     'rds:cluster': {'label': 'RDSCluster', 'property': 'id'},
     # Buckets are the only objects in the S3 service: https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-arn-format.html
     's3': {'label': 'S3Bucket', 'property': 'id', 'id_func': get_bucket_name_from_arn},
+    'secretsmanager:secret': {'label': 'SecretsManagerSecret', 'property': 'id'},
 }
 
 

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -16,6 +16,7 @@ from . import redshift
 from . import resourcegroupstaggingapi
 from . import route53
 from . import s3
+from . import secretsmanager
 from .ec2.auto_scaling_groups import sync_ec2_auto_scaling_groups
 from .ec2.images import sync_ec2_images
 from .ec2.instances import sync_ec2_instances
@@ -62,4 +63,5 @@ RESOURCE_FUNCTIONS: Dict = {
     'permission_relationships': permission_relationships.sync,
     'resourcegroupstaggingapi': resourcegroupstaggingapi.sync,
     'apigateway': apigateway.sync,
+    'secretsmanager': secretsmanager.sync,
 }

--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -6,7 +6,7 @@ from typing import List
 import boto3
 import neo4j
 
-from cartography.util import dict_value_to_str
+from cartography.util import dict_date_to_epoch
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -47,11 +47,11 @@ def load_secrets(neo4j_session: neo4j.Session, data: List, current_aws_account_i
         secret['rotation_rules_automatically_after_days'] = secret.get(
             'RotationRules', {},
         ).get('AutomaticallyAfterDays')
-        secret['LastRotatedDate'] = dict_value_to_str(secret, 'LastRotatedDate')
-        secret['LastChangedDate'] = dict_value_to_str(secret, 'LastChangedDate')
-        secret['LastAccessedDate'] = dict_value_to_str(secret, 'LastAccessedDate')
-        secret['DeletedDate'] = dict_value_to_str(secret, 'DeletedDate')
-        secret['CreatedDate'] = dict_value_to_str(secret, 'CreatedDate')
+        secret['LastRotatedDate'] = dict_date_to_epoch(secret, 'LastRotatedDate')
+        secret['LastChangedDate'] = dict_date_to_epoch(secret, 'LastChangedDate')
+        secret['LastAccessedDate'] = dict_date_to_epoch(secret, 'LastAccessedDate')
+        secret['DeletedDate'] = dict_date_to_epoch(secret, 'DeletedDate')
+        secret['CreatedDate'] = dict_date_to_epoch(secret, 'CreatedDate')
 
     neo4j_session.run(
         ingest_secrets,

--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -1,0 +1,78 @@
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+
+import boto3
+import neo4j
+
+from cartography.util import dict_value_to_str
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def get_secret_list(boto3_session: boto3.session.Session) -> List[Dict]:
+    client = boto3_session.client('secretsmanager')
+    paginator = client.get_paginator('list_secrets')
+    secrets: List[Any] = []
+    for page in paginator.paginate():
+        secrets.extend(page['SecretList'])
+    return secrets
+
+
+@timeit
+def load_secrets(neo4j_session: neo4j.Session, data: List, current_aws_account_id: str, aws_update_tag: int) -> None:
+    ingest_secrets = """
+    UNWIND {Secrets} as secret
+        MERGE (s:SecretsManagerSecret{id: secret.ARN})
+        ON CREATE SET s.firstseen = timestamp()
+        SET s.name = secret.Name, s.description = secret.Description, s.kms_key_id = secret.KmsKeyId,
+            s.rotation_enabled = secret.RotationEnabled, s.rotation_lambda_arn = secret.RotationLambdaARN,
+            s.rotation_rules_automatically_after_days = secret.rotation_rules_automatically_after_days,
+            s.last_rotated_date = secret.LastRotatedDate, s.last_changed_date = secret.LastChangedDate,
+            s.last_accessed_date = secret.LastAccessedDate, s.deleted_date = secret.DeletedDate,
+            s.owning_service = secret.OwningService, s.created_date = secret.CreatedDate,
+            s.primary_region = secret.PrimaryRegion,
+            s.lastupdated = {aws_update_tag}
+        WITH s
+        MATCH (owner:AWSAccount{id: {AWS_ACCOUNT_ID}})
+        MERGE (owner)-[r:RESOURCE]->(s)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
+    """
+    for secret in data:
+        secret['rotation_rules_automatically_after_days'] = secret.get(
+            'RotationRules', {},
+        ).get('AutomaticallyAfterDays')
+        secret['LastRotatedDate'] = dict_value_to_str(secret, 'LastRotatedDate')
+        secret['LastChangedDate'] = dict_value_to_str(secret, 'LastChangedDate')
+        secret['LastAccessedDate'] = dict_value_to_str(secret, 'LastAccessedDate')
+        secret['DeletedDate'] = dict_value_to_str(secret, 'DeletedDate')
+        secret['CreatedDate'] = dict_value_to_str(secret, 'CreatedDate')
+
+    neo4j_session.run(
+        ingest_secrets,
+        Secrets=data,
+        AWS_ACCOUNT_ID=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+    )
+
+
+@timeit
+def cleanup_secrets(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
+    run_cleanup_job('aws_import_secrets_cleanup.json', neo4j_session, common_job_parameters)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session, boto3_session: boto3.session.Session, regions: List[str], current_aws_account_id: str,
+    update_tag: int, common_job_parameters: Dict,
+) -> None:
+    logger.info("Syncing Secrets Manager for account '%s'.", current_aws_account_id)
+    secrets = get_secret_list(boto3_session)
+
+    load_secrets(neo4j_session, secrets, current_aws_account_id, update_tag)
+    cleanup_secrets(neo4j_session, common_job_parameters)

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -101,3 +101,15 @@ def dict_value_to_str(obj: Dict, key: str) -> Optional[str]:
         return str(value)
     else:
         return None
+
+
+def dict_date_to_epoch(obj: Dict, key: str) -> Optional[int]:
+    """
+    Convert the date referenced by the key in the dict to an epoch timestamp, if it exists, and return it. If it
+    doesn't exist, return None.
+    """
+    value = obj.get(key)
+    if value is not None:
+        return int(value.timestamp())
+    else:
+        return None

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -1,6 +1,8 @@
 import logging
 import sys
 from functools import wraps
+from typing import Dict
+from typing import Optional
 
 import botocore
 
@@ -87,3 +89,15 @@ def aws_handle_regions(func):
             else:
                 raise
     return inner_function
+
+
+def dict_value_to_str(obj: Dict, key: str) -> Optional[str]:
+    """
+    Convert the value referenced by the key in the dict to a string, if it exists, and return it. If it doesn't exist,
+    return None.
+    """
+    value = obj.get(key)
+    if value is not None:
+        return str(value)
+    else:
+        return None

--- a/docs/schema/aws.md
+++ b/docs/schema/aws.md
@@ -133,6 +133,8 @@
   - [Relationships](#relationships-61)
 - [EC2ReservedInstance](#ec2reservedinstance)
   - [Relationships](#relationships-62)
+- [SecretsManagerSecret](#secretsmanagersecret)
+  - [Relationships](#relationships-63)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -2359,4 +2361,35 @@ Representation of an AWS [EC2 Reserved Instance](https://docs.aws.amazon.com/AWS
 
         ```
         (AWSAccount)-[RESOURCE]->(EC2ReservedInstance)
+        ```
+
+## SecretsManagerSecret
+
+Representation of an AWS [Secrets Manager Secret](https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_SecretListEntry.html)
+
+| Field | Description |
+|-------|-------------|
+| firstseen| Timestamp of when a sync job first discovered this node  |
+| lastupdated |  Timestamp of the last time the node was updated |
+| **id** | The arn of the secret. |
+| created\_date | The date and time when a secret was created. |
+| deleted\_date | The date and time the deletion of the secret occurred. Not present on active secrets. The secret can be recovered until the number of days in the recovery window has passed, as specified in the RecoveryWindowInDays parameter of the DeleteSecret operation. |
+| description | The user-provided description of the secret. |
+| kms\_key\_id | The ARN or alias of the AWS KMS customer master key (CMK) used to encrypt the SecretString and SecretBinary fields in each version of the secret. If you don't provide a key, then Secrets Manager defaults to encrypting the secret fields with the default KMS CMK, the key named awssecretsmanager, for this account. |
+| last\_accessed\_date | The last date that this secret was accessed. This value is truncated to midnight of the date and therefore shows only the date, not the time. |
+| last\_changed\_date | The last date and time that this secret was modified in any way. |
+| last\_rotated\_date | The most recent date and time that the Secrets Manager rotation process was successfully completed. This value is null if the secret hasn't ever rotated. |
+| name | The friendly name of the secret. You can use forward slashes in the name to represent a path hierarchy. For example, /prod/databases/dbserver1 could represent the secret for a server named dbserver1 in the folder databases in the folder prod. |
+| owning\_service | Returns the name of the service that created the secret. |
+| primary\_region | The Region where Secrets Manager originated the secret. |
+| rotation\_enabled | Indicates whether automatic, scheduled rotation is enabled for this secret. |
+| rotation\_lambda\_arn | The ARN of an AWS Lambda function invoked by Secrets Manager to rotate and expire the secret either automatically per the schedule or manually by a call to RotateSecret. |
+| rotation\_rules\_automatically\_after\_days | Specifies the number of days between automatic scheduled rotations of the secret. |
+
+### Relationships
+
+- AWS Secrets Manager Secrets are a resource under the AWS Account.
+
+        ```
+        (AWSAccount)-[RESOURCE]->(SecretsManagerSecret)
         ```

--- a/docs/schema/aws.md
+++ b/docs/schema/aws.md
@@ -156,8 +156,10 @@ Representation of an AWS Account.
         ```
         (AWSAccount)-[RESOURCE]->(AWSDNSZone,
                               AWSGroup,
+                              AWSLambda,
                               AWSPrincipal,
                               AWSUser,
+                              AWSVpc,
                               AutoScalingGroup,
                               DNSZone,
                               DynamoDBTable,
@@ -168,7 +170,9 @@ Representation of an AWS Account.
                               EC2SecurityGroup,
                               ESDomain,
                               LoadBalancer,
-                              AWSVpc)
+                              RDSCluster,
+                              RDSInstance,
+                              SecretsManagerSecret)
         ```
 
 - An `AWSPolicy` node is defined for an `AWSAccount`.

--- a/tests/data/aws/secretsmanager.py
+++ b/tests/data/aws/secretsmanager.py
@@ -1,0 +1,27 @@
+import datetime
+
+LIST_SECRETS = [
+    {
+        'ARN': 'arn:aws:secretsmanager:us-east-1:000000000000:secret:test-secret-1-000000',
+        'Name': 'test-secret-1',
+        'Description': 'This is a test secret',
+        'RotationEnabled': True,
+        'RotationRules': {'AutomaticallyAfterDays': 90},
+        'RotationLambdaARN': 'arn:aws:lambda:us-east-1:000000000000:function:test-secret-rotate',
+        'KmsKeyId': 'arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-0000-000000000000',
+        'CreatedDate': datetime.datetime(2014, 4, 16, 18, 14, 49),
+        'LastRotatedDate': datetime.datetime(2014, 4, 16, 18, 14, 49),
+        'LastChangedDate': datetime.datetime(2014, 4, 16, 18, 14, 49),
+        'LastAccessedDate': datetime.datetime(2014, 4, 16, 18, 14, 49),
+        'PrimaryRegion': 'us-west-1',
+    },
+    {
+        'ARN': 'arn:aws:secretsmanager:us-east-1:000000000000:secret:test-secret-2-000000',
+        'Name': 'test-secret-2',
+        'Description': 'This is another test secret',
+        'RotationEnabled': False,
+        'CreatedDate': datetime.datetime(2014, 4, 16, 18, 14, 49),
+        'LastChangedDate': datetime.datetime(2014, 4, 16, 18, 14, 49),
+        'LastAccessedDate': datetime.datetime(2014, 4, 16, 18, 14, 49),
+    },
+]

--- a/tests/integration/cartography/intel/aws/test_secretsmanager.py
+++ b/tests/integration/cartography/intel/aws/test_secretsmanager.py
@@ -1,0 +1,54 @@
+import cartography.intel.aws.secretsmanager
+import tests.data.aws.secretsmanager
+
+
+TEST_ACCOUNT_ID = '000000000000'
+TEST_REGION = 'us-east-1'
+TEST_UPDATE_TAG = 123456789
+
+
+def test_load_load_secrets(neo4j_session, *args):
+    """
+    Ensure that expected buckets get loaded with their key fields.
+    """
+    data = tests.data.aws.secretsmanager.LIST_SECRETS
+    cartography.intel.aws.secretsmanager.load_secrets(neo4j_session, data, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+    expected_nodes = {
+        (
+            "test-secret-1",
+            True,
+            90,
+            "arn:aws:lambda:us-east-1:000000000000:function:test-secret-rotate",
+            "arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-0000-000000000000",
+            "us-west-1",
+        ),
+        (
+            "test-secret-2",
+            False,
+            None,
+            None,
+            None,
+            None,
+        ),
+    }
+
+    nodes = neo4j_session.run(
+        """
+        MATCH (s:SecretsManagerSecret)
+        RETURN s.name, s.rotation_enabled, s.rotation_rules_automatically_after_days,
+        s.rotation_lambda_arn, s.kms_key_id, s.primary_region
+        """,
+    )
+    actual_nodes = {
+        (
+            n['s.name'],
+            n['s.rotation_enabled'],
+            n['s.rotation_rules_automatically_after_days'],
+            n['s.rotation_lambda_arn'],
+            n['s.kms_key_id'],
+            n['s.primary_region'],
+        )
+        for n in nodes
+    }
+    assert actual_nodes == expected_nodes

--- a/tests/integration/cartography/intel/aws/test_secretsmanager.py
+++ b/tests/integration/cartography/intel/aws/test_secretsmanager.py
@@ -22,7 +22,7 @@ def test_load_load_secrets(neo4j_session, *args):
             "arn:aws:lambda:us-east-1:000000000000:function:test-secret-rotate",
             "arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-0000-000000000000",
             "us-west-1",
-            1397639689,
+            1397672089,
         ),
         (
             "test-secret-2",
@@ -31,7 +31,7 @@ def test_load_load_secrets(neo4j_session, *args):
             None,
             None,
             None,
-            1397639689,
+            1397672089,
         ),
     }
 

--- a/tests/integration/cartography/intel/aws/test_secretsmanager.py
+++ b/tests/integration/cartography/intel/aws/test_secretsmanager.py
@@ -22,6 +22,7 @@ def test_load_load_secrets(neo4j_session, *args):
             "arn:aws:lambda:us-east-1:000000000000:function:test-secret-rotate",
             "arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-0000-000000000000",
             "us-west-1",
+            1397639689,
         ),
         (
             "test-secret-2",
@@ -30,6 +31,7 @@ def test_load_load_secrets(neo4j_session, *args):
             None,
             None,
             None,
+            1397639689,
         ),
     }
 
@@ -37,7 +39,7 @@ def test_load_load_secrets(neo4j_session, *args):
         """
         MATCH (s:SecretsManagerSecret)
         RETURN s.name, s.rotation_enabled, s.rotation_rules_automatically_after_days,
-        s.rotation_lambda_arn, s.kms_key_id, s.primary_region
+        s.rotation_lambda_arn, s.kms_key_id, s.primary_region, s.last_changed_date
         """,
     )
     actual_nodes = {
@@ -48,6 +50,7 @@ def test_load_load_secrets(neo4j_session, *args):
             n['s.rotation_lambda_arn'],
             n['s.kms_key_id'],
             n['s.primary_region'],
+            n['s.last_changed_date'],
         )
         for n in nodes
     }


### PR DESCRIPTION
This change adds support for AWS secret manager secrets (just the metadata, not the decrypted secrets), adds a RESOURCE relationship with the account, and adds a TAGGED relationship with the tags for the secrets.