### PR TITLE
Fix #665, #678 - Improve GraphStatement transactions

### DIFF
--- a/cartography/graph/job.py
+++ b/cartography/graph/job.py
@@ -83,7 +83,7 @@ class GraphJob:
         Create a job from a JSON file.
         """
         with open(file_path) as j_file:
-            data = json.load(j_file)
+            data: Dict = json.load(j_file)
 
         job_name = os.path.splitext(file_path)[0]
         statements: List[GraphStatement] = _get_statements_from_json(data, job_name)

--- a/cartography/graph/statement.py
+++ b/cartography/graph/statement.py
@@ -110,7 +110,7 @@ class GraphStatement:
             result: neo4j.StatementResult = session.write_transaction(self._run_noniterative)
 
             # Exit if we have finished processing all items
-            if not result.summary().counters.contains_updates():
+            if not result.summary().counters.contains_updates:
                 # Ensure network buffers are cleared
                 result.consume()
                 break

--- a/cartography/graph/statement.py
+++ b/cartography/graph/statement.py
@@ -1,6 +1,9 @@
 import json
 import logging
+import os
+from pathlib import Path
 from typing import Dict
+from typing import Union
 
 import neo4j
 
@@ -22,6 +25,12 @@ class GraphStatementJSONEncoder(json.JSONEncoder):
         else:
             # Let the default encoder roll up the exception.
             return json.JSONEncoder.default(self, obj)
+
+
+# TODO move this cartography.util after we move util.run_*_job to cartography.graph.job.
+def get_job_shortname(file_path: Union[Path, str]) -> str:
+    # Return filename without path and extension
+    return os.path.splitext(file_path)[0]
 
 
 class GraphStatement:
@@ -117,7 +126,7 @@ class GraphStatement:
             result.consume()
 
     @classmethod
-    def create_from_json(cls, json_obj: Dict, parent_job_name: str = None, parent_job_sequence_num: int = None):
+    def create_from_json(cls, json_obj: Dict, short_job_name: str = None, job_sequence_num: int = None):
         """
         Create a statement from a JSON blob.
         """
@@ -126,16 +135,16 @@ class GraphStatement:
             json_obj.get("parameters", {}),
             json_obj.get("iterative", False),
             json_obj.get("iterationsize", 0),
-            parent_job_name,
-            parent_job_sequence_num,
+            short_job_name,
+            job_sequence_num,
         )
 
     @classmethod
-    def create_from_json_file(cls, file_path: str):
+    def create_from_json_file(cls, file_path: Path):
         """
         Create a statement from a JSON file.
         """
         with open(file_path) as json_file:
             data = json.load(json_file)
 
-        return cls.create_from_json(data)
+        return cls.create_from_json(data, get_job_shortname(file_path))

--- a/cartography/graph/statement.py
+++ b/cartography/graph/statement.py
@@ -45,13 +45,10 @@ class GraphStatement:
         """
         Run the statement. This will execute the query against the graph.
         """
-        tx: neo4j.Transaction = session.begin_transaction()
         if self.iterative:
-            self._run_iterative(tx)
+            self._run_iterative()
         else:
-            data: neo4j.StatementResult = self._run(tx)
-            data.consume()
-        tx.commit()
+            session.write_transaction(self._run)
 
     def as_dict(self):
         """
@@ -70,7 +67,7 @@ class GraphStatement:
         """
         return tx.run(self.query, self.parameters)
 
-    def _run_iterative(self, tx: neo4j.Transaction) -> None:
+    def _run_iterative(self) -> None:
         """
         Iterative statement execution.
 
@@ -79,7 +76,7 @@ class GraphStatement:
         self.parameters["LIMIT_SIZE"] = self.iterationsize
 
         while True:
-            result: neo4j.StatementResult = self._run(tx)
+            result: neo4j.StatementResult = session.write_transaction(self._run)
             record: neo4j.Record = result.single()
 
             # TODO: use the BoltStatementResultSummary object to determine the number of items processed

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -8,6 +8,7 @@ import botocore
 import neo4j
 
 from cartography.graph.job import GraphJob
