### PR TITLE
Fix typing of `update_tag` parameters

### DIFF
--- a/cartography/intel/aws/dynamodb.py
+++ b/cartography/intel/aws/dynamodb.py
@@ -30,7 +30,7 @@ def get_dynamodb_tables(boto3_session: boto3.session.Session, region: str) -> Li
 @timeit
 def load_dynamodb_tables(
     neo4j_session: neo4j.Session, data: List[Dict], region: str, current_aws_account_id: str,
-    aws_update_tag: str,
+    aws_update_tag: int,
 ) -> None:
     ingest_table = """
     MERGE (table:DynamoDBTable{id: {Arn}})
@@ -65,7 +65,7 @@ def load_dynamodb_tables(
 @timeit
 def load_gsi(
     neo4j_session: neo4j.Session, table: Dict, region: str, current_aws_account_id: str,
-    aws_update_tag: str,
+    aws_update_tag: int,
 ) -> None:
     ingest_gsi = """
     MERGE (gsi:DynamoDBGlobalSecondaryIndex{id: {Arn}})

--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -121,7 +121,7 @@ def _load_ec2_instance_tx(
         instance_state: str,
         current_aws_account_id: str,
         region: str,
-        update_tag: str,
+        update_tag: int,
 ) -> None:
     query = """
         MERGE (instance:Instance:EC2Instance{id: {InstanceId}})
@@ -188,7 +188,7 @@ def _load_ec2_instance_tx(
     )
 
 
-def _load_ec2_subnet_tx(tx: neo4j.Transaction, instanceid: str, subnet_id: str, region: str, update_tag: str) -> None:
+def _load_ec2_subnet_tx(tx: neo4j.Transaction, instanceid: str, subnet_id: str, region: str, update_tag: int) -> None:
     query = """
         MATCH (instance:EC2Instance{id: {InstanceId}})
         MERGE (subnet:EC2Subnet{subnetid: {SubnetId}})
@@ -215,7 +215,7 @@ def _load_ec2_keypairs_tx(
         region: str,
         instanceid: str,
         current_aws_account_id: str,
-        update_tag: str,
+        update_tag: int,
 ) -> None:
     query = """
         MERGE (keypair:KeyPair:EC2KeyPair{arn: {KeyPairARN}, id: {KeyPairARN}})
@@ -250,7 +250,7 @@ def _load_ec2_security_groups_tx(
         instanceid: str,
         region: str,
         current_aws_account_id: str,
-        update_tag: str,
+        update_tag: int,
 ) -> None:
     query = """
         MERGE (group:EC2SecurityGroup{id: {GroupId}})
@@ -372,7 +372,7 @@ def get_ec2_instance_ebs_volumes(instance: Dict) -> List[Dict]:
 def _load_ec2_instance_ebs_tx(
         tx: neo4j.Transaction,
         ebs_data: List[Dict[str, Any]],
-        update_tag: str,
+        update_tag: int,
         current_aws_account_id: str,
 ) -> None:
     query = """

--- a/cartography/intel/aws/ec2/subnets.py
+++ b/cartography/intel/aws/ec2/subnets.py
@@ -81,7 +81,7 @@ def cleanup_subnets(neo4j_session: neo4j.Session, common_job_parameters: Dict) -
 @timeit
 def sync_subnets(
         neo4j_session: neo4j.Session, boto3_session: boto3.session.Session, regions: List[str],
-        current_aws_account_id: str, update_tag: str, common_job_parameters: Dict,
+        current_aws_account_id: str, update_tag: int, common_job_parameters: Dict,
 ) -> None:
     for region in regions:
         logger.info("Syncing EC2 subnets for region '%s' in account '%s'.", region, current_aws_account_id)

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -378,7 +378,7 @@ def get_policies_for_principal(neo4j_session: neo4j.Session, principal_arn: str)
 
 @timeit
 def sync_assumerole_relationships(
-    neo4j_session: neo4j.Session, current_aws_account_id: str, aws_update_tag: str,
+    neo4j_session: neo4j.Session, current_aws_account_id: str, aws_update_tag: int,
     common_job_parameters: Dict,
 ) -> None:
     # Must be called after load_role

--- a/cartography/intel/digitalocean/compute.py
+++ b/cartography/intel/digitalocean/compute.py
@@ -15,7 +15,7 @@ def sync(
         neo4j_session: neo4j.Session,
         manager: Manager,
         projects_resources: dict,
-        digitalocean_update_tag: str,
+        digitalocean_update_tag: int,
         common_job_parameters: dict,
 ) -> None:
     sync_droplets(neo4j_session, manager, projects_resources, digitalocean_update_tag, common_job_parameters)
@@ -26,7 +26,7 @@ def sync_droplets(
         neo4j_session: neo4j.Session,
         manager: Manager,
         projects_resources: dict,
-        digitalocean_update_tag: str,
+        digitalocean_update_tag: int,
         common_job_parameters: dict,
 ) -> None:
     logger.info("Syncing Droplets")
@@ -80,7 +80,7 @@ def _get_project_id_for_droplet(droplet_id: int, project_resources: dict) -> Opt
 
 
 @timeit
-def load_droplets(neo4j_session: neo4j.Session, data: list, digitalocean_update_tag: str) -> None:
+def load_droplets(neo4j_session: neo4j.Session, data: list, digitalocean_update_tag: int) -> None:
     query = """
         MERGE (p:DOProject{id:{ProjectId}})
         ON CREATE SET p.firstseen = timestamp()

