### PR TITLE
Remove PyJWT as explicit dep in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         "packaging",
         "cryptography<3.4,>=3.2",
         "python-digitalocean>=1.16.0",
-        "PyJWT>=2.1.0",
         "adal>=1.2.4",
         "azure-cli-core>=2.12.0",
         "azure-mgmt-compute>=5.0.0",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.42.0'
+__version__ = '0.42.1'
 
 
 setup(


### PR DESCRIPTION
In my production venv, I'm running into package version conflicts with PyJWT. Since cartography only uses PyJWT as a dependency of a dependency and not directly, I think it should be better to remove it from our setup.py.

cc: @jg10 