### PR TITLE
Use the python driver neo4j>=4.0.0

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -458,7 +458,7 @@ def main(argv=None):
     logging.basicConfig(level=logging.INFO)
     logging.getLogger('botocore').setLevel(logging.WARNING)
     logging.getLogger('googleapiclient').setLevel(logging.WARNING)
-    logging.getLogger('neo4j.bolt').setLevel(logging.WARNING)
+    logging.getLogger('neo4j').setLevel(logging.WARNING)
     argv = argv if argv is not None else sys.argv[1:]
     default_sync = cartography.sync.build_default_sync()
     return CLI(default_sync, prog='cartography').main(argv)

--- a/cartography/driftdetect/cli.py
+++ b/cartography/driftdetect/cli.py
@@ -239,6 +239,6 @@ def main(argv=None):
     :return: The return code.
     """
     logging.basicConfig(level=logging.INFO)
-    logging.getLogger('neo4j.bolt').setLevel(logging.WARNING)
+    logging.getLogger('neo4j').setLevel(logging.WARNING)
     argv = argv if argv is not None else sys.argv[1:]
     return CLI(prog="cartography-detectdrift").main(argv)

--- a/cartography/driftdetect/get_states.py
+++ b/cartography/driftdetect/get_states.py
@@ -2,7 +2,7 @@ import logging
 import os.path
 import time
 
-import neobolt.exceptions
+import neo4j.exceptions
 from marshmallow import ValidationError
 from neo4j import GraphDatabase
 
@@ -34,7 +34,7 @@ def run_get_states(config):
             config.neo4j_uri,
             auth=neo4j_auth,
         )
-    except neobolt.exceptions.ServiceUnavailable as e:
+    except neo4j.exceptions.ServiceUnavailable as e:
         logger.debug("Error occurred during Neo4j connect.", exc_info=True)
         logger.error(
             (
@@ -45,7 +45,7 @@ def run_get_states(config):
             e,
         )
         return
-    except neobolt.exceptions.AuthError as e:
+    except neo4j.exceptions.AuthError as e:
         logger.debug("Error occurred during Neo4j auth.", exc_info=True)
         if not neo4j_auth:
             logger.error(
@@ -86,7 +86,7 @@ def run_get_states(config):
                 logger.exception(msg)
             except FileNotFoundError as err:
                 logger.exception(err)
-            except neobolt.exceptions.CypherSyntaxError as err:
+            except neo4j.exceptions.CypherSyntaxError as err:
                 logger.exception(err)
 
 

--- a/cartography/graph/statement.py
+++ b/cartography/graph/statement.py
@@ -82,14 +82,14 @@ class GraphStatement:
             "iterationsize": self.iterationsize,
         }
 
-    def _run_noniterative(self, tx: neo4j.Transaction) -> neo4j.StatementResult:
+    def _run_noniterative(self, tx: neo4j.Transaction) -> neo4j.Result:
         """
         Non-iterative statement execution.
         """
-        result: neo4j.StatementResult = tx.run(self.query, self.parameters)
+        result: neo4j.Result = tx.run(self.query, self.parameters)
 
         # Handle stats
-        summary: neo4j.BoltStatementResultSummary = result.summary()
+        summary: neo4j.ResultSummary = result._obtain_summary()
         stat_handler.incr('constraints_added', summary.counters.constraints_added)
         stat_handler.incr('constraints_removed', summary.counters.constraints_removed)
         stat_handler.incr('indexes_added', summary.counters.indexes_added)
@@ -113,10 +113,10 @@ class GraphStatement:
         self.parameters["LIMIT_SIZE"] = self.iterationsize
 
         while True:
-            result: neo4j.StatementResult = session.write_transaction(self._run_noniterative)
+            result: neo4j.Result = session.write_transaction(self._run_noniterative)
 
             # Exit if we have finished processing all items
-            if not result.summary().counters.contains_updates:
+            if not result._obtain_summary().counters.contains_updates:
                 # Ensure network buffers are cleared
                 result.consume()
                 break

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections import OrderedDict
 
-import neobolt.exceptions
+import neo4j.exceptions
 from neo4j import GraphDatabase
 from statsd import StatsClient
 
@@ -113,7 +113,7 @@ def run_with_config(sync, config):
             auth=neo4j_auth,
             max_connection_lifetime=config.neo4j_max_connection_lifetime,
         )
-    except neobolt.exceptions.ServiceUnavailable as e:
+    except neo4j.exceptions.ServiceUnavailable as e:
         logger.debug("Error occurred during Neo4j connect.", exc_info=True)
         logger.error(
             (
@@ -124,7 +124,7 @@ def run_with_config(sync, config):
             e,
         )
         return 1
-    except neobolt.exceptions.AuthError as e:
+    except neo4j.exceptions.AuthError as e:
         logger.debug("Error occurred during Neo4j auth.", exc_info=True)
         if not neo4j_auth:
             logger.error(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.54.0rc2'
+__version__ = '0.54.0rc3'
 
 
 setup(
@@ -30,8 +30,7 @@ setup(
         "boto3>=1.15.1",
         "botocore>=1.18.1",
         "dnspython>=1.15.0",
-        "neo4j>=1.7.6,<4.0.0",
-        "neobolt>=1.7.0,<4.0.0",
+        "neo4j>=4.0.0",
         "policyuniverse>=1.1.0.0",
         "google-api-python-client>=1.7.8",
         "oauth2client>=4.1.3",

--- a/tests/integration/cartography/intel/okta/test_group.py
+++ b/tests/integration/cartography/intel/okta/test_group.py
@@ -30,7 +30,7 @@ def test_load_okta_group_members(neo4j_session):
     load_okta_group_members(neo4j_session, TEST_GROUP_ID, transformed_members, TEST_UPDATE_TAG)
 
     # Assert: members are attached to group 123
-    result: neo4j.BoltStatementResult = neo4j_session.run(
+    result: neo4j.Result = neo4j_session.run(
         'MATCH (o:OktaGroup{id: {GROUP_ID}})<-[:MEMBER_OF_OKTA_GROUP]-(u:OktaUser) RETURN u.last_name',
         GROUP_ID=TEST_GROUP_ID,
     )

--- a/tests/integration/driftdetect/test_get_state.py
+++ b/tests/integration/driftdetect/test_get_state.py
@@ -1,6 +1,6 @@
 import os
 
-import neobolt.exceptions
+import neo4j.exceptions
 import pytest
 from marshmallow import ValidationError
 
@@ -99,7 +99,7 @@ def test_faulty_queries(neo4j_session):
     storage = FileSystem
 
     file_1 = "2019 - 01 - 01_00_00_02.json"
-    with pytest.raises(neobolt.exceptions.CypherSyntaxError):
+    with pytest.raises(neo4j.exceptions.CypherSyntaxError):
         get_query_state(neo4j_session, query_directory, state_serializer, storage, file_1)
 
     query_directory = "tests/data/test_update_detectors/invalid_template"

--- a/tests/unit/driftdetect/test_detector.py
+++ b/tests/unit/driftdetect/test_detector.py
@@ -13,7 +13,7 @@ def test_state_no_drift():
     :return:
     """
     mock_session = MagicMock()