--- a/cartography/intel/digitalocean/management.py
+++ b/cartography/intel/digitalocean/management.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 def sync(
         neo4j_session: neo4j.Session,
         manager: Manager,
-        digitalocean_update_tag: str,
+        digitalocean_update_tag: int,
         common_job_parameters: dict,
 ) -> dict:
     projects_resources = sync_projects(neo4j_session, manager, digitalocean_update_tag, common_job_parameters)
@@ -24,7 +24,7 @@ def sync(
 def sync_projects(
         neo4j_session: neo4j.Session,
         manager: Manager,
-        digitalocean_update_tag: str,
+        digitalocean_update_tag: int,
         common_job_parameters: dict,
 ) -> dict:
     logger.info("Syncing Projects")
@@ -73,7 +73,7 @@ def transform_projects(project_res: list, account_id: str) -> list:
 
 
 @timeit
-def load_projects(neo4j_session: neo4j.Session, data: list, digitalocean_update_tag: str) -> None:
+def load_projects(neo4j_session: neo4j.Session, data: list, digitalocean_update_tag: int) -> None:
     query = """
         MERGE (a:DOAccount{id:{AccountId}})
         ON CREATE SET a.firstseen = timestamp()

--- a/cartography/intel/digitalocean/platform.py
+++ b/cartography/intel/digitalocean/platform.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 def sync(
         neo4j_session: neo4j.Session,
         account: Account,
-        digitalocean_update_tag: str,
+        digitalocean_update_tag: int,
         common_job_parameters: dict,
 ) -> None:
     sync_account(neo4j_session, account, digitalocean_update_tag, common_job_parameters)
@@ -23,7 +23,7 @@ def sync(
 def sync_account(
         neo4j_session: neo4j.Session,
         account: Account,
-        digitalocean_update_tag: str,
+        digitalocean_update_tag: int,
         common_job_parameters: dict,
 ) -> None:
     logger.info("Syncing Account")
@@ -45,7 +45,7 @@ def transform_account(account_res: Account) -> dict:
 
 
 @timeit
-def load_account(neo4j_session: neo4j.Session, account: dict, digitalocean_update_tag: str) -> None:
+def load_account(neo4j_session: neo4j.Session, account: dict, digitalocean_update_tag: int) -> None:
     query = """
             MERGE (a:DOAccount{id:{AccountId}})
             ON CREATE SET a.firstseen = timestamp()

--- a/docs/root/dev/writing-intel-modules.md
+++ b/docs/root/dev/writing-intel-modules.md
@@ -60,8 +60,8 @@ There are many best practices to consider here.
 #### Handling cartography's `update_tag`:
 
 `cartography`'s global [config object carries around an `update_tag` property](https://github.com/lyft/cartography/blob/8d60311a10156cd8aa16de7e1fe3e109cc3eca0f/cartography/cli.py#L91-L98)
-which is a tag/label associated with the current sync. Cartography's CLI code [sets this to a Unix timestamp of when the CLI was run](https://github.com/lyft/cartography/blob/8d60311a10156cd8aa16de7e1fe3e109cc3eca0f/cartography/sync.py#L131-L134),
-but in theory could be anything provided that it is unique per sync.
+which is a tag/label associated with the current sync.
+Cartography's CLI code [sets this to a Unix timestamp of when the CLI was run](https://github.com/lyft/cartography/blob/8d60311a10156cd8aa16de7e1fe3e109cc3eca0f/cartography/sync.py#L131-L134).
 
 All `cartography` intel modules need to set the `lastupdated` property on all nodes and all relationships to this
 `update_tag`. You can see a couple examples of this in our

--- a/docs/root/ops.md
+++ b/docs/root/ops.md
@@ -9,9 +9,9 @@ how that process works.
 
 ### Update tags
 
-Each sync run has an `update_tag` associated with it, which by default is the [Unix timestamp of when the sync
-started](https://github.com/lyft/cartography/blob/8d60311a10156cd8aa16de7e1fe3e109cc3eca0f/cartography/sync.py#L131-L134),
-but in theory could be anything provided that it is unique per sync (more details [here](../dev/writing-intel-modules.md#handling-cartographys-update_tag)).
+Each sync run has an `update_tag` associated with it,
+which is the [Unix timestamp of when the sync started](https://github.com/lyft/cartography/blob/8d60311a10156cd8aa16de7e1fe3e109cc3eca0f/cartography/sync.py#L131-L134).
+See our [docs for more details](../dev/writing-intel-modules.md#handling-cartographys-update_tag).
 
 ### Cleanup jobs
 


### PR DESCRIPTION
Automated via `rg 'update_tag: str' -l | xargs gsed -i 's/update_tag: str/update_tag: int/g'`.
Pulling this out of the [larger change to improve mypy configuration](https://github.com/lyft/cartography/pull/790).