### PR TITLE
Fix for #801

### DIFF
--- a/cartography/intel/aws/apigateway.py
+++ b/cartography/intel/aws/apigateway.py
@@ -309,7 +309,7 @@ def load_rest_api_details(
             resources.extend(resource)
         if certificate:
             certificate['apiId'] = api_id
-            certificates.extend(certificate)
+            certificates.append(certificate)
 
     # cleanup existing properties
     run_cleanup_job(


### PR DESCRIPTION
Extend method adds only keys to a list of certificates. Therefore, instead of a list of dictionaries, we just get a list of keys, and in the end we come to an error string indices must be integers. We should use append in the case, since we are adding a dictionary (certificate) into the certificates list.
The replacement have been tested on our prod environment without the error.