### PR TITLE
Export types, set stricter mypy baseline

### DIFF
--- a/cartography/graph/job.py
+++ b/cartography/graph/job.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Union
 
 import neo4j
 
@@ -86,7 +87,7 @@ class GraphJob:
         return cls(name, statements, short_name)
 
     @classmethod
-    def from_json_file(cls, file_path: Path) -> 'GraphJob':
+    def from_json_file(cls, file_path: Union[str, Path]) -> 'GraphJob':
         """
         Create a job from a JSON file.
         """
@@ -113,7 +114,7 @@ class GraphJob:
         job.run(neo4j_session)
 
     @classmethod
-    def run_from_json_file(cls, file_path: Path, neo4j_session: neo4j.Session, parameters: Dict) -> None:
+    def run_from_json_file(cls, file_path: Union[str, Path], neo4j_session: neo4j.Session, parameters: Dict) -> None:
         """
         Run a job from a JSON file. This will deserialize the job and execute all statements sequentially.
         """

--- a/cartography/graph/job.py
+++ b/cartography/graph/job.py
@@ -1,8 +1,10 @@
 import json
 import logging
 from pathlib import Path
+from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 
 import neo4j
 
@@ -18,7 +20,7 @@ class GraphJobJSONEncoder(json.JSONEncoder):
     Support JSON serialization for GraphJob instances.
     """
 
-    def default(self, obj):
+    def default(self, obj: Any) -> Any:
         if isinstance(obj, GraphJob):
             return obj.as_dict()
         else:
@@ -31,7 +33,7 @@ class GraphJob:
     A job that will run against the cartography graph. A job is a sequence of statements which execute sequentially.
     """
 
-    def __init__(self, name: str, statements: List[GraphStatement], short_name: str = None):
+    def __init__(self, name: str, statements: List[GraphStatement], short_name: Optional[str] = None):
         # E.g. "Okta intel module cleanup"
         self.name = name
         self.statements: List[GraphStatement] = statements
@@ -45,7 +47,7 @@ class GraphJob:
         for s in self.statements:
             s.merge_parameters(parameters)
 
-    def run(self, neo4j_session: neo4j.Session):
+    def run(self, neo4j_session: neo4j.Session) -> None:
         """
         Run the job. This will execute all statements sequentially.
         """
@@ -74,7 +76,7 @@ class GraphJob:
         }
 
     @classmethod
-    def from_json(cls, blob: str, short_name: str = None):
+    def from_json(cls, blob: str, short_name: Optional[str] = None) -> 'GraphJob':
         """
         Create a job from a JSON blob.
         """
@@ -84,7 +86,7 @@ class GraphJob:
         return cls(name, statements, short_name)
 
     @classmethod
-    def from_json_file(cls, file_path: Path):
+    def from_json_file(cls, file_path: Path) -> 'GraphJob':
         """
         Create a job from a JSON file.
         """
