### PR TITLE
Fix #800: AWS: aws_handle_regions fix

### DIFF
--- a/cartography/intel/aws/ecs.py
+++ b/cartography/intel/aws/ecs.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions(on_exception_return_value=([], []))
+@aws_handle_regions(default_return_value=([], []))
 def get_ecs_clusters(boto3_session: boto3.session.Session, region: str) -> Tuple[List[str], List[Dict[str, Any]]]:
     client = boto3_session.client('ecs', region_name=region)
     paginator = client.get_paginator('list_clusters')

--- a/cartography/intel/aws/ecs.py
+++ b/cartography/intel/aws/ecs.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions
+@aws_handle_regions(on_exception_return_value=([], []))
 def get_ecs_clusters(boto3_session: boto3.session.Session, region: str) -> Tuple[List[str], List[Dict[str, Any]]]:
     client = boto3_session.client('ecs', region_name=region)
     paginator = client.get_paginator('list_clusters')

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -117,7 +117,7 @@ def timeit(method):
 
 
 # TODO Move this to cartography.intel.aws.util.common
-def aws_handle_regions(func=None, on_exception_return_value=[]):
+def aws_handle_regions(func=None, default_return_value=[]):
     ERROR_CODES = [
         'AccessDenied',
         'AccessDeniedException',
@@ -135,11 +135,11 @@ def aws_handle_regions(func=None, on_exception_return_value=[]):
             # so we can continue without raising an exception
             if e.response['Error']['Code'] in ERROR_CODES:
                 logger.warning("{} in this region. Skipping...".format(e.response['Error']['Message']))
-                return on_exception_return_value
+                return default_return_value
             else:
                 raise
     if func is None:
-        return partial(aws_handle_regions, on_exception_return_value=on_exception_return_value)
+        return partial(aws_handle_regions, on_exception_return_value=default_return_value)
     return wrapper
 
 

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -123,7 +123,7 @@ def aws_handle_regions(func=None, default_return_value=[]) -> Callable:
     A decorator for returning a default value on functions that would return a client error
      like AccessDenied for opt-in AWS regions, and other regions that might be disabled.
 
-    The convenience of this decorator is that it auto-catches some of the potential 
+    The convenience of this decorator is that it auto-catches some of the potential
      Exceptions related to opt-in regions, and returns the specified `default_return_value`.
 
     This should be used on `get_` functions that normally return a list of items.

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -4,6 +4,7 @@ import sys
 from functools import partial
 from functools import wraps
 from string import Template
+from typing import Callable
 from typing import Dict
 from typing import Optional
 from typing import Union
@@ -117,7 +118,11 @@ def timeit(method):
 
 
 # TODO Move this to cartography.intel.aws.util.common
-def aws_handle_regions(func=None, default_return_value=[]):
+def aws_handle_regions(func=None, default_return_value=[]) -> Callable:
+    """
+    A decorator for returning a default. Use on functions that would return a client error
+     like AccessDenied for opt-in AWS regions, and other regions that might be desabled.
+    """
     ERROR_CODES = [
         'AccessDenied',
         'AccessDeniedException',
@@ -139,7 +144,7 @@ def aws_handle_regions(func=None, default_return_value=[]):
             else:
                 raise
     if func is None:
-        return partial(aws_handle_regions, on_exception_return_value=default_return_value)
+        return partial(aws_handle_regions, default_return_value=default_return_value)
     return wrapper
 
 

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -120,8 +120,15 @@ def timeit(method):
 # TODO Move this to cartography.intel.aws.util.common
 def aws_handle_regions(func=None, default_return_value=[]) -> Callable:
     """
-    A decorator for returning a default. Use on functions that would return a client error
-     like AccessDenied for opt-in AWS regions, and other regions that might be desabled.
+    A decorator for returning a default value on functions that would return a client error
+     like AccessDenied for opt-in AWS regions, and other regions that might be disabled.
+
+    The convenience of this decorator is that it auto-catches some of the potential 
+     Exceptions related to opt-in regions, and returns the specified `default_return_value`.
+
+    This should be used on `get_` functions that normally return a list of items.
+     but it can be used elsehwere and you can supply a custom `default_return_value`,
+     other than a simple list `[]`.
     """
     ERROR_CODES = [
         'AccessDenied',

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -22,14 +22,14 @@ def test_run_analysis_job_custom_package(mocker):
 def test_aws_handle_regions(mocker):
     # no exception
     @aws_handle_regions
-    def f(a, b):
+    def happy_path(a, b):
         return a + b
 
-    assert f(1, 2) == 3
+    assert happy_path(1, 2) == 3
 
     # returns the default on_exception_return_value=[]
     @aws_handle_regions
-    def g(a, b):
+    def raises_supported_client_error(a, b):
         e = botocore.exceptions.ClientError(
             {
                 'Error': {
@@ -41,11 +41,11 @@ def test_aws_handle_regions(mocker):
         )
         raise e
 
-    assert g(1, 2) == []
+    assert raises_supported_client_error(1, 2) == []
 
     # returns a custom value
     @aws_handle_regions(default_return_value=([], []))
-    def h(a, b):
+    def raises_supported_error_with_custoim_return_value(a, b):
         e = botocore.exceptions.ClientError(
             {
                 'Error': {
@@ -57,11 +57,11 @@ def test_aws_handle_regions(mocker):
         )
         raise e
 
-    assert h(1, 2) == ([], [])
+    assert raises_supported_error_with_custoim_return_value(1, 2) == ([], [])
 
     # unhandled type of ClientError
     @aws_handle_regions
-    def i(a, b):
+    def raises_unsupported_client_error(a, b):
         e = botocore.exceptions.ClientError(
             {
                 'Error': {
@@ -74,12 +74,12 @@ def test_aws_handle_regions(mocker):
         raise e
 
     with pytest.raises(botocore.exceptions.ClientError):
-        i(1, 2)
+        raises_unsupported_client_error(1, 2)
 
     # other type of error besides ClientError
     @aws_handle_regions(default_return_value=9000)
-    def j(a, b):
+    def raises_unsupported_error(a, b):
         return a / 0
 
     with pytest.raises(ZeroDivisionError):
-        j(1, 2)
+        raises_unsupported_error(1, 2)

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -44,7 +44,7 @@ def test_aws_handle_regions(mocker):
     assert g(1, 2) == []
 
     # returns a custom value
-    @aws_handle_regions(on_exception_return_value=([], []))
+    @aws_handle_regions(default_return_value=([], []))
     def h(a, b):
         e = botocore.exceptions.ClientError(
             {
@@ -77,7 +77,7 @@ def test_aws_handle_regions(mocker):
         i(1, 2)
 
     # other type of error besides ClientError
-    @aws_handle_regions(on_exception_return_value=9000)
+    @aws_handle_regions(default_return_value=9000)
     def j(a, b):
         return a / 0
 

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -1,4 +1,8 @@
+import pytest
+
 from cartography import util
+from cartography.util import aws_handle_regions
+from cartography.util import botocore
 
 
 def test_run_analysis_job_default_package(mocker):
@@ -13,3 +17,69 @@ def test_run_analysis_job_custom_package(mocker):
     read_text_mock = mocker.patch('cartography.util.read_text')
     util.run_analysis_job('test.json', mocker.Mock(), mocker.Mock(), package='a.b.c')
     read_text_mock.assert_called_once_with('a.b.c', 'test.json')
+
+
+def test_aws_handle_regions(mocker):
+    # no exception
+    @aws_handle_regions
+    def f(a, b):
+        return a + b
+
+    assert f(1, 2) == 3
+
+    # returns the default on_exception_return_value=[]
+    @aws_handle_regions
+    def g(a, b):
+        e = botocore.exceptions.ClientError(
+            {
+                'Error': {
+                    'Code': 'AccessDenied',
+                    'Message': 'aws_handle_regions is not working',
+                },
+            },
+            'FakeOperation',
+        )
+        raise e
+
+    assert g(1, 2) == []
+
+    # returns a custom value
+    @aws_handle_regions(on_exception_return_value=([], []))
+    def h(a, b):
+        e = botocore.exceptions.ClientError(
+            {
+                'Error': {
+                    'Code': 'AccessDenied',
+                    'Message': 'aws_handle_regions is not working',
+                },
+            },
+            'FakeOperation',
+        )
+        raise e
+
+    assert h(1, 2) == ([], [])
+
+    # unhandled type of ClientError
+    @aws_handle_regions
+    def i(a, b):
+        e = botocore.exceptions.ClientError(
+            {
+                'Error': {
+                    'Code': '>9000',
+                    'Message': 'aws_handle_regions is not working',
+                },
+            },
+            'FakeOperation',
+        )
+        raise e
+
+    with pytest.raises(botocore.exceptions.ClientError):
+        i(1, 2)
+
+    # other type of error besides ClientError
+    @aws_handle_regions(on_exception_return_value=9000)
+    def j(a, b):
+        return a / 0
+
+    with pytest.raises(ZeroDivisionError):
+        j(1, 2)


### PR DESCRIPTION
Fixes #800 

This PR adds the ability to have custom return values for `aws_handle_regions()`, besides an empty list `[]`. This is important for functions like `get_ecs_clusters()` that normally do no return a simple list.