-    mock_boltstatementresult = MagicMock()
+    mock_result = MagicMock()
     key = "d.test"
     results = [
         {key: "1"},
@@ -24,9 +24,9 @@ def test_state_no_drift():
         {key: "6"},
     ]
 
-    mock_boltstatementresult.__getitem__.side_effect = results.__getitem__
-    mock_boltstatementresult.__iter__.side_effect = results.__iter__
-    mock_session.run.return_value = mock_boltstatementresult
+    mock_result.__getitem__.side_effect = results.__getitem__
+    mock_result.__iter__.side_effect = results.__iter__
+    mock_session.run.return_value = mock_result
     data = FileSystem.load("tests/data/detectors/test_expectations.json")
     state_old = StateSchema().load(data)
     state_new = State(state_old.name, state_old.validation_query, state_old.properties, [])
@@ -43,7 +43,7 @@ def test_state_picks_up_drift():
     """
     key = "d.test"
     mock_session = MagicMock()
-    mock_boltstatementresult = MagicMock()
+    mock_result = MagicMock()
     results = [
         {key: "1"},
         {key: "2"},
@@ -54,9 +54,9 @@ def test_state_picks_up_drift():
         {key: "7"},
     ]
 
-    mock_boltstatementresult.__getitem__.side_effect = results.__getitem__
-    mock_boltstatementresult.__iter__.side_effect = results.__iter__
-    mock_session.run.return_value = mock_boltstatementresult
+    mock_result.__getitem__.side_effect = results.__getitem__
+    mock_result.__iter__.side_effect = results.__iter__
+    mock_session.run.return_value = mock_result
     data = FileSystem.load("tests/data/detectors/test_expectations.json")
     state_old = StateSchema().load(data)
     state_new = State(state_old.name, state_old.validation_query, state_old.properties, [])
@@ -76,7 +76,7 @@ def test_state_multiple_expectations():
     key_1 = "d.test"
     key_2 = "d.test2"
     mock_session = MagicMock()
-    mock_boltstatementresult = MagicMock()
+    mock_result = MagicMock()
     results = [
         {key_1: "1", key_2: "8"},
         {key_1: "2", key_2: "9"},
@@ -87,9 +87,9 @@ def test_state_multiple_expectations():
         {key_1: "7", key_2: "14"},
     ]
 
-    mock_boltstatementresult.__getitem__.side_effect = results.__getitem__
-    mock_boltstatementresult.__iter__.side_effect = results.__iter__
-    mock_session.run.return_value = mock_boltstatementresult
+    mock_result.__getitem__.side_effect = results.__getitem__
+    mock_result.__iter__.side_effect = results.__iter__
+    mock_session.run.return_value = mock_result
     data = FileSystem.load("tests/data/detectors/test_multiple_expectations.json")
     state_old = StateSchema().load(data)
     state_new = State(state_old.name, state_old.validation_query, state_old.properties, [])
@@ -106,7 +106,7 @@ def test_drift_from_multiple_properties():
     :return:
     """
     mock_session = MagicMock()
