### PR TITLE
Fix initialization of DigitalOcean ingestion

### DIFF
--- a/cartography/intel/digitalocean/__init__.py
+++ b/cartography/intel/digitalocean/__init__.py
@@ -29,7 +29,7 @@ def start_digitalocean_ingestion(neo4j_session: neo4j.Session, config: Config) -
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,
     }
-    manager = Manager(config.digitalocean_token)
+    manager = Manager(token=config.digitalocean_token)
 
     """
     Get Account ID related to this credentials and pass it along in `common_job_parameters` to avoid cleaning up other


### PR DESCRIPTION
I'm not sure if this module ever worked before, but it did raise an error on initialization:

```
digitalocean.TokenError: No token provided. Please use a valid token
```

This PR addresses this issue.