### PR TITLE
Sync AWS Secret Manager data from all regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can learn more about the story behind Cartography in our [presentation at BS
 Start [here](docs/setup/install.md).
 
 ## Supported platforms
-- [Amazon Web Services](docs/setup/config/aws.md) -  API Gateway, EC2, Elasticsearch, Elastic Kubernetes Service, DynamoDB, IAM, KMS, Lambda, RDS, Redshift, Route53, S3, STS, Tags
+- [Amazon Web Services](docs/setup/config/aws.md) -  API Gateway, EC2, Elasticsearch, Elastic Kubernetes Service, DynamoDB, IAM, KMS, Lambda, RDS, Redshift, Route53, S3, Secrets Manager, STS, Tags
 - [Google Cloud Platform](docs/setup/config/gcp.md) - Cloud Resource Manager, Compute, DNS, Storage, Google Kubernetes Engine
 - [Google GSuite](docs/setup/config/gsuite.md) - users, groups
 - [Duo CRXcavator](docs/setup/config/crxcavator.md) - Chrome extensions, GSuite users

--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -5,6 +5,7 @@ from typing import List
 import boto3
 import neo4j
 
+from cartography.util import aws_handle_regions
 from cartography.util import dict_date_to_epoch
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -13,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 @timeit
+@aws_handle_regions
 def get_secret_list(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
     client = boto3_session.client('secretsmanager', region_name=region)
     paginator = client.get_paginator('list_secrets')

--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 @timeit
-def get_secret_list(boto3_session: boto3.session.Session) -> List[Dict]:
-    client = boto3_session.client('secretsmanager')
+def get_secret_list(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
+    client = boto3_session.client('secretsmanager', region_name=region)
     paginator = client.get_paginator('list_secrets')
     secrets: List[Dict] = []
     for page in paginator.paginate():
@@ -26,6 +26,7 @@ def get_secret_list(boto3_session: boto3.session.Session) -> List[Dict]:
 def load_secrets(
     neo4j_session: neo4j.Session,
     data: List[Dict],
+    region: str,
     current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
@@ -39,7 +40,7 @@ def load_secrets(
             s.last_rotated_date = secret.LastRotatedDate, s.last_changed_date = secret.LastChangedDate,
             s.last_accessed_date = secret.LastAccessedDate, s.deleted_date = secret.DeletedDate,
             s.owning_service = secret.OwningService, s.created_date = secret.CreatedDate,
-            s.primary_region = secret.PrimaryRegion,
+            s.primary_region = secret.PrimaryRegion, s.region = {Region},
             s.lastupdated = {aws_update_tag}
         WITH s
         MATCH (owner:AWSAccount{id: {AWS_ACCOUNT_ID}})
@@ -57,6 +58,7 @@ def load_secrets(
     neo4j_session.run(
         ingest_secrets,
         Secrets=data,
+        Region=region,
         AWS_ACCOUNT_ID=current_aws_account_id,
         aws_update_tag=aws_update_tag,
     )
@@ -72,8 +74,8 @@ def sync(
     neo4j_session: neo4j.Session, boto3_session: boto3.session.Session, regions: List[str], current_aws_account_id: str,
     update_tag: int, common_job_parameters: Dict,
 ) -> None:
-    logger.info("Syncing Secrets Manager for account '%s'.", current_aws_account_id)
-    secrets = get_secret_list(boto3_session)
-
-    load_secrets(neo4j_session, secrets, current_aws_account_id, update_tag)
+    for region in regions:
+        logger.info("Syncing Secrets Manager for region '%s' in account '%s'.", region, current_aws_account_id)
+        secrets = get_secret_list(boto3_session, region)
+        load_secrets(neo4j_session, secrets, region, current_aws_account_id, update_tag)
     cleanup_secrets(neo4j_session, common_job_parameters)

--- a/tests/integration/cartography/intel/aws/test_secretsmanager.py
+++ b/tests/integration/cartography/intel/aws/test_secretsmanager.py
@@ -47,7 +47,7 @@ def test_load_load_secrets(neo4j_session, *args):
         """
         MATCH (s:SecretsManagerSecret)
         RETURN s.name, s.rotation_enabled, s.rotation_rules_automatically_after_days,
-        s.rotation_lambda_arn, s.kms_key_id, s.primary_region, s.last_changed_date
+        s.rotation_lambda_arn, s.kms_key_id, s.primary_region, s.region, s.last_changed_date
         """,
     )
     actual_nodes = {
@@ -58,6 +58,7 @@ def test_load_load_secrets(neo4j_session, *args):
             n['s.rotation_lambda_arn'],
             n['s.kms_key_id'],
             n['s.primary_region'],
+            n['s.region'],
             n['s.last_changed_date'],
         )
         for n in nodes

--- a/tests/integration/cartography/intel/aws/test_secretsmanager.py
+++ b/tests/integration/cartography/intel/aws/test_secretsmanager.py
@@ -12,7 +12,13 @@ def test_load_load_secrets(neo4j_session, *args):
     Ensure that expected buckets get loaded with their key fields.
     """
     data = tests.data.aws.secretsmanager.LIST_SECRETS
-    cartography.intel.aws.secretsmanager.load_secrets(neo4j_session, data, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    cartography.intel.aws.secretsmanager.load_secrets(
+        neo4j_session,
+        data,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
 
     expected_nodes = {
         (
@@ -22,6 +28,7 @@ def test_load_load_secrets(neo4j_session, *args):
             "arn:aws:lambda:us-east-1:000000000000:function:test-secret-rotate",
             "arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-0000-000000000000",
             "us-west-1",
+            "us-east-1",
             1397672089,
         ),
         (
@@ -31,6 +38,7 @@ def test_load_load_secrets(neo4j_session, *args):
             None,
             None,
             None,
+            "us-east-1",
             1397672089,
         ),
     }


### PR DESCRIPTION
This change syncs secret manager data for all regions, rather than just the region that cartography is being run from.