### PR TITLE
filter ebs snapshots to just the current account (#793)

### DIFF
--- a/cartography/intel/aws/ec2/snapshots.py
+++ b/cartography/intel/aws/ec2/snapshots.py
@@ -32,7 +32,7 @@ def get_snapshots(boto3_session: boto3.session.Session, region: str, in_use_snap
     for page in paginator.paginate(OwnerIds=['self']):
         snapshots.extend(page['Snapshots'])
 
-    # fetch in-use snapshots not in self-owned snapshots
+    # fetch in-use snapshots not in self_owned snapshots
     self_owned_snapshot_ids = {s['SnapshotId'] for s in snapshots}
     other_snapshot_ids = set(in_use_snapshot_ids) - self_owned_snapshot_ids
     if other_snapshot_ids:

--- a/cartography/intel/aws/ec2/snapshots.py
+++ b/cartography/intel/aws/ec2/snapshots.py
@@ -13,12 +13,28 @@ logger = logging.getLogger(__name__)
 
 
 @timeit
+def get_snapshots_in_use(neo4j_session: neo4j.Session, region: str, current_aws_account_id: str) -> List[str]:
+    query = """
+    MATCH (:AWSAccount{id: {AWS_ACCOUNT_ID}})-[:RESOURCE]->(v:EBSVolume)
+    WHERE v.region = {Region}
+    RETURN v.snapshotid as snapshot
+    """
+    results = neo4j_session.run(query, AWS_ACCOUNT_ID=current_aws_account_id, Region=region)
+    return [r['snapshot'] for r in results]
+
+
+@timeit
 @aws_handle_regions
-def get_snapshots(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
+def get_snapshots(boto3_session: boto3.session.Session, region: str, snapshotIds: List[str]) -> List[Dict]:
     client = boto3_session.client('ec2', region_name=region)
     paginator = client.get_paginator('describe_snapshots')
     snapshots: List[Dict] = []
     for page in paginator.paginate(OwnerIds=['self']):
+        snapshots.extend(page['Snapshots'])
+
+    if not snapshotIds:
+        return snapshots
+    for page in paginator.paginate(SnapshotIds=snapshotIds):
         snapshots.extend(page['Snapshots'])
     return snapshots
 
@@ -110,7 +126,8 @@ def sync_ebs_snapshots(
 ) -> None:
     for region in regions:
         logger.debug("Syncing snapshots for region '%s' in account '%s'.", region, current_aws_account_id)
-        data = get_snapshots(boto3_session, region)
+        snapshots_in_use = get_snapshots_in_use(neo4j_session, region, current_aws_account_id)
+        data = get_snapshots(boto3_session, region, snapshots_in_use)
         load_snapshots(neo4j_session, data, region, current_aws_account_id, update_tag)
         snapshot_volumes = get_snapshot_volumes(data)
         load_snapshot_volume_relations(neo4j_session, snapshot_volumes, current_aws_account_id, update_tag)

--- a/cartography/intel/aws/ec2/snapshots.py
+++ b/cartography/intel/aws/ec2/snapshots.py
@@ -18,7 +18,7 @@ def get_snapshots(boto3_session: boto3.session.Session, region: str) -> List[Dic
     client = boto3_session.client('ec2', region_name=region)
     paginator = client.get_paginator('describe_snapshots')
     snapshots: List[Dict] = []
-    for page in paginator.paginate():
+    for page in paginator.paginate(OwnerIds=['self']):
         snapshots.extend(page['Snapshots'])
     return snapshots
 

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
@@ -1,9 +1,44 @@
 import cartography.intel.aws.ec2.snapshots
+import cartography.intel.aws.ec2.volumes
 import tests.data.aws.ec2.snapshots
+import tests.data.aws.ec2.volumes
 
 TEST_ACCOUNT_ID = '000000000000'
 TEST_REGION = 'eu-west-1'
 TEST_UPDATE_TAG = 123456789
+
+
+def test_get_snapshots_in_use(neo4j_session):
+    # Arrange
+    data = tests.data.aws.ec2.volumes.DESCRIBE_VOLUMES
+    transformed_data = cartography.intel.aws.ec2.volumes.transform_volumes(data, TEST_REGION, TEST_ACCOUNT_ID)
+
+    # Act
+    neo4j_session.run(
+        """
+        MERGE (aws:AWSAccount{id: {aws_account_id}})
+        ON CREATE SET aws.firstseen = timestamp()
+        SET aws.lastupdated = {aws_update_tag}
+        """,
+        aws_account_id=TEST_ACCOUNT_ID,
+        aws_update_tag=TEST_UPDATE_TAG,
+    )
+    cartography.intel.aws.ec2.volumes.load_volumes(
+        neo4j_session,
+        transformed_data,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    # Assert
+    expected_snapshots = {
+        "sn-01", "sn-02",
+    }
+
+    snapshots = cartography.intel.aws.ec2.snapshots.get_snapshots_in_use(neo4j_session, TEST_REGION, TEST_ACCOUNT_ID)
+
+    assert set(snapshots) == expected_snapshots
 
 
 def test_load_volumes(neo4j_session):

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
@@ -37,8 +37,8 @@ def test_get_snapshots_in_use(neo4j_session):
     ]
 
     actual_snapshots = cartography.intel.aws.ec2.snapshots.get_snapshots_in_use(
-        neo4j_session, 
-        TEST_REGION, TEST_ACCOUNT_ID
+        neo4j_session,
+        TEST_REGION, TEST_ACCOUNT_ID,
     )
 
     assert actual_snapshots == expected_snapshots

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
@@ -36,7 +36,10 @@ def test_get_snapshots_in_use(neo4j_session):
         "sn-01", "sn-02",
     ]
 
-    actual_snapshots = cartography.intel.aws.ec2.snapshots.get_snapshots_in_use(neo4j_session, TEST_REGION, TEST_ACCOUNT_ID)
+    actual_snapshots = cartography.intel.aws.ec2.snapshots.get_snapshots_in_use(
+        neo4j_session, 
+        TEST_REGION, TEST_ACCOUNT_ID
+    )
 
     assert actual_snapshots == expected_snapshots
 

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
@@ -32,13 +32,13 @@ def test_get_snapshots_in_use(neo4j_session):
     )
 
     # Assert
-    expected_snapshots = {
+    expected_snapshots = [
         "sn-01", "sn-02",
-    }
+    ]
 
-    snapshots = cartography.intel.aws.ec2.snapshots.get_snapshots_in_use(neo4j_session, TEST_REGION, TEST_ACCOUNT_ID)
+    actual_snapshots = cartography.intel.aws.ec2.snapshots.get_snapshots_in_use(neo4j_session, TEST_REGION, TEST_ACCOUNT_ID)
 
-    assert set(snapshots) == expected_snapshots
+    assert actual_snapshots == expected_snapshots
 
 
 def test_load_volumes(neo4j_session):


### PR DESCRIPTION
The `describe_snapshots` call returns approximately 40k public snapshots which creates extra nodes / relationships and generally causes performances issues with the graph. This PR filters snapshots by `OwnerId` `"self". This parameter is documented [here](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-snapshots.html) and returns snapshots owned or explicitly granted to the caller's account.