### PR TITLE
Fix #809: handle GCP firewall None fields

### DIFF
--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -327,15 +327,15 @@ def transform_gcp_forwarding_rules(fwd_response: Resource) -> List[Dict]:
         # Region looks like "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region name}"
         region = fwd.get('region', None)
         forwarding_rule['region'] = region.split('/')[-1] if region else None
-        forwarding_rule['ip_address'] = fwd['IPAddress']
-        forwarding_rule['ip_protocol'] = fwd['IPProtocol']
+        forwarding_rule['ip_address'] = fwd.get('IPAddress', None)
+        forwarding_rule['ip_protocol'] = fwd.get('IPProtocol', None)
         forwarding_rule['allow_global_access'] = fwd.get('allowGlobalAccess', None)
 
-        forwarding_rule['load_balancing_scheme'] = fwd['loadBalancingScheme']
-        forwarding_rule['name'] = fwd['name']
+        forwarding_rule['load_balancing_scheme'] = fwd.get('loadBalancingScheme', None)
+        forwarding_rule['name'] = fwd.get('name', None)
         forwarding_rule['port_range'] = fwd.get('portRange', None)
         forwarding_rule['ports'] = fwd.get('ports', None)
-        forwarding_rule['self_link'] = fwd['selfLink']
+        forwarding_rule['self_link'] = fwd.get('selfLink', None)
         target = fwd.get('target', None)
         if target:
             forwarding_rule['target'] = _parse_compute_full_uri_to_partial_uri(target)


### PR DESCRIPTION
Expanding https://github.com/lyft/cartography/pull/810 to cover the remaining fields, since [they also trigger the same error](https://github.com/lyft/cartography/issues/809#issuecomment-1102304261)