### PR TITLE
Update test-requirements for Python 3.8 support

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.6"
+          python-version: "3.8"
       - uses: pre-commit/action@v2.0.0
         with:
           extra_args: --all-files --show-diff-on-failure
@@ -37,7 +37,7 @@ jobs:
           sudo service neo4j restart
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.6"
+          python-version: "3.8"
       # Cache our pip dir for efficiency; see https://medium.com/ai2-blog/python-caching-in-github-actions-e9452698e98d.
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -29,7 +29,7 @@ jobs:
           wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
           echo 'deb https://debian.neo4j.com stable 3.5' | sudo tee /etc/apt/sources.list.d/neo4j.list
           sudo apt-get update
-      - name: Install  Neo4j
+      - name: Install Neo4j
         run: sudo apt-get install neo4j
       - name: Disable auth for neo4j
         run: |

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -29,7 +29,7 @@ jobs:
           wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
           echo 'deb https://debian.neo4j.com stable 3.5' | sudo tee /etc/apt/sources.list.d/neo4j.list
           sudo apt-get update
-      - name: Install Neo4j
+      - name: Install  Neo4j
         run: sudo apt-get install neo4j
       - name: Disable auth for neo4j
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 COPY . /srv/cartography
 
+# Installs pip supported by python3.8
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.8 get-pip.py
 
 RUN pip install -e . && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,15 @@ WORKDIR /srv/cartography
 
 ENV PATH=/venv/bin:$PATH
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-dev python3-pip python3-setuptools openssl libssl-dev gcc pkg-config libffi-dev libxml2-dev libxmlsec1-dev && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.8-dev python3-pip python3-setuptools openssl libssl-dev gcc pkg-config libffi-dev libxml2-dev libxmlsec1-dev curl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
 COPY . /srv/cartography
 
-RUN pip3 install -e . && \
-    pip3 install -r test-requirements.txt
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.8 get-pip.py
+
+RUN pip install -e . && \
+    pip install -r test-requirements.txt
 
 RUN groupadd cartography && \
     useradd -s /bin/bash -d /home/cartography -m -g cartography cartography

--- a/docs/setup/install.md
+++ b/docs/setup/install.md
@@ -8,7 +8,7 @@
 
 # Cartography Installation
 
-Time to set up the server that will run Cartography.  Cartography _should_ work on both Linux and Windows servers, but bear in mind we've only tested it in Linux so far.  Cartography requires Python 3.6 or greater.
+Time to set up the server that will run Cartography.  Cartography _should_ work on both Linux and Windows servers, but bear in mind we've only tested it in Linux so far.  Cartography supports Python 3.8. Older versions of Python may work but are not explicitly supported.
 
 1. **Get and install the Neo4j graph database** on your server.
     1. Neo4j requires a JVM (JDK/JRE 11 or higher) to be installed. One option is to install [Amazon Coretto 11](https://docs.aws.amazon.com/corretto/latest/corretto-11-ug/what-is-corretto-11.html).

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Security',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 pre-commit
-pytest>=4.6
+pytest>=6.2.4
 pytest-mock
-pytest-cov
+pytest-cov==2.10.0
 
 types-PyYAML
 types-requests


### PR DESCRIPTION
Python 3.8 in some cases can improve performance by more than 10% over Python 3.7 and earlier versions! There’s also many bugfixes and new features in the standard library; see the Python 3.8 [release notes](https://docs.python.org/3/whatsnew/3.8.html) for more info. We need to make sure that cartography runs with Python 3.8
This PR involves making sure that the packages work with Python 3.8 and unit tests run successfully
