### PR TITLE
#664: Decomp Okta cleanups

### DIFF
--- a/cartography/data/jobs/cleanup/okta_groups_cleanup.json
+++ b/cartography/data/jobs/cleanup/okta_groups_cleanup.json
@@ -1,0 +1,17 @@
+{
+  "statements": [
+    {
+      "query": "MATCH (:OktaOrganization{id: {OKTA_ORG_ID}})-[:RESOURCE]->(:OktaGroup)<-[r:MEMBER_OF_OKTA_GROUP]-(:OktaUser) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100,
+      "__comment__": "Delete stale OktaUser relationship to OktaGroup"
+    },
+    {
+      "query": "MATCH (:OktaOrganization{id: {OKTA_ORG_ID}})-[:RESOURCE]->(n:OktaGroup) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100,
+      "__comment__": "Delete stale OktaGroup"
+    }
+  ],
+  "name": "Okta groups cleanup"
+}

--- a/cartography/data/jobs/cleanup/okta_import_cleanup.json
+++ b/cartography/data/jobs/cleanup/okta_import_cleanup.json
@@ -25,18 +25,6 @@
       "__comment__": "Delete Stale OktaGroup to AWSRole ALLOWED_BY relationship"
     },
     {
-      "query": "MATCH (:OktaOrganization{id: {OKTA_ORG_ID}})-[:RESOURCE]->(:OktaGroup)<-[r:MEMBER_OF_OKTA_GROUP]-(:OktaUser) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
-      "iterative": true,
-      "iterationsize": 100,
-      "__comment__": "Delete stale OktaUser relationship to OktaGroup"
-    },
-    {
-      "query": "MATCH (:OktaOrganization{id: {OKTA_ORG_ID}})-[:RESOURCE]->(n:OktaGroup) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
-      "iterative": true,
-      "iterationsize": 100,
-      "__comment__": "Delete stale OktaGroup"
-    },
-    {
       "query": "MATCH (:OktaOrganization{id: {OKTA_ORG_ID}})-[:RESOURCE]->(n:OktaApplication) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
       "iterative": true,
       "iterationsize": 100,

--- a/cartography/intel/okta/__init__.py
+++ b/cartography/intel/okta/__init__.py
@@ -28,8 +28,12 @@ def _cleanup_okta_organizations(neo4j_session: neo4j.Session, common_job_paramet
     :param common_job_parameters: Parameters to carry to the cleanup job
     :return: Nothing
     """
-
     run_cleanup_job('okta_import_cleanup.json', neo4j_session, common_job_parameters)
+    cleanup_okta_groups(neo4j_session, common_job_parameters)
+
+
+def cleanup_okta_groups(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
+    run_cleanup_job('okta_groups_cleanup.json', neo4j_session, common_job_parameters)
 
 
 @timeit

--- a/cartography/intel/okta/applications.py
+++ b/cartography/intel/okta/applications.py
@@ -394,7 +394,7 @@ def sync_okta_applications(
     :param okta_api_key: Okta api key
     :return: Nothing
     """
-    logger.debug("Syncing Okta Applications")
+    logger.info("Syncing Okta Applications")
 
     api_client = create_api_client(okta_org_id, "/api/v1/apps", okta_api_key)
 

--- a/cartography/intel/okta/awssaml.py
+++ b/cartography/intel/okta/awssaml.py
@@ -121,7 +121,7 @@ def sync_okta_aws_saml(neo4j_session: neo4j.Session, mapping_regex: str, okta_up
     :param okta_api_key: Okta api key
     :return: Nothing
     """
-    logger.debug("Syncing Okta SAML Integration")
+    logger.info("Syncing Okta SAML Integration")
 
     # Query for the aws application and its associated groups
     group_to_role_mapping = query_for_okta_to_aws_role_mapping(neo4j_session, mapping_regex)

--- a/cartography/intel/okta/factors.py
+++ b/cartography/intel/okta/factors.py
@@ -144,7 +144,7 @@ def sync_users_factors(
     :return: Nothing
     """
 
-    logger.debug("Syncing Okta User Factors")
+    logger.info("Syncing Okta User Factors")
 
     factor_client = _create_factor_client(okta_org_id, okta_api_key)
 

--- a/cartography/intel/okta/groups.py
+++ b/cartography/intel/okta/groups.py
@@ -77,7 +77,7 @@ def _get_okta_group_members(api_client: ApiClient, group_id: str) -> List[str]:
                 }
                 paged_response = api_client.get_path(f'/{group_id}/users', params)
         except OktaError as okta_error:
-            logger.debug(f"Got error while going through list group member {okta_error}")
+            logger.error(f"Got error while going through list group member {okta_error}")
             break
 
         member_list.append(paged_response.text)
@@ -270,7 +270,7 @@ def sync_okta_groups(
     :param sync_state: Okta sync state
     :return: Nothing
     """
-    logger.debug("Syncing Okta groups")
+    logger.info("Syncing Okta groups")
     api_client = create_api_client(okta_org_id, "/api/v1/groups", okta_api_key)
 
     okta_group_data = _get_okta_groups(api_client)

--- a/cartography/intel/okta/origins.py
+++ b/cartography/intel/okta/origins.py
@@ -116,7 +116,7 @@ def sync_trusted_origins(
     :return: Nothing
     """
 
-    logger.debug("Syncing Okta Trusted Origins")
+    logger.info("Syncing Okta Trusted Origins")
 
     api_client = create_api_client(okta_org_id, "/api/v1/trustedOrigins", okta_api_key)
 

--- a/cartography/intel/okta/roles.py
+++ b/cartography/intel/okta/roles.py
@@ -164,7 +164,7 @@ def sync_roles(
     :return: None
     """
 
-    logger.debug("Syncing Okta Roles")
+    logger.info("Syncing Okta Roles")
 
     # get API client
     api_client = create_api_client(okta_org_id, "/api/v1/users", okta_api_key)

--- a/cartography/intel/okta/users.py
+++ b/cartography/intel/okta/users.py
@@ -185,7 +185,7 @@ def sync_okta_users(
     :return: Nothing
     """
 
-    logger.debug("Syncing Okta users")
+    logger.info("Syncing Okta users")
     user_client = _create_user_client(okta_org_id, okta_api_key)
     data = _get_okta_users(user_client)
     users_data, user_ids = transform_okta_user_list(data)

--- a/tests/integration/cartography/intel/okta/groups.py
+++ b/tests/integration/cartography/intel/okta/groups.py
@@ -1,0 +1,30 @@
+from cartography.intel.okta import cleanup_okta_groups
+
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = 'ORG_ID'
+
+COMMON_JOB_PARAMETERS = {'UPDATE_TAG': TEST_UPDATE_TAG, 'OKTA_ORG_ID': TEST_ORG_ID}
+
+
+def test_cleanup_okta_groups(neo4j_session):
+    # Arrange
+    neo4j_session.run(
+        'MERGE (:OktaOrganization{id: {ORG_ID}})-[:RESOURCE]->(:OktaGroup{id: "Group ID", lastupdated: 0000})',
+        ORG_ID=TEST_ORG_ID,
+    )
+
+    # Assert 1: a group exists
+    expected_nodes = {('Group ID')}
+    nodes = neo4j_session.run("MATCH (g:OktaGroup) RETURN g.id")
+    actual_nodes = {(n['g.id']) for n in nodes}
+    assert actual_nodes == expected_nodes
+
+    # Act
+    cleanup_okta_groups(neo4j_session, COMMON_JOB_PARAMETERS)
+
+    # Assert 2: the group was cleaned up
+    expected_nodes = set()
+    nodes = neo4j_session.run("MATCH (g:OktaGroup) RETURN g.id")
+    actual_nodes = set([(n['g.id']) for n in nodes])
+    assert actual_nodes == expected_nodes

--- a/tests/integration/cartography/intel/okta/groups.py
+++ b/tests/integration/cartography/intel/okta/groups.py
@@ -26,5 +26,5 @@ def test_cleanup_okta_groups(neo4j_session):
     # Assert 2: the group was cleaned up
     expected_nodes = set()
     nodes = neo4j_session.run("MATCH (g:OktaGroup) RETURN g.id")
-    actual_nodes = set([(n['g.id']) for n in nodes])
+    actual_nodes = {(n['g.id']) for n in nodes}
     assert actual_nodes == expected_nodes


### PR DESCRIPTION
Paying back some tech debt in small pieces. This PR:

- Splits Okta group cleanup apart from the main larger cleanup job
- Adds integration tests
- Adjusts Okta log levels from debug to info