### PR TITLE
Include status information in k8s pod containers

### DIFF
--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -39,8 +39,13 @@ def get_pods(client: K8sClient, cluster: Dict) -> List[Dict]:
                         _state = 'running'
                     elif status.state.terminated:
                         _state = 'terminated'
+                    try:
+                        image_sha = status.image_id.split("@")[1]
+                    except IndexError:
+                        image_sha = None
                     containers[status.name]["status"] = {
                         "image_id": status.image_id,
+                        "image_sha": image_sha,
                         "ready": status.ready,
                         "started": status.started,
                         "state": _state,
@@ -83,6 +88,7 @@ def load_pods(session: Session, data: List[Dict], update_tag: int) -> None:
             ON CREATE SET container.firstseen = timestamp()
             SET container.image = k8container.image,
                 container.status_image_id = k8container.status.image_id,
+                container.status_image_sha = k8container.status.image_sha,
                 container.status_ready = k8container.status.ready,
                 container.status_started = k8container.status.started,
                 container.status_state = k8container.status.state,

--- a/docs/schema/kubernetes.md
+++ b/docs/schema/kubernetes.md
@@ -92,6 +92,7 @@ Representation of a [Kubernetes Container.](https://kubernetes.io/docs/concepts/
 | name | Name of the container in kubernetes pod |
 | image | Docker image used in the container |
 | status\_image\_id | ImageID of the container's image. |
+| status\_image\_sha | The SHA portion of the status\_image\_id |
 | status\_ready | Specifies whether the container has passed its readiness probe. |
 | status\_started | Specifies whether the container has passed its startup probe. |
 | statys\_state | State of the container (running, terminated, waiting) |

--- a/docs/schema/kubernetes.md
+++ b/docs/schema/kubernetes.md
@@ -90,6 +90,10 @@ Representation of a [Kubernetes Container.](https://kubernetes.io/docs/concepts/
 | id | Identifier for the container which is derived from the UID of pod and the name of container |
 | name | Name of the container in kubernetes pod |
 | image | Docker image used in the container |
+| status\_image\_id | ImageID of the container's image. |
+| status\_ready | Specifies whether the container has passed its readiness probe. |
+| status\_started | Specifies whether the container has passed its startup probe. |
+| statys\_state | State of the container (running, terminated, waiting) |
 
 ### Relationships
 - KubernetesPod has KubernetesContainers.


### PR DESCRIPTION
This PR includes status information about containers in k8s pod containers. This gives information about the current state of the container. The image_id is especially of note, as it gives the specific image SHA that's running for the container.