@@ -98,7 +100,7 @@ class GraphJob:
 
     @classmethod
     def run_from_json(
-        cls, neo4j_session: neo4j.Session, blob: str, parameters: Dict = None, short_name: str = None,
+        cls, neo4j_session: neo4j.Session, blob: str, parameters: Dict, short_name: Optional[str] = None,
     ) -> None:
         """
         Run a job from a JSON blob. This will deserialize the job and execute all statements sequentially.
@@ -111,7 +113,7 @@ class GraphJob:
         job.run(neo4j_session)
 
     @classmethod
-    def run_from_json_file(cls, file_path: Path, neo4j_session: neo4j.Session, parameters: Dict = None) -> None:
+    def run_from_json_file(cls, file_path: Path, neo4j_session: neo4j.Session, parameters: Dict) -> None:
         """
         Run a job from a JSON file. This will deserialize the job and execute all statements sequentially.
         """
@@ -124,7 +126,7 @@ class GraphJob:
         job.run(neo4j_session)
 
 
-def _get_statements_from_json(blob: Dict, short_job_name: str = None) -> List[GraphStatement]:
+def _get_statements_from_json(blob: Dict, short_job_name: Optional[str] = None) -> List[GraphStatement]:
     """
     Deserialize all statements from the JSON blob.
     """

--- a/cartography/graph/statement.py
+++ b/cartography/graph/statement.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from typing import Any
 from typing import Dict
 from typing import Union
 
@@ -51,7 +52,7 @@ class GraphStatement:
         self.parent_job_name = parent_job_name if parent_job_name else None
         self.parent_job_sequence_num = parent_job_sequence_num if parent_job_sequence_num else None
 
-    def merge_parameters(self, parameters):
+    def merge_parameters(self, parameters: Dict) -> None:
         """
         Merge given parameters with existing parameters.
         """
@@ -69,7 +70,7 @@ class GraphStatement:
             session.write_transaction(self._run_noniterative).consume()
         logger.info(f"Completed {self.parent_job_name} statement #{self.parent_job_sequence_num}")
 
-    def as_dict(self):
+    def as_dict(self) -> Dict[str, Any]:
         """
         Convert statement to a dictionary.
         """

--- a/cartography/graph/statement.py
+++ b/cartography/graph/statement.py
@@ -43,9 +43,7 @@ class GraphStatement:
         parent_job_name: str = None, parent_job_sequence_num: int = None,
     ):
         self.query = query
-        self.parameters: Dict = parameters
-        if not parameters:
-            self.parameters = {}
+        self.parameters = parameters or {}
         self.iterative = iterative
         self.iterationsize = iterationsize
         self.parameters["LIMIT_SIZE"] = self.iterationsize

--- a/cartography/intel/aws/apigateway.py
+++ b/cartography/intel/aws/apigateway.py
@@ -2,7 +2,6 @@ import json
 import logging
 from typing import Any
 from typing import Dict
-from typing import Generator
 from typing import List
 from typing import Optional
 from typing import Tuple
@@ -35,17 +34,20 @@ def get_apigateway_rest_apis(boto3_session: boto3.session.Session, region: str) 
 @aws_handle_regions
 def get_rest_api_details(
         boto3_session: boto3.session.Session, rest_apis: List[Dict], region: str,
-) -> Generator[Any, Any, Any]:
+) -> List[Tuple[Any, Any, Any, Any, Any]]:
     """
     Iterates over all API Gateway REST APIs.
     """
     client = boto3_session.client('apigateway', region_name=region)
+    apis = []
     for api in rest_apis:
         stages = get_rest_api_stages(api, client)
-        certificate = get_rest_api_client_certificate(stages, client)  # clientcertificate id is given by the api stage
+        # clientcertificate id is given by the api stage
+        certificate = get_rest_api_client_certificate(stages, client)  # type: ignore
         resources = get_rest_api_resources(api, client)
         policy = get_rest_api_policy(api, client)
-        yield api['id'], stages, certificate, resources, policy
+        apis.append((api['id'], stages, certificate, resources, policy))
+    return apis
 
 
 @timeit

--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -253,7 +253,7 @@ def load(neo4j_session: neo4j.Session, data: List[Dict], region: str, aws_accoun
                 'netinf_id': network_interface['NetworkInterfaceId'],
                 'instance_id': network_interface['Attachment']['InstanceId'],
             })
-    load_network_interfaces(neo4j_session, data, region, aws_account_id, update_tag)
+    load_network_interfaces(neo4j_session, data, region, aws_account_id, update_tag)  # type: ignore
     load_network_interface_instance_relations(
         neo4j_session, instance_associations, region, aws_account_id, update_tag,
     )

--- a/cartography/intel/aws/eks.py
+++ b/cartography/intel/aws/eks.py
@@ -107,7 +107,7 @@ def sync(
 
         cluster_data: Dict = {}
         for cluster_name in clusters:
-            cluster_data[cluster_name] = get_eks_describe_cluster(boto3_session, region, cluster_name)
+            cluster_data[cluster_name] = get_eks_describe_cluster(boto3_session, region, cluster_name)  # type: ignore
 
         load_eks_clusters(neo4j_session, cluster_data, region, current_aws_account_id, update_tag)
 

--- a/cartography/intel/aws/elasticsearch.py
+++ b/cartography/intel/aws/elasticsearch.py
@@ -239,4 +239,4 @@ def sync(
         data = _get_es_domains(client)
         _load_es_domains(neo4j_session, data, current_aws_account_id, update_tag)
 
-    cleanup(neo4j_session, update_tag, current_aws_account_id)
+    cleanup(neo4j_session, update_tag, current_aws_account_id)  # type: ignore

--- a/cartography/intel/aws/lambda_function.py
+++ b/cartography/intel/aws/lambda_function.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any
 from typing import Dict
-from typing import Generator
 from typing import List
 from typing import Tuple
 
@@ -111,13 +110,15 @@ def get_event_source_mappings(lambda_function: Dict, client: botocore.client.Bas
 @aws_handle_regions
 def get_lambda_function_details(
         boto3_session: boto3.session.Session, data: List[Dict], region: str,
-) -> Generator[Any, Any, None]:
+) -> List[Tuple[str, List[Any], List[Any], List[Any]]]:
     client = boto3_session.client('lambda', region_name=region)
+    details = []
     for lambda_function in data:
         function_aliases = get_function_aliases(lambda_function, client)
         event_source_mappings = get_event_source_mappings(lambda_function, client)
         layers = lambda_function.get('Layers', [])
-        yield lambda_function['FunctionArn'], function_aliases, event_source_mappings, layers
+        details.append((lambda_function['FunctionArn'], function_aliases, event_source_mappings, layers))
+    return details
 
 
 @timeit

--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -410,7 +410,7 @@ def sync_rds_clusters(
     for region in regions:
         logger.info("Syncing RDS for region '%s' in account '%s'.", region, current_aws_account_id)
         data = get_rds_cluster_data(boto3_session, region)
-        load_rds_clusters(neo4j_session, data, region, current_aws_account_id, update_tag)
+        load_rds_clusters(neo4j_session, data, region, current_aws_account_id, update_tag)  # type: ignore
     cleanup_rds_clusters(neo4j_session, common_job_parameters)
 
 
@@ -425,7 +425,7 @@ def sync_rds_instances(
     for region in regions:
         logger.info("Syncing RDS for region '%s' in account '%s'.", region, current_aws_account_id)
         data = get_rds_instance_data(boto3_session, region)
-        load_rds_instances(neo4j_session, data, region, current_aws_account_id, update_tag)
+        load_rds_instances(neo4j_session, data, region, current_aws_account_id, update_tag)  # type: ignore
     cleanup_rds_instances_and_db_subnet_groups(neo4j_session, common_job_parameters)
 
 

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -221,11 +221,11 @@ def sync(
         logger.info(f"Syncing AWS tags for account {current_aws_account_id} and region {region}")
         for resource_type in tag_resource_type_mappings.keys():
             tag_data = get_tags(boto3_session, [resource_type], region)
-            transform_tags(tag_data, resource_type)
+            transform_tags(tag_data, resource_type)  # type: ignore
             logger.info(f"Loading {len(tag_data)} tags for resource type {resource_type}")
             load_tags(
                 neo4j_session=neo4j_session,
-                tag_data=tag_data,
+                tag_data=tag_data,  # type: ignore
                 resource_type=resource_type,
                 region=region,
                 current_aws_account_id=current_aws_account_id,

--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -34,7 +34,7 @@ def _sync_tenant(
     common_job_parameters: Dict,
 ) -> None:
     logger.info("Syncing Azure Tenant: %s", tenant_id)
-    tenant.sync(neo4j_session, tenant_id, current_user, update_tag, common_job_parameters)
+    tenant.sync(neo4j_session, tenant_id, current_user, update_tag, common_job_parameters)  # type: ignore
 
 
 def _sync_multiple_subscriptions(

--- a/cartography/intel/azure/compute.py
+++ b/cartography/intel/azure/compute.py
@@ -216,7 +216,7 @@ def sync_snapshot(
     cleanup_snapshot(neo4j_session, common_job_parameters)
 
 
-@ timeit
+@timeit
 def sync(
     neo4j_session: neo4j.Session, credentials: Credentials, subscription_id: str, update_tag: int,
     common_job_parameters: Dict,

--- a/cartography/intel/azure/sql.py
+++ b/cartography/intel/azure/sql.py
@@ -96,7 +96,7 @@ def sync_server_details(
         server_list: List[Dict], sync_tag: int,
 ) -> None:
     details = get_server_details(credentials, subscription_id, server_list)
-    load_server_details(neo4j_session, credentials, subscription_id, details, sync_tag)
+    load_server_details(neo4j_session, credentials, subscription_id, details, sync_tag)  # type: ignore
 
 
 @timeit
@@ -609,7 +609,7 @@ def sync_database_details(
         subscription_id: str, databases: List[Dict], update_tag: int,
 ) -> None:
     db_details = get_database_details(credentials, subscription_id, databases)
-    load_database_details(neo4j_session, db_details, update_tag)
+    load_database_details(neo4j_session, db_details, update_tag)  # type: ignore
 
 
 @timeit

--- a/cartography/intel/dns.py
+++ b/cartography/intel/dns.py
@@ -52,11 +52,11 @@ def ingest_dns_record_by_fqdn(
         value = ",".join(ip_list)
         record_id = ingest_dns_record(
             neo4j_session, fqdn, value, record_type, update_tag, points_to_record,
-            record_label, dns_node_additional_label,
+            record_label, dns_node_additional_label,  # type: ignore
         )
         _link_ip_to_A_record(neo4j_session, update_tag, ip_list, record_id)
 
-        return record_id
+        return record_id  # type: ignore
     else:
         raise NotImplementedError(
             "Ingestion of DNS record type '{}' by FQDN has not been implemented. Failed to ingest '{}'.".format(

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -41,7 +41,7 @@ def call_github_api(query: str, variables: str, token: str, api_url: str) -> Dic
             f'call_github_api() response has errors, please investigate. Raw response: {response_json["errors"]}; '
             f'continuing sync.',
         )
-    return response_json
+    return response_json  # type: ignore
 
 
 def fetch_page(token: str, api_url: str, organization: str, query: str, cursor: Optional[str] = None) -> Dict:

--- a/cartography/intel/jamf/computers.py
+++ b/cartography/intel/jamf/computers.py
@@ -42,7 +42,7 @@ def sync_computer_groups(
     jamf_password: str,
 ) -> None:
     groups = get_computer_groups(jamf_base_uri, jamf_user, jamf_password)
-    load_computer_groups(groups, neo4j_session, update_tag)
+    load_computer_groups(groups, neo4j_session, update_tag)  # type: ignore
 
 
 @timeit

--- a/cartography/stats.py
+++ b/cartography/stats.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from statsd import StatsClient
 
 
@@ -14,9 +16,8 @@ class ScopedStatsClient:
     """
 
     _client: StatsClient = None
