### PR TITLE
Fix Cartography 0.59.0 release

### DIFF
--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -10,6 +10,7 @@ import cartography.intel.analysis
 import cartography.intel.aws
 import cartography.intel.azure
 import cartography.intel.create_indexes
+import cartography.intel.crowdstrike
 import cartography.intel.crxcavator.crxcavator
 import cartography.intel.digitalocean
 import cartography.intel.gcp


### PR DESCRIPTION
At the moment, with `cartography==0.59.0` running `cartography -h` results in
```
Traceback (most recent call last):
  File "***/bin/cartography", line 8, in <module>
    sys.exit(main())
  File "***/cartography/cli.py", line 504, in main
    default_sync = cartography.sync.build_default_sync()
  File "***/cartography/sync.py", line 166, in build_default_sync
    ('crowdstrike', cartography.intel.crowdstrike.start_crowdstrike_ingestion),
AttributeError: module 'cartography.intel' has no attribute 'crowdstrike'
```
as it has not been imported in this `sync.py`