### PR TITLE
AWS: Tags: improve logging, cleanup old dangling tags

### DIFF
--- a/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
@@ -56,47 +56,52 @@
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:ESDomain)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:ESDomain)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RedshiftCluster) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RedshiftCluster) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) as TotalCompleted",
+            "iterative": true,
+            "iterationsize": 100
+        },
+        {
+            "query": "MATCH (n:AWSTag) WHERE NOT (n)--() AND n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         }

--- a/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
@@ -101,7 +101,7 @@
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag) WHERE NOT (n)<-[:TAGGED]-() AND n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag) WHERE NOT (n)--() AND n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         }

--- a/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
@@ -101,7 +101,7 @@
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag) WHERE NOT (n)--() AND n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag) WHERE NOT (n)<-[:TAGGED]-() AND n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
             "iterative": true,
             "iterationsize": 100
         }

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -207,9 +207,10 @@ def sync(
     tag_resource_type_mappings: Dict = TAG_RESOURCE_TYPE_MAPPINGS,
 ) -> None:
     for region in regions:
-        logger.info("Syncing AWS tags for region '%s'.", region)
+        logger.info(f"Syncing AWS tags for account {current_aws_account_id} and region {region}")
         for resource_type in tag_resource_type_mappings.keys():
             tag_data = get_tags(boto3_session, [resource_type], region)
             transform_tags(tag_data, resource_type)
+            logger.info(f"Loading {len(tag_data)} tags for resource type {resource_type}")
             load_tags(neo4j_session, tag_data, resource_type, region, update_tag)
     cleanup(neo4j_session, common_job_parameters)

--- a/tests/data/aws/resourcegroupstaggingapi.py
+++ b/tests/data/aws/resourcegroupstaggingapi.py
@@ -29,3 +29,14 @@ GET_RESOURCES_RESPONSE = [
         ],
     },
 ]
+
+# a second response for a second instance we may use for testing
+GET_RESOURCES_RESPONSE_UPDATED = [
+    {
+        'ResourceARN': 'arn:aws:ec2:us-east-1:1234:instance/i-02',
+        'Tags': [{
+            'Key': 'TestKeyUpdated',
+            'Value': 'TestValueUpdated',
+        }],
+    },
+]


### PR DESCRIPTION
This PR 
* improves logging: account id and tag load count #772 
* adds the RETURN COUNT(*) to the AWSTag cleanup job, so that we can begin collecting its metrics
* removes old, unattached AWSTag nodes that may have been attached to resources that no longer exist