### PR TITLE
Ramonpetgrave64 fix kubernetes version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.53.0rc1'
+__version__ = '0.52.0'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.52.0'
+__version__ = '0.53.0rc1'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "azure-mgmt-storage>=16.0.0",
         "azure-mgmt-sql<=1.0.0",
         "azure-identity>=1.5.0",
-        "kubernetes>=18.20.0",
+        "kubernetes>=18.20.0,<=21.7.0",
         "pdpyras>=4.3.0",
     ],
     extras_require={


### PR DESCRIPTION
This fixes maximum of kubernetes to 21.7.0, since `NetworkingV1beta1Api ` seems to not be present in the latest version 22.6.0.  At the moment, our CI builds are failing due to the below error, and possibly newer installations are failing, too.

```
cartography/intel/kubernetes/util.py:8: in <module>
    from kubernetes.client import NetworkingV1beta1Api
E   ImportError: cannot import name 'NetworkingV1beta1Api' from 'kubernetes.client' (/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/kubernetes/client/__init__.py)
```

We will have to investigate using a new client that is not "beta", if it exists in the newest version of the library.