### PR TITLE
module sync stats.

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -11,9 +11,12 @@ import neo4j
 
 from cartography.intel.aws.permission_relationships import parse_statement_node
 from cartography.intel.aws.permission_relationships import principal_allowed_on_resource
+from cartography.util import get_stats_client
+from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 logger = logging.getLogger(__name__)
+stat_handler = get_stats_client(__name__)
 
 # Overview of IAM in AWS
 # https://aws.amazon.com/iam/
@@ -729,3 +732,11 @@ def sync(
     sync_assumerole_relationships(neo4j_session, current_aws_account_id, update_tag, common_job_parameters)
     sync_user_access_keys(neo4j_session, boto3_session, current_aws_account_id, update_tag, common_job_parameters)
     run_cleanup_job('aws_import_principals_cleanup.json', neo4j_session, common_job_parameters)
+    merge_module_sync_metadata(
+        neo4j_session,
+        group_type='AWSAccount',
+        group_id=current_aws_account_id,
+        synced_type='AWSPrincipal',
+        update_tag=update_tag,
+        stat_handler=stat_handler,
+    )

--- a/cartography/intel/aws/s3.py
+++ b/cartography/intel/aws/s3.py
@@ -622,14 +622,6 @@ def load_s3_buckets(neo4j_session: neo4j.Session, data: Dict, current_aws_accoun
             AWS_ACCOUNT_ID=current_aws_account_id,
             aws_update_tag=aws_update_tag,
         )
-    merge_module_sync_metadata(
-        neo4j_session,
-        group_type='AWSAccount',
-        group_id=current_aws_account_id,
-        synced_type='S3Bucket',
-        update_tag=aws_update_tag,
-        stat_handler=stat_handler,
-    )
 
 
 @timeit
@@ -656,3 +648,12 @@ def sync(
     acl_and_policy_data_iter = get_s3_bucket_details(boto3_session, bucket_data)
     load_s3_details(neo4j_session, acl_and_policy_data_iter, current_aws_account_id, update_tag)
     cleanup_s3_bucket_acl_and_policy(neo4j_session, common_job_parameters)
+
+    merge_module_sync_metadata(
+        neo4j_session,
+        group_type='AWSAccount',
+        group_id=current_aws_account_id,
+        synced_type='S3Bucket',
+        update_tag=update_tag,
+        stat_handler=stat_handler,
+    )

--- a/cartography/intel/aws/s3.py
+++ b/cartography/intel/aws/s3.py
@@ -15,12 +15,14 @@ from botocore.exceptions import ClientError
 from botocore.exceptions import EndpointConnectionError
 from policyuniverse.policy import Policy
 
+from cartography.util import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_analysis_job
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+stat_handler = get_stats_client(__name__)
 
 
 @timeit
@@ -626,6 +628,7 @@ def load_s3_buckets(neo4j_session: neo4j.Session, data: Dict, current_aws_accoun
         group_id=current_aws_account_id,
         synced_type='S3Bucket',
         update_tag=aws_update_tag,
+        stat_handler=stat_handler,
     )
 
 

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -13,6 +13,7 @@ import neo4j
 from cartography.graph.job import GraphJob
 from cartography.graph.statement import get_job_shortname
 from cartography.stats import get_stats_client
+from cartography.stats import ScopedStatsClient
 
 if sys.version_info >= (3, 7):
     from importlib.resources import open_binary, read_text
@@ -55,6 +56,7 @@ def merge_module_sync_metadata(
     group_id: Union[str, int],
     synced_type: str,
     update_tag: int,
+    stat_handler: ScopedStatsClient,
 ):
     '''
     This function creates `ModuleSyncMetadata` nodes when called from each of the individual modules or sub-modules.
@@ -81,6 +83,7 @@ def merge_module_sync_metadata(
         group_id=group_id,
         UPDATE_TAG=update_tag,
     )
+    stat_handler.incr(f'{group_type}_{group_id}_{synced_type}_lastupdated', update_tag)
 
 
 def load_resource_binary(package, resource_name):

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -59,7 +59,7 @@ def merge_module_sync_metadata(
     stat_handler: ScopedStatsClient,
 ):
     '''
-    This function creates `ModuleSyncMetadata` nodes when called from each of the individual modules or sub-modules.
+    This creates `ModuleSyncMetadata` nodes when called from each of the individual modules or sub-modules.
     The 'types' used here should be actual node labels. For example, if we did sync a particular AWSAccount's S3Buckets,
     the `grouptype` is 'AWSAccount', the `groupid` is the particular account's `id`, and the `syncedtype` is 'S3Bucket'.
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.53.0'
+__version__ = '0.54.rc1'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.54.rc1'
+__version__ = '0.54.0rc2'
 
 
 setup(

--- a/tests/integration/cartography/intel/aws/test_s3.py
+++ b/tests/integration/cartography/intel/aws/test_s3.py
@@ -48,43 +48,6 @@ def test_load_s3_buckets(neo4j_session, *args):
     assert actual_nodes == expected_nodes
 
 
-def test_load_s3_buckets_sync_metadata(neo4j_session, *args):
-    # Arrange
-    data = tests.data.aws.s3.LIST_BUCKETS
-    expected_nodes = {
-        (
-            f'AWSAccount_{TEST_ACCOUNT_ID}_S3Bucket',
-            'AWSAccount',
-            TEST_ACCOUNT_ID,
-            'S3Bucket',
-            TEST_UPDATE_TAG,
-        ),
-    }
-    # Act
-    cartography.intel.aws.s3.load_s3_buckets(neo4j_session, data, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
-    nodes = neo4j_session.run(f"""
-        MATCH (m:ModuleSyncMetadata{{id:'AWSAccount_{TEST_ACCOUNT_ID}_S3Bucket'}})
-        RETURN
-            m.id,
-            m.syncedtype,
-            m.grouptype,
-            m.groupid,
-            m.lastupdated
-    """)
-    # Assert
-    actual_nodes = {
-        (
-            n['m.id'],
-            n['m.grouptype'],
-            n['m.groupid'],
-            n['m.syncedtype'],
-            n['m.lastupdated'],
-        )
-        for n in nodes
-    }
-    assert actual_nodes == expected_nodes
-
-
 def test_load_s3_encryption(neo4j_session, *args):
     """
     Ensure that expected bucket gets loaded with their encryption fields.

--- a/tests/integration/cartography/test_util.py
+++ b/tests/integration/cartography/test_util.py
@@ -1,0 +1,62 @@
+from unittest.mock import patch
+
+from cartography.stats import ScopedStatsClient
+from cartography.util import get_stats_client
+from cartography.util import merge_module_sync_metadata
+
+
+TEST_ACCOUNT_ID = '000000000000'
+TEST_UPDATE_TAG = 123456789
+
+
+@patch.object(ScopedStatsClient, 'incr')
+def test_merge_module_sync_metadata(mock_stat_incr, neo4j_session):
+    # Arrange
+    group_type = 'AWSAccount'
+    group_id = TEST_ACCOUNT_ID
+    synced_type = 'S3Bucket'
+    stat_handler = get_stats_client(__name__)
+    expected_nodes = {
+        (
+            f'AWSAccount_{TEST_ACCOUNT_ID}_S3Bucket',
+            'AWSAccount',
+            TEST_ACCOUNT_ID,
+            'S3Bucket',
+            TEST_UPDATE_TAG,
+        ),
+    }
+    # Act
+    merge_module_sync_metadata(
+        neo4j_session=neo4j_session,
+        group_type=group_type,
+        group_id=group_id,
+        synced_type=synced_type,
+        update_tag=TEST_UPDATE_TAG,
+        stat_handler=stat_handler,
+    )
+    # Assert
+    nodes = neo4j_session.run(f"""
+        MATCH (m:ModuleSyncMetadata{{id:'AWSAccount_{TEST_ACCOUNT_ID}_S3Bucket'}})
+        RETURN
+            m.id,
+            m.syncedtype,
+            m.grouptype,
+            m.groupid,
+            m.lastupdated
+    """)
+    # Assert
+    actual_nodes = {
+        (
+            n['m.id'],
+            n['m.grouptype'],
+            n['m.groupid'],
+            n['m.syncedtype'],
+            n['m.lastupdated'],
+        )
+        for n in nodes
+    }
+    assert actual_nodes == expected_nodes
+    mock_stat_incr.assert_called_once_with(
+        f'{group_type}_{group_id}_{synced_type}_lastupdated',
+        TEST_UPDATE_TAG,
+    )


### PR DESCRIPTION
We also invoke the ModuleSyncMetadata node creation from the aws iam module, continuing the work #758  and #768.
We also add an integration test specific to the node's creation