### PR TITLE
[draft] query and process go modules during repo sync

### DIFF
--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -296,7 +296,11 @@ def _transform_python_requirements(req_file_contents: Dict, repo_url: str, out_r
             })
 
 
-def _transform_go_mod(go_mod_contents: Optional[Dict[str, Any]], repo_url: str, out_go_mod: List[Dict[str, Any]]) -> None:
+def _transform_go_mod(
+    go_mod_contents: Optional[Dict[str, Any]],
+    repo_url: str,
+    out_go_mod: List[Dict[str, Any]],
+) -> None:
     text_contents: Optional[str] = (go_mod_contents or {}).get('text')
     if text_contents is None:
         return

--- a/tests/data/github/repos.py
+++ b/tests/data/github/repos.py
@@ -32,6 +32,7 @@ GET_REPOS = [
         },
         'collaborators': {'edges': [], 'nodes': []},
         'requirements': {'text': 'cartography\nhttplib2<0.7.0\njinja2\nlxml\n-e git+https://example.com#egg=foobar\nhttps://example.com/foobar.tar.gz\npip @ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4bbb3c72346a6de940a148ea686\n'},  # noqa
+        'gomod': None,
     }, {
         'name': 'SampleRepo2',
         'nameWithOwner': 'example_org/SampleRepo2',
@@ -64,6 +65,7 @@ GET_REPOS = [
         },
         'collaborators': None,
         'requirements': None,
+        'gomod': None,
     },
     {
         'name': 'cartography',
@@ -141,5 +143,6 @@ GET_REPOS = [
         'requirements': {
             'text': 'cartography==0.1.0\nhttplib2>=0.7.0\njinja2\nlxml\n# This is a comment line to be ignored\n',
         },
+        'gomod': None,
     },
 ]

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -248,7 +248,11 @@ def test_transform_go_mod():
     """
     go_mod_contents = textwrap.dedent(go_mod_contents)
     out_go_mod = []
-    cartography.intel.github.repos._transform_go_mod({'text': go_mod_contents}, 'https://github.com/lyft/cartography', out_go_mod)
+    cartography.intel.github.repos._transform_go_mod(
+        {'text': go_mod_contents},
+        'https://github.com/lyft/cartography',
+        out_go_mod,
+    )
     assert out_go_mod == [
         {
             'id': 'github.com/lyft/directdependency|v1.0.0',

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -243,7 +243,7 @@ def test_transform_go_mod():
     )
 
     require (
-        github.ocm/lyft/newindirectdependency v3.2.1 // indirect
+        github.com/lyft/newindirectdependency v3.2.1 // indirect
     )
     """
     go_mod_contents = textwrap.dedent(go_mod_contents)
@@ -256,20 +256,20 @@ def test_transform_go_mod():
     assert out_go_mod == [
         {
             'id': 'github.com/lyft/directdependency|v1.0.0',
-            'name': 'githuhb.com/lyft/directdependency',
+            'name': 'github.com/lyft/directdependency',
             'version': 'v1.0.0',
             'repo_url': 'https://github.com/lyft/cartography',
         },
         {
-            'id': 'github.com/lyft/olddirectdependency|v1.0.0',
-            'name': 'githuhb.com/lyft/olddirectdependency',
+            'id': 'github.com/lyft/olddirectdependency|v1.2.3',
+            'name': 'github.com/lyft/olddirectdependency',
             'version': 'v1.2.3',
             'repo_url': 'https://github.com/lyft/cartography',
         },
         {
-            'id': 'github.com/lyft/newdirectdependency|v1.0.0',
-            'name': 'githuhb.com/lyft/newdirectdependency',
-            'version': 'v1.2.3',
+            'id': 'github.com/lyft/newdirectdependency|v3.2.1',
+            'name': 'github.com/lyft/newdirectdependency',
+            'version': 'v3.2.1',
             'repo_url': 'https://github.com/lyft/cartography',
         },
     ]

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -261,14 +261,14 @@ def test_transform_go_mod():
             'repo_url': 'https://github.com/lyft/cartography',
         },
         {
-            'id': 'github.com/lyft/olddirectdependency|v1.2.3',
-            'name': 'github.com/lyft/olddirectdependency',
+            'id': 'github.com/lyft/oldindirectdependency|v1.2.3',
+            'name': 'github.com/lyft/oldindirectdependency',
             'version': 'v1.2.3',
             'repo_url': 'https://github.com/lyft/cartography',
         },
         {
-            'id': 'github.com/lyft/newdirectdependency|v3.2.1',
-            'name': 'github.com/lyft/newdirectdependency',
+            'id': 'github.com/lyft/newindirectdependency|v3.2.1',
+            'name': 'github.com/lyft/newindirectdependency',
             'version': 'v3.2.1',
             'repo_url': 'https://github.com/lyft/cartography',
         },


### PR DESCRIPTION
this draft PR introduces the ability to ingest go modules in cartography. go 1.17 [changes how the go module graph works and adds extra indirect dependencies into the `go.mod`](https://golang.org/doc/go1.17#go-command). this PR leverages that new behavior to collect requirements from more go modules!

this naive ingestion scheme will probably have to change before it's productionized but it's a good start 🙂 