### PR TITLE
AWS rgta: change parameter update_tag to aws_update_tag

### DIFF
--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -229,6 +229,6 @@ def sync(
                 resource_type=resource_type,
                 region=region,
                 current_aws_account_id=current_aws_account_id,
-                update_tag=update_tag,
+                aws_update_tag=update_tag,
             )
     cleanup(neo4j_session, common_job_parameters)


### PR DESCRIPTION
Followup fix for #833 
```
...
Traceback (most recent call last):
  File <path>/cartography/intel/aws/resourcegroupstaggingapi.py", line 226, in sync
    load_tags(
  File <path>/cartography/util.py", line 112, in timed
    result = method(*args, **kwargs)
TypeError: load_tags() got an unexpected keyword argument 'update_tag'
```