+from cartography.graph.statement import get_job_shortname
 from cartography.stats import get_stats_client
 
 if sys.version_info >= (3, 7):
@@ -26,12 +27,13 @@ def run_analysis_job(filename, neo4j_session, common_job_parameters, package='ca
             filename,
         ),
         common_job_parameters,
+        get_job_shortname(filename),
     )
 
 
 def run_cleanup_job(
     filename: str, neo4j_session: neo4j.Session, common_job_parameters: Dict,
-    package:str = 'cartography.data.jobs.cleanup',
+    package: str = 'cartography.data.jobs.cleanup',
 ) -> None:
     GraphJob.run_from_json(
         neo4j_session,
@@ -40,6 +42,7 @@ def run_cleanup_job(
             filename,
         ),
         common_job_parameters,
+        get_job_shortname(filename),
     )
 
 

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -5,6 +5,7 @@ from typing import Dict
 from typing import Optional
 
 import botocore
+import neo4j
 
 from cartography.graph.job import GraphJob
 from cartography.stats import get_stats_client
@@ -28,7 +29,10 @@ def run_analysis_job(filename, neo4j_session, common_job_parameters, package='ca
     )
 
 
-def run_cleanup_job(filename, neo4j_session, common_job_parameters, package='cartography.data.jobs.cleanup'):
+def run_cleanup_job(
+    filename: str, neo4j_session: neo4j.Session, common_job_parameters: Dict,
+    package:str = 'cartography.data.jobs.cleanup',
+) -> None:
     GraphJob.run_from_json(
         neo4j_session,
         read_text(

--- a/tests/data/jobs/sample.py
+++ b/tests/data/jobs/sample.py
@@ -1,0 +1,19 @@
+SAMPLE_CLEANUP_JOB = """
+{
+  "statements": [
+    {
+      "query": "MATCH(:TypeA)-[r:REL]->(:TypeB) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE r",
+      "iterative": true,
+      "iterationsize": 100
+    },{
+      "query": "MATCH (n:TypeA) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    },{
+      "query": "MATCH (n:TypeB) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    }],
+  "name": "cleanup stale resources"
+}
+"""

--- a/tests/integration/cartography/data/jobs/test_cleanup_jobs.py
+++ b/tests/integration/cartography/data/jobs/test_cleanup_jobs.py
@@ -1,0 +1,102 @@
+from unittest import mock
+from cartography.util import run_cleanup_job
+import cartography.util
+
+
+UPDATE_TAG_T1 = 111111
+UPDATE_TAG_T2 = 222222
+UPDATE_TAG_T3 = 333333
+
+SAMPLE_CLEANUP_JOB = """
+{
+  "statements": [
+    {
+      "query": "MATCH (:NodeTypeA)-[r:RELATION]->(:NodeTypeB) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE r",
+      "iterative": true,
+      "iterationsize": 100
+    },{
+      "query": "MATCH (n:NodeTypeA) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    },{
+      "query": "MATCH (n:NodeTypeB) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    }],
+  "name": "cleanup stale resources"
+}
+"""
+
+SAMPLE_JOB_FILENAME = '/path/to/this/cleanupjob/mycleanupjob.json'
+
+
+@mock.patch.object(cartography.util, 'read_text', return_value=SAMPLE_CLEANUP_JOB)
+def test_run_cleanup_job_on_relationships(mock_read_text:mock.MagicMock, neo4j_session):
+    # Arrange: nodes id1 and id2 are connected to each other at time T2 via stale relationship r
+    neo4j_session.run(
+        """
+        MERGE (a:NodeTypeA{id:"id1", lastupdated:{UPDATE_TAG_T2}})-[r:RELATION{lastupdated:{UPDATE_TAG_T1}}]->
+              (b:NodeTypeB{id:"id2", lastupdated:{UPDATE_TAG_T2}})
+        """,
+        UPDATE_TAG_T1=UPDATE_TAG_T1,
+        UPDATE_TAG_T2=UPDATE_TAG_T2,
+    )
+
+    # Act: delete all nodes and rels where `lastupdated` != UPDATE_TAG_T2
+    job_parameters = {'UPDATE_TAG': UPDATE_TAG_T2}
+    run_cleanup_job(SAMPLE_JOB_FILENAME, neo4j_session, job_parameters)
+
+    # Assert 1: Node id1 is no longer attached to Node id2
+    nodes = neo4j_session.run(
+        """
+        MATCH (a:NodeTypeA)
+        OPTIONAL MATCH (a)-[r:RELATION]->(b:NodeTypeB)
+        RETURN a.id, r.lastupdated, b.id
+        """,
+    )
+    actual_nodes = {(n['a.id'], n['r.lastupdated'], n['b.id']) for n in nodes}
+    expected_nodes = {
+        ('id1', None, None)
+    }
+    assert actual_nodes == expected_nodes
+
+    # Assert 2: Node id2 still exists
+    nodes = neo4j_session.run(
+        """
+        MATCH (b:NodeTypeB) RETURN b.id, b.lastupdated
+        """,
+    )
+    actual_nodes = {(n['b.id'], n['b.lastupdated']) for n in nodes}
+    expected_nodes = {
+        ('id2', UPDATE_TAG_T2)
+    }
+    assert actual_nodes == expected_nodes
+    mock_read_text.assert_called_once()
+
+
+@mock.patch.object(cartography.util, 'read_text', return_value=SAMPLE_CLEANUP_JOB)
+def test_run_cleanup_job_on_nodes(mock_read_text: mock.MagicMock, neo4j_session):
+    # Arrange: we are now at time T3, and node id1 exists but node id2 no longer exists
+    neo4j_session.run(
+        """
+        MATCH (a:NodeTypeA{id:"id1"}) SET a.lastupdated={UPDATE_TAG_T3}
+        """,
+        UPDATE_TAG_T3=UPDATE_TAG_T3,
+    )
+
+    # Act: delete all nodes and rels where `lastupdated` != UPDATE_TAG_T3
+    job_parameters = {'UPDATE_TAG': UPDATE_TAG_T3}
+    run_cleanup_job(SAMPLE_JOB_FILENAME, neo4j_session, job_parameters)
+
+    # Assert: Node id1 is the only node that still exists
+    nodes = neo4j_session.run(
+        """
+        MATCH (n) RETURN n.id, n.lastupdated
+        """,
+    )
+    actual_nodes = {(n['n.id'], n['n.lastupdated']) for n in nodes}
+    expected_nodes = {
+        ('id1', UPDATE_TAG_T3),
+    }
+    assert actual_nodes == expected_nodes
+    mock_read_text.assert_called_once()

--- a/tests/unit/cartography/data/test_graphjob.py
+++ b/tests/unit/cartography/data/test_graphjob.py
@@ -1,0 +1,12 @@
+from cartography.graph.job import GraphJob
+from tests.data.jobs.sample import SAMPLE_CLEANUP_JOB
+
+
+def test_graphjob_from_json():
+    # Act
+    job: GraphJob = GraphJob.from_json(SAMPLE_CLEANUP_JOB)
+
+    # Assert that the job was created from json string contents correctly
+    assert job.name == "cleanup stale resources"
+    assert len(job.statements) == 3
+    assert job.short_name is None


### PR DESCRIPTION
- Adds type hints to GraphJob and GraphStatement.
- Uses managed `write_transaction` function instead of manually calling `tx.commit()` on our own.
- Adds a field for `parent_job_name` in a GraphStatement.
- Emits metrics on the number of objects changed by a given GraphStatement.
- Adds tests.

This also passes existing integration tests that use [analysis](https://github.com/lyft/cartography/blob/694d6f572763ab22abf141e5b3480dfb05368757/tests/integration/cartography/data/jobs/test_syntax.py#L12) (although these tests only _run_ the job but don't verify results) and [cleanup](https://github.com/lyft/cartography/blob/694d6f572763ab22abf141e5b3480dfb05368757/tests/integration/cartography/intel/okta/test_group.py#L74) jobs.