### PR TITLE
Fix access of json string redrive policy in sqs

### DIFF
--- a/cartography/intel/aws/sqs.py
+++ b/cartography/intel/aws/sqs.py
@@ -100,6 +100,7 @@ def load_sqs_queues(
                 rp = json.loads(redrive_policy)
             except TypeError:
                 rp = {}
+            queue['RedrivePolicy'] = rp
             dead_letter_arn = rp.get('deadLetterTargetArn')
             if dead_letter_arn:
                 dead_letter_queues.append({

--- a/tests/data/aws/sqs.py
+++ b/tests/data/aws/sqs.py
@@ -3,7 +3,7 @@ GET_SQS_QUEUE_ATTRIBUTES = {
         'QueueArn': 'arn:aws:secretsmanager:us-east-1:000000000000:test-queue-1',
         'CreatedTimestamp': '1627539901900',
         'LastModifiedTimestamp': '1627539901900',
-        'RedrivePolicy': "{'deadLetterTargetArn': 'arn:aws:secretsmanager:us-east-1:000000000000:test-queue-2', 'maxReceiveCount': '1'}",  # noqa: E501
+        'RedrivePolicy': '{"deadLetterTargetArn": "arn:aws:secretsmanager:us-east-1:000000000000:test-queue-2", "maxReceiveCount": "1"}',  # noqa: E501
         'VisibilityTimeout': '10',
     },
     'https://us-east-1.queue.amazonaws.com/000000000000/test-queue-2': {

--- a/tests/data/aws/sqs.py
+++ b/tests/data/aws/sqs.py
@@ -3,10 +3,7 @@ GET_SQS_QUEUE_ATTRIBUTES = {
         'QueueArn': 'arn:aws:secretsmanager:us-east-1:000000000000:test-queue-1',
         'CreatedTimestamp': '1627539901900',
         'LastModifiedTimestamp': '1627539901900',
-        'RedrivePolicy': {
-            'deadLetterTargetArn': 'arn:aws:secretsmanager:us-east-1:000000000000:test-queue-2',
-            'maxReceiveCount': '1',
-        },
+        'RedrivePolicy': "{'deadLetterTargetArn': 'arn:aws:secretsmanager:us-east-1:000000000000:test-queue-2', 'maxReceiveCount': '1'}",  # noqa: E501
         'VisibilityTimeout': '10',
     },
     'https://us-east-1.queue.amazonaws.com/000000000000/test-queue-2': {


### PR DESCRIPTION
This change json loads the redrive policy from the SQS queue, which is a JSON string, though the boto docs indicate it's an object. It gets the deadletter queue from the loaded object.

Fixes https://github.com/lyft/cartography/issues/677