-    mock_boltstatementresult = MagicMock()
+    mock_result = MagicMock()
     key_1 = "d.test"
     key_2 = "d.test2"
     key_3 = "d.test3"
@@ -119,9 +119,9 @@ def test_drift_from_multiple_properties():
         {key_1: "6", key_2: "13", key_3: ["20", "27", "34"]},
         {key_1: "7", key_2: "14", key_3: ["21", "28", "35"]},
     ]
-    mock_boltstatementresult.__getitem__.side_effect = results.__getitem__
-    mock_boltstatementresult.__iter__.side_effect = results.__iter__
-    mock_session.run.return_value = mock_boltstatementresult
+    mock_result.__getitem__.side_effect = results.__getitem__
+    mock_result.__iter__.side_effect = results.__iter__
+    mock_session.run.return_value = mock_result
     data = FileSystem.load("tests/data/detectors/test_multiple_properties.json")
     state_old = StateSchema().load(data)
     state_new = State(state_old.name, state_old.validation_query, state_old.properties, [])


### PR DESCRIPTION
Upgrade the neo4j driver, improving stability.
The new 4.x drivers [should be backwards compatible](https://github.com/neo4j/neo4j-python-driver#neo4j-bolt-driver-for-python) with older neo4j 3.x database that we currently use.
```
... These drivers will also be compatible with the previous Neo4j release, although new server features will not be available.
```
Tests pass, but before we merge, ~~we need to make sure that logging still works correctly~~
https://github.com/lyft/cartography/blob/master/cartography/cli.py#L461
https://github.com/lyft/cartography/blob/master/cartography/driftdetect/cli.py#L242

The logger is now called `'bolt'`
https://github.com/neo4j/neo4j-python-driver/blob/8f708fe9374f7e6bdfdf84ff611f266a8a5e9344/neo4j/io/_bolt3.py#L62
