### PR TITLE
#734: Remove `return count(*) TotalCompleted` from aws rgta cleanup

### DIFF
--- a/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
@@ -1,102 +1,102 @@
 {
     "statements": [
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:NetworkInterface)-[:PART_OF_SUBNET]->(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:NetworkInterface)-[:PART_OF_SUBNET]->(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:NetworkInterface)-[:PART_OF_SUBNET]->(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:NetworkInterface)-[:PART_OF_SUBNET]->(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:EC2Subnet)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:ESDomain)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:ESDomain)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:ESDomain)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:ESDomain)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RedshiftCluster) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RedshiftCluster) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         }

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.50.0'
+__version__ = '0.51.0rc1'
 
 
 setup(


### PR DESCRIPTION
See #734.

`return count(*) as TotalCompleted` was previously used to determine when to exit the loop for deleting objects in a cleanup job. This is no longer needed after #680 because we get the counts directly from the Python library:

https://github.com/lyft/cartography/blob/894d0761554999c8d95b02b66b6554a44050f37e/cartography/graph/statement.py#L118-L126

If this works out well then I will follow with a PR to do this for the other cleanup jobs, such as with Okta --
currently the only place where cleanup jobs have correctness test coverage is here:
https://github.com/lyft/cartography/blob/68d73d98597bf92ed83bac846e5a6a96e2b7b8bd/tests/integration/cartography/intel/okta/test_group.py#L46

My plan is to put this in a pre-release 0.51.0rc1.