### PR TITLE
Fix failing integration test in AWS EC2 snapshots

### DIFF
--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
@@ -32,16 +32,16 @@ def test_get_snapshots_in_use(neo4j_session):
     )
 
     # Assert
-    expected_snapshots = [
+    expected_snapshots = {
         "sn-01", "sn-02",
-    ]
+    }
 
     actual_snapshots = cartography.intel.aws.ec2.snapshots.get_snapshots_in_use(
         neo4j_session,
         TEST_REGION, TEST_ACCOUNT_ID,
     )
 
-    assert actual_snapshots == expected_snapshots
+    assert expected_snapshots == set(actual_snapshots)
 
 
 def test_load_volumes(neo4j_session):


### PR DESCRIPTION
Looks like this test was failing and somehow got merged. Fixing.