-    _root: 'ScopedStatsClient' = None
 
-    def __init__(self, prefix: str = None, root: 'ScopedStatsClient' = None):
+    def __init__(self, prefix: Optional[str], root: 'ScopedStatsClient'):
         self._scope_prefix = prefix
         self._root = root
 
@@ -35,7 +36,7 @@ class ScopedStatsClient:
 
     @staticmethod
     def get_root_client() -> 'ScopedStatsClient':
-        client = ScopedStatsClient()
+        client = ScopedStatsClient(prefix=None, root=None)  # type: ignore
         client._root = client
         return client
 

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -19,7 +19,7 @@ import neo4j
 
 from cartography.graph.job import GraphJob
 from cartography.graph.statement import get_job_shortname
-from cartography.stats import _scoped_stats_client
+from cartography.stats import get_stats_client
 from cartography.stats import ScopedStatsClient
 
 if sys.version_info >= (3, 7):
@@ -114,11 +114,9 @@ def timeit(method: F) -> F:
     # Allow access via `inspect` to the wrapped function. This is used in integration tests to standardize param names.
     @wraps(method)
     def timed(*args, **kwargs):  # type: ignore
-        stats_client = _scoped_stats_client  # global client
+        stats_client = get_stats_client(method.__module__)
         if stats_client.is_enabled():
