### PR TITLE
Deprecate cleanup of AWS accounts

### DIFF
--- a/cartography/data/jobs/cleanup/aws_account_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_account_cleanup.json
@@ -1,9 +1,0 @@
-{
-  "statements": [
-    {
-      "query": "MATCH (n:AWSAccount) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
-      "iterative": true,
-      "iterationsize": 100
-  }],
-  "name": "cleanup AWS Accounts"
-}

--- a/cartography/intel/aws/organizations.py
+++ b/cartography/intel/aws/organizations.py
@@ -5,7 +5,6 @@ import boto3
 import botocore.exceptions
 import neo4j
 
-from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -116,11 +115,5 @@ def load_aws_accounts(
 
 
 @timeit
-def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
-    run_cleanup_job('aws_account_cleanup.json', neo4j_session, common_job_parameters)
-
-
-@timeit
 def sync(neo4j_session: neo4j.Session, accounts: Dict, update_tag: int, common_job_parameters: Dict) -> None:
     load_aws_accounts(neo4j_session, accounts, update_tag, common_job_parameters)
-    cleanup(neo4j_session, common_job_parameters)


### PR DESCRIPTION
Currently, Cartography doesn't support the case of multiple runs ingesting different AWS Organizations,
as the most recent run will cleanup the AWS Accounts of all the other Organizations.

After discussing this with @achantavy we came to the following conclusions:

* The current idea of detach deleting everything attached to an `AWSAccount` is too broad
* Consumers of the graph should make use of the `lastupdated` fields to determine if something is stale or not
* In the case of multiple accounts, it is safer to err toward keep more data instead of broad deleting it
* We also have cleanup jobs for the individual resources already

This PR deprecates the current behaviour, and removes the cleanup job targeted to the `AWSAccount` node type.