### PR TITLE
Add sync metadata to github, k8s and pagerduty modules

### DIFF
--- a/cartography/intel/github/users.py
+++ b/cartography/intel/github/users.py
@@ -6,10 +6,13 @@ from typing import Tuple
 import neo4j
 
 from cartography.intel.github.util import fetch_all
+from cartography.util import get_stats_client
+from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+stat_handler = get_stats_client(__name__)
 
 
 GITHUB_ORG_USERS_PAGINATED_GRAPHQL = """
@@ -103,3 +106,11 @@ def sync(
     user_data, org_data = get(github_api_key, github_url, organization)
     load_organization_users(neo4j_session, user_data, org_data, common_job_parameters['UPDATE_TAG'])
     run_cleanup_job('github_users_cleanup.json', neo4j_session, common_job_parameters)
+    merge_module_sync_metadata(
+        neo4j_session,
+        group_type='GitHubOrganization',
+        group_id=org_data['url'],
+        synced_type='GitHubOrganization',
+        update_tag=common_job_parameters['UPDATE_TAG'],
+        stat_handler=stat_handler,
+    )

--- a/cartography/intel/kubernetes/namespaces.py
+++ b/cartography/intel/kubernetes/namespaces.py
@@ -7,15 +7,26 @@ from neo4j import Session
 
 from cartography.intel.kubernetes.util import get_epoch
 from cartography.intel.kubernetes.util import K8sClient
+from cartography.util import get_stats_client
+from cartography.util import merge_module_sync_metadata
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+stat_handler = get_stats_client(__name__)
 
 
 @timeit
 def sync_namespaces(session: Session, client: K8sClient, update_tag: int) -> Dict:
     cluster, namespaces = get_namespaces(client)
     load_namespaces(session, cluster, namespaces, update_tag)
+    merge_module_sync_metadata(
+        session,
+        group_type='KubernetesCluster',
+        group_id=cluster['uid'],
+        synced_type='KubernetesCluster',
+        update_tag=update_tag,
+        stat_handler=stat_handler,
+    )
     return cluster
 
 

--- a/cartography/intel/pagerduty/__init__.py
+++ b/cartography/intel/pagerduty/__init__.py
@@ -12,10 +12,13 @@ from cartography.intel.pagerduty.services import sync_services
 from cartography.intel.pagerduty.teams import sync_teams
 from cartography.intel.pagerduty.users import sync_users
 from cartography.intel.pagerduty.vendors import sync_vendors
+from cartography.util import get_stats_client
+from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+stat_handler = get_stats_client(__name__)
 
 
 @timeit
@@ -45,4 +48,13 @@ def start_pagerduty_ingestion(
         "pagerduty_import_cleanup.json",
         neo4j_session,
         common_job_parameters,
+    )
+
+    merge_module_sync_metadata(
+        neo4j_session,
+        group_type='pagerduty',
+        group_id='default',
+        synced_type="pagerduty",
+        update_tag=config.update_tag,
+        stat_handler=stat_handler,
     )

--- a/cartography/intel/pagerduty/__init__.py
+++ b/cartography/intel/pagerduty/__init__.py
@@ -53,7 +53,7 @@ def start_pagerduty_ingestion(
     merge_module_sync_metadata(
         neo4j_session,
         group_type='pagerduty',
-        group_id='default',
+        group_id='module',
         synced_type="pagerduty",
         update_tag=config.update_tag,
         stat_handler=stat_handler,


### PR DESCRIPTION
This change adds sync metadata to github, k8s, and pagerduty modules, for the top-level resources. Pagerduty doesn't have a top-level resource, because pagerduty doesn't expose it, so the top-level resource is considered the module, with `module` as the group_id.