### PR TITLE
Add ref to docker instructions

### DIFF
--- a/docs/dev/developer-guide.md
+++ b/docs/dev/developer-guide.md
@@ -15,6 +15,7 @@
 
 ## Testing
 
+_If you'd like to test using Docker and Docker Compose, see [here](/docs/containers/testing-with-docker.md)_
 ### Running from source
 
 1. **Install**


### PR DESCRIPTION
Docker compose is likely the easiest way to get up and running on one's laptop, though it has a limited number of intelmodules (only GH at time of writing)