### PR TITLE
Pull in more EMR data from the available describe cluster data

### DIFF
--- a/cartography/intel/aws/emr.py
+++ b/cartography/intel/aws/emr.py
@@ -57,18 +57,34 @@ def load_emr_clusters(
     UNWIND {Clusters} as emr_cluster
         MERGE (cluster:EMRCluster{id: emr_cluster.Name})
         ON CREATE SET cluster.firstseen = timestamp(),
-            cluster.arn                 = emr_cluster.ClusterArn,
-            cluster.id                  = emr_cluster.Id,
-            cluster.name                = emr_cluster.Name,
-            cluster.servicerole         = emr_cluster.ServiceRole,
-            cluster.region              = {Region}
-        SET cluster.lastupdated         = {aws_update_tag}
+            cluster.arn = emr_cluster.ClusterArn,
+            cluster.id = emr_cluster.Id,
+            cluster.region = {Region}
+        SET cluster.name = emr_cluster.Name,
+            cluster.instance_collection_type = emr_cluster.InstanceCollectionType,
+            cluster.log_encryption_kms_key_id = emr_cluster.LogEncryptionKmsKeyId,
+            cluster.requested_ami_version = emr_cluster.RequestedAmiVersion,
+            cluster.running_ami_version = emr_cluster.RunningAmiVersion,
+            cluster.release_label = emr_cluster.ReleaseLabel,
+            cluster.auto_terminate = emr_cluster.AutoTerminate,
+            cluster.termination_protected = emr_cluster.TerminationProtected,
+            cluster.visible_to_all_users = emr_cluster.VisibleToAllUsers,
+            cluster.master_public_dns_name = emr_cluster.MasterPublicDnsName,
+            cluster.security_configuration = emr_cluster.SecurityConfiguration,
+            cluster.autoscaling_role = emr_cluster.AutoScalingRole,
+            cluster.scale_down_behavior = emr_cluster.ScaleDownBehavior,
+            cluster.custom_ami_id = emr_cluster.CustomAmiId,
+            cluster.repo_upgrade_on_boot = emr_cluster.RepoUpgradeOnBoot,
+            cluster.outpost_arn = emr_cluster.OutpostArn,
+            cluster.log_uri = emr_cluster.LogUri,
+            cluster.servicerole = emr_cluster.ServiceRole,
+            cluster.lastupdated = {aws_update_tag}
         WITH cluster
 
         MATCH (owner:AWSAccount{id: {AWS_ACCOUNT_ID}})
         MERGE (owner)-[r:RESOURCE]->(cluster)
-        ON CREATE SET r.firstseen       = timestamp()
-        SET r.lastupdated               = {aws_update_tag}
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = {aws_update_tag}
     """
 
     logger.info("Loading EMR %d clusters for region '%s' into graph.", len(cluster_data), region)

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1261,24 +1261,23 @@ Representation of a scan finding from AWS ECR. This is the result output of [`ec
 
 Representation of an AWS [EKS Cluster](https://docs.aws.amazon.com/eks/latest/APIReference/API_Cluster.html).
 
-| Field            | Description                                                                                                 |
-| ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| firstseen        | Timestamp of when a sync job first discovered this node                                                     |
-| lastupdated      | Timestamp of the last time the node was updated                                                             |
-| created_at       | The date and time the cluster was created                                                                   |
-| region           | The AWS region                                                                                              |
-| **arn**          | AWS-unique identifier for this object                                                                       |
-| id               | same as `arn`                                                                                               |
-| name             | Name of the EKS Cluster                                                                                     |
-| endpoint         | The endpoint for the Kubernetes API server.                                                                 |
-| endpoint_public_access | Indicates whether the Amazon EKS public API server endpoint is enabled                                |
-| exposed_internet | Set to True if the EKS Cluster public API server endpoint is enabled                                        |
-| rolearn          | The ARN of the IAM role that provides permissions for the Kubernetes control plane to make calls to AWS API |
-| version          | Kubernetes version running                                                                                  |
-| platform_version | Version of EKS                                                                                              |
-| status           | Status of the cluster. Valid Values: creating, active, deleting, failed, updating                           |
-| audit_logging    | Whether audit logging is enabled                                                                            |
-
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| created_at | The date and time the cluster was created |
+| region | The AWS region |
+| **arn** | AWS-unique identifier for this object |
+| id | same as `arn` |
+| name | Name of the EKS Cluster |
+| endpoint | The endpoint for the Kubernetes API server. |
+| endpoint_public_access | Indicates whether the Amazon EKS public API server endpoint is enabled |
+| exposed_internet | Set to True if the EKS Cluster public API server endpoint is enabled |
+| rolearn | The ARN of the IAM role that provides permissions for the Kubernetes control plane to make calls to AWS API |
+| version | Kubernetes version running |
+| platform_version | Version of EKS |
+| status | Status of the cluster. Valid Values: creating, active, deleting, failed, updating |
+| audit_logging | Whether audit logging is enabled |
 
 #### Relationships
 
@@ -1287,20 +1286,34 @@ Representation of an AWS [EKS Cluster](https://docs.aws.amazon.com/eks/latest/AP
       (AWSAccount)-[RESOURCE]->(EKSCluster)
       ```
 
-
-
 ### EMRCluster
 
 Representation of an AWS [EMR Cluster](https://docs.aws.amazon.com/emr/latest/APIReference/API_Cluster.html).
 
-| Field            | Description                                                                                                 |
-| ---------------- | ----------------------------------------------------------------------------------------------------------- |
-| firstseen        | Timestamp of when a sync job first discovered this node                                                     |
-| lastupdated      | Timestamp of the last time the node was updated                                                             |
-| region           | The AWS region                                                                                              |
-| **arn**          | AWS-unique identifier for this object                                                                       |
-| id               | The Id of the EMR Cluster.                                                                                  |
-| servicerole      | Service Role of the EMR Cluster                                                                             |
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| region | The AWS region |
+| **arn** | AWS-unique identifier for this object |
+| id | The Id of the EMR Cluster. |
+| instance\_collection\_type | The instance group configuration of the cluster. A value of INSTANCE\_GROUP indicates a uniform instance group configuration. A value of INSTANCE\_FLEET indicates an instance fleets configuration. |
+| log\_encryption\_kms\_key\_id | The KMS key used for encrypting log files. |
+| requested\_ami\_version | The AMI version requested for this cluster. |
+| running\_ami\_version | The AMI version running on this cluster. |
+| release\_label | The Amazon EMR release label, which determines the version of open-source application packages installed on the cluster. |
+| auto\_terminate | Specifies whether the cluster should terminate after completing all steps. |
+| termination\_protected | Indicates whether Amazon EMR will lock the cluster to prevent the EC2 instances from being terminated by an API call or user intervention, or in the event of a cluster error. |
+| visible\_to\_all\_users | Indicates whether the cluster is visible to IAM principals in the Amazon Web Services account associated with the cluster. |
+| master\_public\_dns\_name | The DNS name of the master node. If the cluster is on a private subnet, this is the private DNS name. On a public subnet, this is the public DNS name. |
+| security\_configuration | The name of the security configuration applied to the cluster. |
+| autoscaling\_role | An IAM role for automatic scaling policies. |
+| scale\_down\_behavior | The way that individual Amazon EC2 instances terminate when an automatic scale-in activity occurs or an instance group is resized. |
+| custom\_ami\_id | The ID of a custom Amazon EBS-backed Linux AMI if the cluster uses a custom AMI. |
+| repo\_upgrade\_on\_boot | Specifies the type of updates that are applied from the Amazon Linux AMI package repositories when an instance boots using the AMI. |
+| outpost\_arn | The Amazon Resource Name (ARN) of the Outpost where the cluster is launched. |
+| log\_uri | The path to the Amazon S3 location where logs for this cluster are stored. |
+| servicerole | Service Role of the EMR Cluster |
 
 
 #### Relationships


### PR DESCRIPTION
This change pulls in useful data that's already available on the EMR describe cluster data being pulled down.