-            # Example metric name "cartography.intel.aws.iam.get_group_membership_data"
-            metric_name = f"{method.__module__}.{method.__name__}"
-            timer = stats_client.timer(metric_name)
+            timer = stats_client.timer(method.__name__)
             timer.start()
             result = method(*args, **kwargs)
             timer.stop()

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,16 +7,50 @@ max-line-length = 120
 max-line-length = 120
 
 [mypy]
-check_untyped_defs = true
-disallow_untyped_defs = true
-ignore_errors = true
+disallow_any_generics = false
+disallow_untyped_decorators = true
 implicit_reexport = false
+show_error_codes = true
+warn_redundant_casts = true
+warn_unused_configs = true
+warn_unused_ignores = true
+# required for `warn_unused_configs = true`
+incremental = false
 
-[mypy-cartography.intel.*]
-ignore_errors = false
+[mypy-cartography.intel,cartography.intel.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+strict_equality = true
 
-[mypy-cartography.intel]
-ignore_errors = false
+[mypy-cartography.intel.crxcavator.crxcavator]
+ignore_errors = true
+
+[mypy-cartography.intel.aws.kms]
+ignore_errors = true
+
+[mypy-cartography.intel.aws.route53]
+ignore_errors = true
+
+[mypy-cartography.intel.aws.s3]
+ignore_errors = true
+
+[mypy-cartography.intel.azure.cosmosdb]
+ignore_errors = true
+
+[mypy-cartography.intel.azure.storage]
+ignore_errors = true
+
+[mypy-cartography.intel.gcp.compute]
+ignore_errors = true
+
+[mypy-cartography.intel.okta.applications]
+ignore_errors = true
+
+[mypy-tests.*]
+disallow_untyped_defs = false
+allow_redefinition = true
 
 [coverage:report]
 fail_under = 30

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,17 @@ disallow_untyped_calls = true
 disallow_untyped_defs = true
 strict_equality = true
 
+[mypy-cartography.graph.job,cartography.intel.github.*,cartography.util]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+strict_equality = true
+warn_unreachable = true
+warn_return_any = true
+
 [mypy-cartography.intel.crxcavator.crxcavator]
 ignore_errors = true
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     license='apache2',
     packages=find_packages(exclude=['tests*']),
     package_data={
+        'cartography': ['py.typed'],
         'cartography.data': [
             '*.cypher',
             '*.yaml',

--- a/tests/data/aws/sqs.py
+++ b/tests/data/aws/sqs.py
@@ -1,15 +1,21 @@
-GET_SQS_QUEUE_ATTRIBUTES = {
-    'https://us-east-1.queue.amazonaws.com/000000000000/test-queue-1': {
-        'QueueArn': 'arn:aws:secretsmanager:us-east-1:000000000000:test-queue-1',
-        'CreatedTimestamp': '1627539901900',
-        'LastModifiedTimestamp': '1627539901900',
-        'RedrivePolicy': '{"deadLetterTargetArn": "arn:aws:secretsmanager:us-east-1:000000000000:test-queue-2", "maxReceiveCount": "1"}',  # noqa: E501
-        'VisibilityTimeout': '10',
-    },
-    'https://us-east-1.queue.amazonaws.com/000000000000/test-queue-2': {
-        'QueueArn': 'arn:aws:secretsmanager:us-east-1:000000000000:test-queue-2',
-        'CreatedTimestamp': '1627539901900',
-        'LastModifiedTimestamp': '1627539901900',
-        'VisibilityTimeout': '10',
-    },
-}
+GET_SQS_QUEUE_ATTRIBUTES = [
+    (
+        'https://us-east-1.queue.amazonaws.com/000000000000/test-queue-1',
+        {
+            'QueueArn': 'arn:aws:secretsmanager:us-east-1:000000000000:test-queue-1',
+            'CreatedTimestamp': '1627539901900',
+            'LastModifiedTimestamp': '1627539901900',
+            'RedrivePolicy': '{"deadLetterTargetArn": "arn:aws:secretsmanager:us-east-1:000000000000:test-queue-2", "maxReceiveCount": "1"}',  # noqa: E501
+            'VisibilityTimeout': '10',
+        },
+    ),
+    (
+        'https://us-east-1.queue.amazonaws.com/000000000000/test-queue-2',
+        {
+            'QueueArn': 'arn:aws:secretsmanager:us-east-1:000000000000:test-queue-2',
+            'CreatedTimestamp': '1627539901900',
+            'LastModifiedTimestamp': '1627539901900',
+            'VisibilityTimeout': '10',
+        },
+    ),
+]

--- a/tests/integration/cartography/data/jobs/test_cleanup_jobs.py
+++ b/tests/integration/cartography/data/jobs/test_cleanup_jobs.py
@@ -128,6 +128,5 @@ def test_run_cleanup_job_iterative_multiple_batches(mock_read_text: mock.MagicMo
         """,
     )
     actual_nodes = {n['n.id'] for n in nodes}
-    expected_nodes = set()
-    assert actual_nodes == expected_nodes
+    assert actual_nodes == set()
     mock_read_text.assert_called_once()


### PR DESCRIPTION
# Export types, set stricter mypy baseline

Lyft recently shipped a change to our internal GitHub code
that included a type error, which we should have been able to catch in CI.
Update Cartography to make this possible:
- Follow https://peps.python.org/pep-0561/ to export the type hints
  already present in the Cartography codebase,
  by adding a `py.typed` file and including it in our distributions.
- In our recent buggy change, the lack of typing on decorators (namely `@timeit`)
  meant that although all the functions involved had type hints,
  because they were decorated with `@timeit` mypy saw them typed as `Any`
  and was not able to warn us of a mismatch of argument types/count.
  So, add type annotations to `@timeit` and set `disallow_untyped_decorators = true`.
- Ratchet up the default mypy configuration to be more strict generally.
  We're not yet ready to set `strict = true` globally,
  and that option is unforunately only settable globally,
  not on a per-module basis
  so we cannot opt modules out.
  Set as many global strictness flags as feasible,
  since we cannot incrementally adopt them in a per-module basis.
  Fix all errors outside intel modules;
  for intel modules, `# type: ignore` if there are only 1 or 2 errors
  or else ignore errors on the entire module.

# Ratchet mypy on modules used by Lyft's GitHub ingestion

Lyft has additional changes planned to its GitHub code in the near term,
so ratchet up the strictness flags to catch any errors.
Note that we leave `disallow_any_generics = false`;
setting it to `true` would be more strict
but it's not clear it's yet worth it to add those types,
vs switching to e.g. TypedDict.

The `GraphJob.run_from_json` and `GraphJob.run_from_json_file`
methods lose the default value of `None` for their `parameters` argument;
this appears to be a breaking change for API callers not passing that argument.
However, the parameters argument is passed through to a dict.update call,
which does not accept `None` as an input,
so any callers not passing that argument would have failed at runtime anyways.

# Loosen typing on GraphJob json file_paths

The `file_path` parameter is passed directly to `open`,
which supports `typing.Union[str, bytes, os.PathLike]`,
and internally at Lyft we always pass a string for this parameter.

We need to parse out a shortname as a string from the path,
so we can't expand this type to include bytes;
only expand to be a Union of str and Path.

# Remove unneeded use of global stats client

Instead of manually scoping our stat, use `get_stats_client`.