### PR TITLE
Secure test_suite.yml workflow

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v0.1.1
+      - uses: step-security/harden-runner@v0.3.0
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
@@ -29,7 +29,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v0.1.1
+      - uses: step-security/harden-runner@v0.3.0
       - uses: actions/checkout@v2
       # See https://debian.neo4j.com/
       - name: Neo4j setup

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v0.3.0
+      - uses: step-security/harden-runner@v0.4.0
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
@@ -29,7 +29,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v0.3.0
+      - uses: step-security/harden-runner@v0.4.0
       - uses: actions/checkout@v2
       # See https://debian.neo4j.com/
       - name: Neo4j setup

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -15,7 +15,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v0.4.0
+      - uses: step-security/harden-runner@v1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
@@ -29,7 +31,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@v0.4.0
+      - uses: step-security/harden-runner@v1
+        with:
+          egress-policy: audit
       - uses: actions/checkout@v2
       # See https://debian.neo4j.com/
       - name: Neo4j setup

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -7,10 +7,15 @@ on:
     branches:
       - master
 
+permissions: read-all
+
 jobs:
   linter:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v0.1.1
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
@@ -20,8 +25,11 @@ jobs:
           extra_args: --all-files --show-diff-on-failure
 
   unit-and-integration-tests:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@v0.1.1
       - uses: actions/checkout@v2
       # See https://debian.neo4j.com/
       - name: Neo4j setup

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   linter:
     permissions:
-      contents: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: step-security/harden-runner@v0.1.1


### PR DESCRIPTION
This PR makes two changes to the test_suite.yml workflow
1. Adds minimum token permissions for the `GITHUB_TOKEN`. This is a security best practice as per [GitHub Actions Hardening Guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#restricting-permissions-for-tokens) and is also part of the [Scorecards](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) checks.
2. Adds `step-security/harden-runner` to the jobs. This is a new GitHub Action that provides runtime security for GitHub hosted runner. As of now, it can be used to set allowed outbound traffic for workflow runs to prevent credential exfiltration. You can see the results from the run on the fork [here](https://github.com/varunsh-coder/cartography/runs/4287501915?check_suite_focus=true#step:3:3). I noticed outbound calls to security.ubuntu.com and azure.archive.ubuntu.com on port 80, which I will investigate. After the workflow has run a couple of times, and discovered outbound calls, I can create another PR to restrict outbound calls to allowed domains. 

@achantavy would love to pilot `step-security/harden-runner` on this repo to get feedback and improve the experience. Do let me know if you have any questions. Thanks!
 