### PR TITLE
Add more lambda attributes, and make relationship between lambda and ECR

### DIFF
--- a/cartography/data/jobs/analysis/aws_lambda_ecr.json
+++ b/cartography/data/jobs/analysis/aws_lambda_ecr.json
@@ -1,0 +1,14 @@
+{
+    "name": "Lambda functions with ECR images",
+    "statements": [
+        {
+            "__comment": "Create HAS_IMAGE realtionship from lambda functions to the associated ECR image",
+            "query":"MATCH (l:AWSLambda), (e:ECRImage)\nWHERE e.digest = 'sha256:' + l.codesha256\nMERGE (l)-[:HAS]->(e)",
+            "iterative": false
+        },
+        {
+            "query": "MATCH (:AWSLambda)-[r:HAS]->(:ECRImage) WHERE r.lastupdated <> {UPDATE_TAG} DELETE (r)",
+            "iterative": false
+        }
+    ]
+}

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -77,6 +77,12 @@ def _sync_one_account(
         common_job_parameters,
     )
 
+    run_analysis_job(
+        'aws_lambda_ecr.json',
+        neo4j_session,
+        common_job_parameters,
+    )
+
 
 def _autodiscover_account_regions(boto3_session: boto3.session.Session, account_id: str) -> List[str]:
     regions: List[str] = []

--- a/cartography/intel/aws/lambda_function.py
+++ b/cartography/intel/aws/lambda_function.py
@@ -59,6 +59,10 @@ def load_lambda_functions(
         lambda.packagetype = lf.PackageType,
         lambda.signingprofileversionarn = lf.SigningProfileVersionArn,
         lambda.signingjobarn = lf.SigningJobArn,
+        lambda.codesha256 = lf.CodeSha256,
+        lambda.architectures = lf.Architectures,
+        lambda.masterarn = lf.MasterArn,
+        lambda.kmskeyarn = lf.KMSKeyArn,
         lambda.lastupdated = {aws_update_tag}
         WITH lambda, lf
         MATCH (owner:AWSAccount{id: {AWS_ACCOUNT_ID}})

--- a/docs/schema/aws.md
+++ b/docs/schema/aws.md
@@ -320,6 +320,10 @@ Representation of an AWS [Lambda Function](https://docs.aws.amazon.com/lambda/la
 | packagetype |  The type of deployment package. |
 | signingprofileversionarn | The ARN of the signing profile version. |
 | signingjobarn | The ARN of the signing job. |
+| codesha256 | The SHA256 hash of the function's deployment package. |
+| architectures | The instruction set architecture that the function supports. Architecture is a string array with one of the valid values. |
+| masterarn | For Lambda@Edge functions, the ARN of the main function. |
+| kmskeyarn | The KMS key that's used to encrypt the function's environment variables. This key is only returned if you've configured a customer managed key. |
 
 ### Relationships
 
@@ -351,6 +355,12 @@ Representation of an AWS [Lambda Function](https://docs.aws.amazon.com/lambda/la
 
         ```
         (AWSLambda)-[HAS]->(AWSLambdaLayer)
+        ```
+
+- AWSLambda functions has AWS ECR Images.
+
+        ```
+        (AWSLambda)-[HAS]->(ECRImage)
         ```
 
 ## AWSLambdaFunctionAlias


### PR DESCRIPTION
This change pulls in more lambda attributes, and makes a relationship between lambda and ECR, for lambdas that use images, and have a matching sha256.