### PR TITLE
Add the pod status phase to the k8s pod nodes

### DIFF
--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -28,6 +28,7 @@ def get_pods(client: K8sClient, cluster: Dict) -> List[Dict]:
             {
                 "uid": pod.metadata.uid,
                 "name": pod.metadata.name,
+                "status_phase": pod.status.phase,
                 "creation_timestamp": get_epoch(pod.metadata.creation_timestamp),
                 "deletion_timestamp": get_epoch(pod.metadata.deletion_timestamp),
                 "namespace": pod.metadata.namespace,
@@ -54,6 +55,7 @@ def load_pods(session: Session, data: List[Dict], update_tag: int) -> None:
         ON CREATE SET pod.firstseen = timestamp()
         SET pod.lastupdated = {update_tag},
             pod.name = k8pod.name,
+            pod.status_phase = k8pod.status_phase,
             pod.created_at = k8pod.creation_timestamp,
             pod.deleted_at = k8pod.deletion_timestamp
         WITH pod, k8pod.namespace as ns, k8pod.cluster_uid as cuid, k8pod.containers as k8containers

--- a/docs/schema/kubernetes.md
+++ b/docs/schema/kubernetes.md
@@ -48,8 +48,8 @@ Representation of a [Kubernetes Namespace.](https://kubernetes.io/docs/concepts/
 | lastupdated | Timestamp of the last time the node was updated |
 | id | UID of the kubernetes namespace |
 | name | Name of the kubernetes namespace |
-| created_at | Timestamp of the creation time of the kubernetes namespace |
-| deleted_at | Timestamp of the deletion time of the kubernetes namespace |
+| created\_at | Timestamp of the creation time of the kubernetes namespace |
+| deleted\_at | Timestamp of the deletion time of the kubernetes namespace |
 
 ### Relationships
 - KubernetesNamespace can have KubernetesPods.
@@ -71,8 +71,9 @@ Representation of a [Kubernetes Pod.](https://kubernetes.io/docs/concepts/worklo
 | lastupdated | Timestamp of the last time the node was updated |
 | id | UID of the kubernetes pod |
 | name | Name of the kubernetes pod |
-| created_at | Timestamp of the creation time of the kubernetes pod |
-| deleted_at | Timestamp of the deletion time of the kubernetes pod |
+| status\_phase | The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle.  |
+| created\_at | Timestamp of the creation time of the kubernetes pod |
+| deleted\_at | Timestamp of the deletion time of the kubernetes pod |
 
 ### Relationships
 - KubernetesPod has KubernetesContainers.
@@ -106,12 +107,12 @@ Representation of a [Kubernetes Service.](https://kubernetes.io/docs/concepts/se
 | lastupdated | Timestamp of the last time the node was updated |
 | id | UID of the kubernetes service |
 | name | Name of the kubernetes service |
-| created_at | Timestamp of the creation time of the kubernetes service |
-| deleted_at | Timestamp of the deletion time of the kubernetes service |
+| created\_at | Timestamp of the creation time of the kubernetes service |
+| deleted\_at | Timestamp of the deletion time of the kubernetes service |
 | type | Type of kubernetes service e.g. `ClusterIP` |
-| load_balancer_ip | IP of the load balancer when service type is `LoadBalancer` |
-| ingress_host | Hostname of the ingress endpoint, if any |
-| ingress_ip | IP of the ingress endpoint, if any |
+| load\_balancer\_ip | IP of the load balancer when service type is `LoadBalancer` |
+| ingress\_host | Hostname of the ingress endpoint, if any |
+| ingress\_ip | IP of the ingress endpoint, if any |
 
 ### Relationships
 - KubernetesService can serve KubernetesPods.


### PR DESCRIPTION
This change syncs in the phase of a pod when syncing pods in from k8s. This makes it possible to filter out pods that are still defined, but not actually running.