### PR TITLE
Set logging level for azure.core.pipeline.policies.http_logging_policy

### DIFF
--- a/cartography/intel/azure/util/credentials.py
+++ b/cartography/intel/azure/util/credentials.py
@@ -104,6 +104,7 @@ class Authenticator:
             logging.getLogger('msrest').setLevel(logging.ERROR)
             logging.getLogger('msrestazure.azure_active_directory').setLevel(logging.ERROR)
             logging.getLogger('urllib3').setLevel(logging.ERROR)
+            logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel(logging.ERROR)
 
             arm_credentials, subscription_id, tenant_id = get_azure_cli_credentials(with_tenant=True)
             aad_graph_credentials, placeholder_1, placeholder_2 = get_azure_cli_credentials(
@@ -139,6 +140,7 @@ class Authenticator:
             logging.getLogger('msrest').setLevel(logging.ERROR)
             logging.getLogger('msrestazure.azure_active_directory').setLevel(logging.ERROR)
             logging.getLogger('urllib3').setLevel(logging.ERROR)
+            logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel(logging.ERROR)
 
             arm_credentials = ClientSecretCredential(
                 client_id=client_id,


### PR DESCRIPTION
Currently, the Azure ingestion is very verbose, as it logs every http request: 

```bash
INFO:azure.core.pipeline.policies.http_logging_policy:Request URL: 'https://management.azure.com/subscriptions/<redacted>/resourceGroups/<redacted>/providers/Microsoft.Storage/...?api-version=REDACTED'
Request method: 'GET'
Request headers:
    'Accept': 'application/json'
    'x-ms-client-request-id': '<redacted>'
    'User-Agent': 'azsdk-python-azure-mgmt-storage/19.0.0 Python/3.9.7 (Linux-5.4.129+-x86_64-with-glibc2.31)' 'Authorization': 'REDACTED'
No body was attached to the request
```

This MR sets the logging level of `azure.core.pipeline.policies.http_logging_policy` to `ERROR`