### PR TITLE
Fix Azure library errors in azure-mgmt-sql

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "azure-mgmt-cosmosdb>=6.0.0",
         "msrestazure >= 0.6.4",
         "azure-mgmt-storage>=16.0.0",
-        "azure-mgmt-sql==1.0.0",
+        "azure-mgmt-sql<=1.0.0",
         "azure-identity>=1.5.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "packaging",
         "cryptography<3.4,>=3.2",
         "python-digitalocean>=1.16.0",
-        "PyJWT==1.7.1",     # azure-cli-core has pinned the PyJWT version as 1.7.1
+        "PyJWT>=2.1.0",
         "adal>=1.2.4",
         "azure-cli-core>=2.12.0",
         "azure-mgmt-compute>=5.0.0",
@@ -51,7 +51,7 @@ setup(
         "azure-mgmt-cosmosdb>=6.0.0",
         "msrestazure >= 0.6.4",
         "azure-mgmt-storage>=16.0.0",
-        "azure-mgmt-sql>=0.11.0",
+        "azure-mgmt-sql==1.0.0",
         "azure-identity>=1.5.0",
     ],
     extras_require={


### PR DESCRIPTION
This PR pins the version of azure-mgmt-sql to version 1.0.0 and updates the PyJWT library to match the referenced library version in azure-cli-core. 

As referenced [here](https://pypi.org/project/azure-mgmt-sql/) version 2 of the azure-mgmt-sql library introduced many breaking changes and I experienced our Azure sync failing when getting an SQL servers Threat Detection Policy which was one of the breaking changes made. 

I've tested this and it works again with the pinned version as otherwise it will get the latest version which is currently 3.0.1 and will not work. 