### PR TITLE
Stop using implicit reexports

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -13,7 +13,7 @@ from . import organizations
 from .resources import RESOURCE_FUNCTIONS
 from cartography.config import Config
 from cartography.intel.aws.util.common import parse_and_validate_aws_requested_syncs
-from cartography.util import get_stats_client
+from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_analysis_job
 from cartography.util import run_cleanup_job

--- a/cartography/intel/aws/dynamodb.py
+++ b/cartography/intel/aws/dynamodb.py
@@ -5,8 +5,8 @@ from typing import List
 import boto3
 import neo4j
 
+from cartography.stats import get_stats_client
 from cartography.util import aws_handle_regions
-from cartography.util import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
 from cartography.util import timeit

--- a/cartography/intel/aws/elasticache.py
+++ b/cartography/intel/aws/elasticache.py
@@ -6,8 +6,8 @@ from typing import Set
 import boto3
 import neo4j
 
+from cartography.stats import get_stats_client
 from cartography.util import aws_handle_regions
-from cartography.util import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
 from cartography.util import timeit

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -11,7 +11,7 @@ import neo4j
 
 from cartography.intel.aws.permission_relationships import parse_statement_node
 from cartography.intel.aws.permission_relationships import principal_allowed_on_resource
-from cartography.util import get_stats_client
+from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
 from cartography.util import timeit

--- a/cartography/intel/aws/rds.py
+++ b/cartography/intel/aws/rds.py
@@ -6,9 +6,9 @@ from typing import List
 import boto3
 import neo4j
 
+from cartography.stats import get_stats_client
 from cartography.util import aws_handle_regions
 from cartography.util import dict_value_to_str
-from cartography.util import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
 from cartography.util import timeit

--- a/cartography/intel/aws/s3.py
+++ b/cartography/intel/aws/s3.py
@@ -15,7 +15,7 @@ from botocore.exceptions import ClientError
 from botocore.exceptions import EndpointConnectionError
 from policyuniverse.policy import Policy
 
-from cartography.util import get_stats_client
+from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_analysis_job
 from cartography.util import run_cleanup_job

--- a/cartography/intel/crowdstrike/__init__.py
+++ b/cartography/intel/crowdstrike/__init__.py
@@ -6,7 +6,7 @@ from cartography.config import Config
 from cartography.intel.crowdstrike.endpoints import sync_hosts
 from cartography.intel.crowdstrike.spotlight import sync_vulnerabilities
 from cartography.intel.crowdstrike.util import get_authorization
-from cartography.util import get_stats_client
+from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
 from cartography.util import timeit

--- a/cartography/intel/github/users.py
+++ b/cartography/intel/github/users.py
@@ -6,7 +6,7 @@ from typing import Tuple
 import neo4j
 
 from cartography.intel.github.util import fetch_all
-from cartography.util import get_stats_client
+from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
 from cartography.util import timeit

--- a/cartography/intel/kubernetes/namespaces.py
+++ b/cartography/intel/kubernetes/namespaces.py
@@ -7,7 +7,7 @@ from neo4j import Session
 
 from cartography.intel.kubernetes.util import get_epoch
 from cartography.intel.kubernetes.util import K8sClient
-from cartography.util import get_stats_client
+from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import timeit
 

--- a/cartography/intel/okta/__init__.py
+++ b/cartography/intel/okta/__init__.py
@@ -14,7 +14,7 @@ from cartography.intel.okta import origins
 from cartography.intel.okta import roles
 from cartography.intel.okta import users
 from cartography.intel.okta.sync_state import OktaSyncState
-from cartography.util import get_stats_client
+from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
 from cartography.util import timeit

--- a/cartography/intel/pagerduty/__init__.py
+++ b/cartography/intel/pagerduty/__init__.py
@@ -12,7 +12,7 @@ from cartography.intel.pagerduty.services import sync_services
 from cartography.intel.pagerduty.teams import sync_teams
 from cartography.intel.pagerduty.users import sync_users
 from cartography.intel.pagerduty.vendors import sync_vendors
-from cartography.util import get_stats_client
+from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
 from cartography.util import timeit

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ max-line-length = 120
 check_untyped_defs = true
 disallow_untyped_defs = true
 ignore_errors = true
+implicit_reexport = false
 
 [mypy-cartography.intel.*]
 ignore_errors = false

--- a/tests/integration/cartography/test_util.py
+++ b/tests/integration/cartography/test_util.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
+from cartography.stats import get_stats_client
 from cartography.stats import ScopedStatsClient
-from cartography.util import get_stats_client
 from cartography.util import merge_module_sync_metadata
 
 

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -1,9 +1,9 @@
+import botocore
 import pytest
 
 from cartography import util
 from cartography.util import aws_handle_regions
 from cartography.util import batch
-from cartography.util import botocore
 
 
 def test_run_analysis_job_default_package(mocker):


### PR DESCRIPTION
Enable this mypy rule as a pre-req for general mypy strictening.
Aside from manually updating setup.cfg
and the botocore import in `tests/unit/cartography/test_util.py`,
the bulk of the changes were automated via:
```
rg 'from cartography.util import get_stats_client' -l | xargs gsed -i 's/from cartography.util import get_stats_client/from cartography.stats import get_stats_client/g'
pre-commit run reorder-python-imports --all-files
```