### PR TITLE
Correctly propagate exceptions to exit code

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -499,7 +499,7 @@ class CLI:
         try:
             return cartography.sync.run_with_config(self.sync, config)
         except KeyboardInterrupt:
-            return 130
+            return cartography.util.STATUS_KEYBOARD_INTERRUPT
 
 
 def main(argv=None):

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -368,7 +368,7 @@ class CLI:
         )
         return parser
 
-    def main(self, argv):
+    def main(self, argv) -> int:
         """
         Entrypoint for the command line interface.
 
@@ -517,4 +517,4 @@ def main(argv=None):
     logging.getLogger('neo4j.bolt').setLevel(logging.WARNING)
     argv = argv if argv is not None else sys.argv[1:]
     default_sync = cartography.sync.build_default_sync()
-    return CLI(default_sync, prog='cartography').main(argv)
+    sys.exit(CLI(default_sync, prog='cartography').main(argv))

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -368,7 +368,7 @@ class CLI:
         )
         return parser
 
-    def main(self, argv) -> int:
+    def main(self, argv: str) -> int:
         """
         Entrypoint for the command line interface.
 
@@ -376,7 +376,7 @@ class CLI:
         :param argv: The parameters supplied to the command line program.
         """
         # TODO support parameter lookup in environment variables if not present on command line
-        config: cartography.config.Config = self.parser.parse_args(argv)
+        config: argparse.Namespace = self.parser.parse_args(argv)
         # Logging config
         if config.verbose:
             logging.getLogger('cartography').setLevel(logging.DEBUG)

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -27,6 +27,8 @@ import cartography.intel.kubernetes
 import cartography.intel.okta
 from cartography.config import Config
 from cartography.stats import set_stats_client
+from cartography.util import STATUS_FAILURE
+from cartography.util import STATUS_SUCCESS
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +91,7 @@ class Sync:
                     raise  # TODO this should be configurable
                 logger.info("Finishing sync stage '%s'", stage_name)
         logger.info("Finishing sync with update tag '%d'", config.update_tag)
-        return 0
+        return STATUS_SUCCESS
 
 
 def run_with_config(sync: Sync, config: Union[Config, argparse.Namespace]) -> int:
@@ -133,7 +135,7 @@ def run_with_config(sync: Sync, config: Union[Config, argparse.Namespace]) -> in
             config.neo4j_uri,
             e,
         )
-        return 1
+        return STATUS_FAILURE
     except neobolt.exceptions.AuthError as e:
         logger.debug("Error occurred during Neo4j auth.", exc_info=True)
         if not neo4j_auth:
@@ -154,7 +156,7 @@ def run_with_config(sync: Sync, config: Union[Config, argparse.Namespace]) -> in
                 ),
                 e,
             )
-        return 1
+        return STATUS_FAILURE
     default_update_tag = int(time.time())
     if not config.update_tag:
         config.update_tag = default_update_tag

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -1,16 +1,17 @@
+import argparse
 import logging
 import time
 from collections import OrderedDict
 from typing import Callable
 from typing import List
 from typing import Tuple
+from typing import Union
 
 import neo4j
 import neobolt.exceptions
 from neo4j import GraphDatabase
 from statsd import StatsClient
 
-import cartography.config
 import cartography.intel.analysis
 import cartography.intel.aws
 import cartography.intel.azure
@@ -24,6 +25,7 @@ import cartography.intel.github
 import cartography.intel.gsuite
 import cartography.intel.kubernetes
 import cartography.intel.okta
+from cartography.config import Config
 from cartography.stats import set_stats_client
 
 logger = logging.getLogger(__name__)
@@ -64,7 +66,7 @@ class Sync:
         for name, func in stages:
             self.add_stage(name, func)
 
-    def run(self, neo4j_driver: neo4j.Driver, config: cartography.config.Config) -> int:
+    def run(self, neo4j_driver: neo4j.Driver, config: Union[Config, argparse.Namespace]) -> int:
         """
         Execute all stages in the sync task in sequence.
 
@@ -90,7 +92,7 @@ class Sync:
         return 0
 
 
-def run_with_config(sync: cartography.sync.Sync, config: cartography.config.Config) -> int:
+def run_with_config(sync: Sync, config: Union[Config, argparse.Namespace]) -> int:
     """
     Execute the cartography.sync.Sync.run method with parameters built from the given configuration object.
 
@@ -159,7 +161,7 @@ def run_with_config(sync: cartography.sync.Sync, config: cartography.config.Conf
     return sync.run(neo4j_driver, config)
 
 
-def build_default_sync() -> cartography.sync.Sync:
+def build_default_sync() -> Sync:
     """
     Build the default cartography sync, which runs all intelligence modules shipped with the cartography package.
 

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -1,11 +1,16 @@
 import logging
 import time
 from collections import OrderedDict
+from typing import Callable
+from typing import List
+from typing import Tuple
 
+import neo4j
 import neobolt.exceptions
 from neo4j import GraphDatabase
 from statsd import StatsClient
 
+import cartography.config
 import cartography.intel.analysis
 import cartography.intel.aws
 import cartography.intel.azure
@@ -38,7 +43,7 @@ class Sync:
         # NOTE we may need meta-stages at some point to allow hooking into pre-sync, sync, and post-sync
         self._stages = OrderedDict()
 
-    def add_stage(self, name, func):
+    def add_stage(self, name: str, func: Callable) -> None:
         """
         Add one stage to the sync task.
 
@@ -49,7 +54,7 @@ class Sync:
         """
         self._stages[name] = func
 
-    def add_stages(self, stages):
+    def add_stages(self, stages: List[Tuple[str, Callable]]) -> None:
         """
         Add multiple stages to the sync task.
 
@@ -59,7 +64,7 @@ class Sync:
         for name, func in stages:
             self.add_stage(name, func)
 
-    def run(self, neo4j_driver, config):
+    def run(self, neo4j_driver: neo4j.Driver, config: cartography.config.Config) -> int:
         """
         Execute all stages in the sync task in sequence.
 
@@ -82,9 +87,10 @@ class Sync:
                     raise  # TODO this should be configurable
                 logger.info("Finishing sync stage '%s'", stage_name)
         logger.info("Finishing sync with update tag '%d'", config.update_tag)
+        return 0
 
 
-def run_with_config(sync, config):
+def run_with_config(sync: cartography.sync.Sync, config: cartography.config.Config) -> int:
     """
     Execute the cartography.sync.Sync.run method with parameters built from the given configuration object.
 
@@ -153,7 +159,7 @@ def run_with_config(sync, config):
     return sync.run(neo4j_driver, config)
 
 
-def build_default_sync():
+def build_default_sync() -> cartography.sync.Sync:
     """
     Build the default cartography sync, which runs all intelligence modules shipped with the cartography package.
 

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -30,6 +30,11 @@ else:
 logger = logging.getLogger(__name__)
 
 
+STATUS_SUCCESS = 0
+STATUS_FAILURE = 1
+STATUS_KEYBOARD_INTERRUPT = 130
+
+
 def run_analysis_job(
     filename: str,
     neo4j_session: neo4j.Session,


### PR DESCRIPTION
Currently if any of [these errors](https://github.com/lyft/cartography/blob/b3f29ed65a6bf04fe1e4ab19b529ce007368c5b4/cartography/sync.py#L118-L149) happen (e.g. we fail to connect to the neo4j database) then we return 1 and the exit code is not propagated up to the process -- the resulting returned exit code to the OS is still 0 (success). This PR fixes this and adds typehints to make this process a bit easier to read.

Related to https://github.com/lyft/cartography/pull/509.