### PR TITLE
Fix #723: Autoscaling Groups ingestion fails when region is denied

### DIFF
--- a/cartography/util.py
+++ b/cartography/util.py
@@ -78,11 +78,11 @@ def timeit(method):
 # TODO Move this to cartography.intel.aws.util.common
 def aws_handle_regions(func):
     ERROR_CODES = [
-        'AccessDeniedException',
-        'UnrecognizedClientException',
-        'InvalidClientTokenId',
-        'AuthFailure',
         'AccessDenied',
+        'AccessDeniedException',
+        'AuthFailure',
+        'InvalidClientTokenId',
+        'UnrecognizedClientException',
     ]
 
     def inner_function(*args, **kwargs):

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -82,6 +82,7 @@ def aws_handle_regions(func):
         'UnrecognizedClientException',
         'InvalidClientTokenId',
         'AuthFailure',
+        'AccessDenied',
     ]
 
     def inner_function(*args, **kwargs):


### PR DESCRIPTION
This PR adds another error code to the `util.aws_handle_regions` decorator, to handle another scenario described in #723.

I also sorted the error codes alphabetically for clarity, but happy to have it reverted if not enough value added.

---

_Note: I opened a new PR as I made a mess with signing commits after changing my computer._