### PR TITLE
AWS: use transactions in resourcegrouptaggingapi

### DIFF
--- a/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -1,3 +1,5 @@
+import copy
+
 import cartography.intel.aws.ec2
 import cartography.intel.aws.resourcegroupstaggingapi as rgta
 import tests.data.aws.ec2.instances
@@ -22,10 +24,11 @@ def test_transform_and_load_ec2_tags(neo4j_session):
     """
     _ensure_local_neo4j_has_test_ec2_instance_data(neo4j_session)
     resource_type = 'ec2:instance'
-    rgta.transform_tags(tests.data.aws.resourcegroupstaggingapi.GET_RESOURCES_RESPONSE, resource_type)
+    get_resources_response = copy.deepcopy(tests.data.aws.resourcegroupstaggingapi.GET_RESOURCES_RESPONSE)
+    rgta.transform_tags(get_resources_response, resource_type)
     rgta.load_tags(
         neo4j_session,
-        tests.data.aws.resourcegroupstaggingapi.GET_RESOURCES_RESPONSE,
+        get_resources_response,
         resource_type,
         TEST_REGION,
         TEST_UPDATE_TAG,

--- a/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -1,3 +1,5 @@
+import copy
+
 import cartography.intel.aws.resourcegroupstaggingapi as rgta
 import tests.data.aws.resourcegroupstaggingapi as test_data
 
@@ -38,6 +40,7 @@ def test_get_short_id_from_lb2_arn():
 
 
 def test_transform_tags():
-    assert 'resource_id' not in test_data.GET_RESOURCES_RESPONSE[0]
-    rgta.transform_tags(test_data.GET_RESOURCES_RESPONSE, 'ec2:instance')
-    assert 'resource_id' in test_data.GET_RESOURCES_RESPONSE[0]
+    get_resources_response = copy.deepcopy(test_data.GET_RESOURCES_RESPONSE)
+    assert 'resource_id' not in get_resources_response[0]
+    rgta.transform_tags(get_resources_response, 'ec2:instance')
+    assert 'resource_id' in get_resources_response[0]


### PR DESCRIPTION
Adresses #778

Upgrades the `load_tags` function to use neo4j transactions.