### PR TITLE
Log errors in github graphql response

### DIFF
--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -35,7 +35,10 @@ def call_github_api(query: str, variables: str, token: str, api_url: str) -> Dic
         logger.warning("GitHub: requests.get('%s') timed out.", api_url)
         raise
     response.raise_for_status()
-    return response.json()
+    response_json = response.json()
+    if "errors" in response_json:
+        logger.error(response_json["errors"])
+    return response_json
 
 
 def fetch_page(token: str, api_url: str, organization: str, query: str, cursor: Optional[str] = None) -> Dict:

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -915,6 +915,7 @@ Representation of an AWS [EC2 Key Pair](https://docs.aws.amazon.com/AWSEC2/lates
         ```
         (EC2KeyPair)-[MATCHING_FINGERPRINT]->(EC2KeyPair)
         ```
+
 ### EC2PrivateIp
 Representation of an AWS EC2 [InstancePrivateIpAddress](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstancePrivateIpAddress.html)
 
@@ -1112,7 +1113,7 @@ Representation of an AWS EC2 [Subnet](https://docs.aws.amazon.com/AWSEC2/latest/
  | region | The region of the gateway |
 
 
- ### Relationships
+#### Relationships
 
  -  Internet Gateways are attached to a VPC.
 
@@ -1595,6 +1596,7 @@ Represents an Elastic Load Balancer V2 ([Application Load Balancer](https://docs
         ```
         (LoadBalancerV2)-[ELBV2_LISTENER]->(ELBV2Listener)
         ```
+
 ### Nameserver
 
 Represents a DNS nameserver.
@@ -1698,6 +1700,8 @@ Representation of an AWS [PeeringConnection](https://docs.aws.amazon.com/vpc/lat
 | status_code | The status of the VPC peering connection. |
 | status_message | A message that provides more information about the status, if applicable. |
 
+#### Relationships
+
 - `AWSVpc` is an accepter or requester vpc.
   ```
   (AWSVpc)<-[REQUESTER_VPC]-(AWSPeeringConnection)
@@ -1709,7 +1713,6 @@ Representation of an AWS [PeeringConnection](https://docs.aws.amazon.com/vpc/lat
   (AWSCidrBlock)<-[REQUESTER_CIDR]-(AWSPeeringConnection)
   (AWSCidrBlock)<-[ACCEPTER_CIDR]-(AWSPeeringConnection)
   ```
-
 
 ### RedshiftCluster
 

--- a/docs/root/modules/crxcavator/schema.md
+++ b/docs/root/modules/crxcavator/schema.md
@@ -58,7 +58,7 @@ Placeholder representation of a single G Suite [user object](https://developers.
 | price | Extension price in webstore if applicable |
 | report\_link | URL of full extension report on crxcavator.io |
 
- ### Relationships
+#### Relationships
 
 - GSuiteUsers install ChromeExtensions.
 

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -27,7 +27,7 @@ Representation of a GCP [Organization](https://cloud.google.com/resource-manager
     (GCPOrganization)-[RESOURCE]->(GCPProjects)
     ```
 
- ## GCPFolder
+### GCPFolder
 
  Representation of a GCP [Folder](https://cloud.google.com/resource-manager/reference/rest/v2/folders).  An additional helpful reference is the [Google Compute Platform resource hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy).
 
@@ -40,7 +40,7 @@ Representation of a GCP [Organization](https://cloud.google.com/resource-manager
 | lifecyclestate | The folder's current lifecycle state. Assigned by the server.  See the [official docs](https://cloud.google.com/resource-manager/reference/rest/v2/folders#LifecycleState). |
 
 
- ### Relationships
+#### Relationships
 
  - GCPOrganizations are parents of GCPFolders.
 
@@ -60,7 +60,7 @@ Representation of a GCP [Organization](https://cloud.google.com/resource-manager
     (GCPFolder)-[RESOURCE]->(GCPFolder)
     ```
 
- ## GCPProject
+### GCPProject
 
  Representation of a GCP [Project](https://cloud.google.com/resource-manager/reference/rest/v1/projects).  An additional helpful reference is the [Google Compute Platform resource hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy).
 
@@ -629,6 +629,8 @@ Representation of an IP range or subnet.
 | firstseen   | Timestamp of when a sync job first discovered this node                  |
 | lastupdated | Timestamp of the last time the node was updated                          |
 | id          | CIDR notation for the IP range. E.g. "0.0.0.0/0" for the whole internet. |
+
+#### Relationships
 
 - GCP Firewall rules are defined on IpRange objects.
 

--- a/docs/root/modules/github/config.md
+++ b/docs/root/modules/github/config.md
@@ -5,7 +5,7 @@
 Follow these steps to analyze GitHub repos and other objects with Cartography.
 
 1. Prepare your GitHub credentials.
-    1. Prepare a GitHub token, ensuring that it has at minimum the `repo` scope and the `read:org` permission.
+    1. Prepare a GitHub token; the following scopes are required, at minimum: `repo`, `read:org`, `read:user`, `user:email`
     1. GitHub ingest supports multiple endpoints, such as a public instance and an enterprise instance by taking a base64-encoded config object structured as
        ```json
        {

--- a/docs/root/modules/okta/schema.md
+++ b/docs/root/modules/okta/schema.md
@@ -170,6 +170,7 @@ Representation of an [Okta Application](https://developer.okta.com/docs/referenc
     ```
     (ReplyUri)-[REPLYURI]->(OktaApplication)
     ```
+
 ### OktaUserFactor
 
 Representation of Okta User authentication [Factors](https://developer.okta.com/docs/reference/api/factors/#factor-object).


### PR DESCRIPTION
GraphQL queries generally always return with a 200 response, but put errors into the response. To log errors, we need to log them from the response.