### PR TITLE
AWS: Tags: load tags by account id

### DIFF
--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -1,5 +1,4 @@
 import logging
-from os import access
 from string import Template
 from typing import Dict
 from typing import List
@@ -141,8 +140,10 @@ def _load_tags_tx(
     INGEST_TAG_TEMPLATE = Template("""
     UNWIND {TagData} as tag_mapping
         UNWIND tag_mapping.Tags as input_tag
-            MATCH (a:AWSAccount{id:{Account}})-[res:RESOURCE]->(resource:$resource_label{$property:tag_mapping.resource_id})
-            MERGE(aws_tag:AWSTag:Tag{id:input_tag.Key + ":" + input_tag.Value})
+            MATCH
+            (a:AWSAccount{id:{Account}})-[res:RESOURCE]->(resource:$resource_label{$property:tag_mapping.resource_id})
+            MERGE
+            (aws_tag:AWSTag:Tag{id:input_tag.Key + ":" + input_tag.Value})
             ON CREATE SET aws_tag.firstseen = timestamp()
 
             SET aws_tag.lastupdated = {UpdateTag},
@@ -163,7 +164,7 @@ def _load_tags_tx(
         TagData=tag_data,
         UpdateTag=aws_update_tag,
         Region=region,
-        Account=current_aws_account_id
+        Account=current_aws_account_id,
     )
 
 
@@ -228,6 +229,6 @@ def sync(
                 resource_type=resource_type,
                 region=region,
                 current_aws_account_id=current_aws_account_id,
-                update_tag=update_tag
+                update_tag=update_tag,
             )
     cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -1,4 +1,5 @@
 import logging
+from os import access
 from string import Template
 from typing import Dict
 from typing import List
@@ -134,12 +135,13 @@ def _load_tags_tx(
     tag_data: Dict,
     resource_type: str,
     region: str,
+    current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
     INGEST_TAG_TEMPLATE = Template("""
     UNWIND {TagData} as tag_mapping
         UNWIND tag_mapping.Tags as input_tag
-            MATCH (resource:$resource_label{$property:tag_mapping.resource_id})
+            MATCH (a:AWSAccount{id:{Account}})-[res:RESOURCE]->(resource:$resource_label{$property:tag_mapping.resource_id})
             MERGE(aws_tag:AWSTag:Tag{id:input_tag.Key + ":" + input_tag.Value})
             ON CREATE SET aws_tag.firstseen = timestamp()
 
@@ -161,12 +163,17 @@ def _load_tags_tx(
         TagData=tag_data,
         UpdateTag=aws_update_tag,
         Region=region,
+        Account=current_aws_account_id
     )
 
 
 @timeit
 def load_tags(
-    neo4j_session: neo4j.Session, tag_data: Dict, resource_type: str, region: str,
+    neo4j_session: neo4j.Session,
+    tag_data: Dict,
+    resource_type: str,
+    region: str,
+    current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
     for tag_data_batch in batch(tag_data, size=100):
@@ -175,6 +182,7 @@ def load_tags(
             tag_data=tag_data_batch,
             resource_type=resource_type,
             region=region,
+            current_aws_account_id=current_aws_account_id,
             aws_update_tag=aws_update_tag,
         )
 
@@ -214,5 +222,12 @@ def sync(
             tag_data = get_tags(boto3_session, [resource_type], region)
             transform_tags(tag_data, resource_type)
             logger.info(f"Loading {len(tag_data)} tags for resource type {resource_type}")
-            load_tags(neo4j_session, tag_data, resource_type, region, update_tag)
+            load_tags(
+                neo4j_session=neo4j_session,
+                tag_data=tag_data,
+                resource_type=resource_type,
+                region=region,
+                current_aws_account_id=current_aws_account_id,
+                update_tag=update_tag
+            )
     cleanup(neo4j_session, common_job_parameters)

--- a/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -4,6 +4,7 @@ import cartography.intel.aws.ec2
 import cartography.intel.aws.resourcegroupstaggingapi as rgta
 import tests.data.aws.ec2.instances
 import tests.data.aws.resourcegroupstaggingapi
+from tests.integration.cartography.intel.aws.common import create_test_account
 
 
 TEST_ACCOUNT_ID = '1234'
@@ -12,6 +13,7 @@ TEST_UPDATE_TAG = 123456789
 
 
 def _ensure_local_neo4j_has_test_ec2_instance_data(neo4j_session):
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
     data = tests.data.aws.ec2.instances.DESCRIBE_INSTANCES['Reservations']
     cartography.intel.aws.ec2.instances.load_ec2_instances(
         neo4j_session, data, TEST_REGION, TEST_ACCOUNT_ID, TEST_UPDATE_TAG,
@@ -31,6 +33,7 @@ def test_transform_and_load_ec2_tags(neo4j_session):
         get_resources_response,
         resource_type,
         TEST_REGION,
+        TEST_ACCOUNT_ID,
         TEST_UPDATE_TAG,
     )
     expected = {
@@ -58,6 +61,7 @@ def test_transform_and_load_ec2_tags(neo4j_session):
         new_response,
         resource_type,
         TEST_REGION,
+        TEST_ACCOUNT_ID,
         new_update_tag,
     )
     neo4j_session.run('MATCH (i:EC2Instance) DETACH DELETE (i) RETURN COUNT(*) as TotalCompleted')


### PR DESCRIPTION
Previously, we would incorrectly map tags to resources in all AWS accounts, which is incorrect behavior. This PR ensures that we map to resources only in the current AWS account being synced.