### PR TITLE
Test auto-approval in repositories without owners

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,2 @@
 This project is governed by [Lyft's code of conduct](https://github.com/lyft/code-of-conduct).
-All contributors and participants agree to abide by its terms.
+All contributors and participants agree to abide by its terms.  PRs should be approved by someone other than the submitter.


### PR DESCRIPTION
In this PR, we make a change to a file that is not covered by `OWNERS`, to see if it auto-approves.