### PR TITLE
Neo4j 4.x upgrade: convert some incompatible queries

### DIFF
--- a/cartography/data/jobs/analysis/aws_ec2_keypair_analysis.json
+++ b/cartography/data/jobs/analysis/aws_ec2_keypair_analysis.json
@@ -18,7 +18,7 @@
         },
         {
             "__comment__": "Set EC2KeyPairs with MD5 hash keyfingerprints (47 characters, instead of 59 characters) as user_uploaded = True",
-            "query": "MATCH (k:EC2KeyPair) WHERE length(k.keyfingerprint) = 47 SET k.user_uploaded = True return COUNT(*) as TotalCompleted",
+            "query": "MATCH (k:EC2KeyPair) WHERE size(k.keyfingerprint) = 47 SET k.user_uploaded = True return COUNT(*) as TotalCompleted",
             "iterative": false
         },
         {

--- a/cartography/data/jobs/analysis/aws_ec2_keypair_analysis.json
+++ b/cartography/data/jobs/analysis/aws_ec2_keypair_analysis.json
@@ -18,7 +18,7 @@
         },
         {
             "__comment__": "Set EC2KeyPairs with MD5 hash keyfingerprints (47 characters, instead of 59 characters) as user_uploaded = True",
-            "query": "MATCH (k:EC2KeyPair) WHERE size(k.keyfingerprint) = 47 SET k.user_uploaded = True return COUNT(*) as TotalCompleted",
+            "query": "MATCH (k:EC2KeyPair) WHERE size(k.keyfingerprint) = 47 SET k.user_uploaded = True",
             "iterative": false
         },
         {

--- a/tests/data/aws/ec2/key_pairs.py
+++ b/tests/data/aws/ec2/key_pairs.py
@@ -12,5 +12,10 @@ DESCRIBE_KEY_PAIRS = {
             "KeyFingerprint": "33:33:33:33:33:33:33:33:33:33:33:33:33:33:33:33:33:33:33:33",
             "KeyName": "sample_key_pair_3",
         },
+        # shorter, md5 hash, means it is user_uploaded
+        {
+            "KeyFingerprint": "44:44:44:44:44:44:44:44:44:44:44:44:44:44:44:44",
+            "KeyName": "sample_key_pair_4",
+        },
     ],
 }

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_key_pairs.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_key_pairs.py
@@ -1,4 +1,5 @@
 import cartography.intel.aws.ec2
+from cartography.util import run_analysis_job, run_cleanup_job
 import tests.data.aws.ec2.key_pairs
 
 
@@ -29,6 +30,10 @@ def test_load_ec2_key_pairs(neo4j_session, *args):
             "arn:aws:ec2:us-east-1:000000000000:key-pair/sample_key_pair_3",
             "33:33:33:33:33:33:33:33:33:33:33:33:33:33:33:33:33:33:33:33",
         ),
+        (
+            "arn:aws:ec2:us-east-1:000000000000:key-pair/sample_key_pair_4",
+            "44:44:44:44:44:44:44:44:44:44:44:44:44:44:44:44",
+        )
     }
 
     nodes = neo4j_session.run(
@@ -40,6 +45,41 @@ def test_load_ec2_key_pairs(neo4j_session, *args):
         (
             n['k.arn'],
             n['k.keyfingerprint'],
+        )
+        for n in nodes
+    }
+    assert actual_nodes == expected_nodes
+
+def test_ec2_key_pairs_analysis_job(neo4j_session, *args):
+    data = tests.data.aws.ec2.key_pairs.DESCRIBE_KEY_PAIRS['KeyPairs']
+    cartography.intel.aws.ec2.key_pairs.load_ec2_key_pairs(
+        neo4j_session,
+        data,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    run_analysis_job(
+        'aws_ec2_keypair_analysis.json', 
+        neo4j_session, 
+        {'UPDATE_TAG': TEST_UPDATE_TAG})
+    expected_nodes = {
+        (
+            "arn:aws:ec2:us-east-1:000000000000:key-pair/sample_key_pair_4",
+            "44:44:44:44:44:44:44:44:44:44:44:44:44:44:44:44",
+            True
+        )
+    }
+    nodes = neo4j_session.run(
+        """
+        MATCH (k:EC2KeyPair) WHERE k.user_uploaded = true RETURN k.arn, k.keyfingerprint, k.user_uploaded
+        """,
+    )
+    actual_nodes = {
+        (
+            n['k.arn'],
+            n['k.keyfingerprint'],
+            n['k.user_uploaded']
         )
         for n in nodes
     }

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_key_pairs.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_key_pairs.py
@@ -1,6 +1,6 @@
 import cartography.intel.aws.ec2
-from cartography.util import run_analysis_job, run_cleanup_job
 import tests.data.aws.ec2.key_pairs
+from cartography.util import run_analysis_job
 
 
 TEST_ACCOUNT_ID = '000000000000'
@@ -33,7 +33,7 @@ def test_load_ec2_key_pairs(neo4j_session, *args):
         (
             "arn:aws:ec2:us-east-1:000000000000:key-pair/sample_key_pair_4",
             "44:44:44:44:44:44:44:44:44:44:44:44:44:44:44:44",
-        )
+        ),
     }
 
     nodes = neo4j_session.run(
@@ -50,6 +50,7 @@ def test_load_ec2_key_pairs(neo4j_session, *args):
     }
     assert actual_nodes == expected_nodes
 
+
 def test_ec2_key_pairs_analysis_job(neo4j_session, *args):
     data = tests.data.aws.ec2.key_pairs.DESCRIBE_KEY_PAIRS['KeyPairs']
     cartography.intel.aws.ec2.key_pairs.load_ec2_key_pairs(
@@ -60,15 +61,16 @@ def test_ec2_key_pairs_analysis_job(neo4j_session, *args):
         TEST_UPDATE_TAG,
     )
     run_analysis_job(
-        'aws_ec2_keypair_analysis.json', 
-        neo4j_session, 
-        {'UPDATE_TAG': TEST_UPDATE_TAG})
+        'aws_ec2_keypair_analysis.json',
+        neo4j_session,
+        {'UPDATE_TAG': TEST_UPDATE_TAG},
+    )
     expected_nodes = {
         (
             "arn:aws:ec2:us-east-1:000000000000:key-pair/sample_key_pair_4",
             "44:44:44:44:44:44:44:44:44:44:44:44:44:44:44:44",
-            True
-        )
+            True,
+        ),
     }
     nodes = neo4j_session.run(
         """
@@ -79,7 +81,7 @@ def test_ec2_key_pairs_analysis_job(neo4j_session, *args):
         (
             n['k.arn'],
             n['k.keyfingerprint'],
-            n['k.user_uploaded']
+            n['k.user_uploaded'],
         )
         for n in nodes
     }

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -6,4 +6,4 @@ from tests.integration import settings
 def test_neo4j_connection():
     driver = neo4j.GraphDatabase.driver(settings.get("NEO4J_URL"))
     with driver.session() as session:
-        session.run("CALL db.schema();")
+        session.run("CALL db.indexes();")


### PR DESCRIPTION
The  calls `length` and `dbms.schema` no longer work in 4.4, so we are replacing them with `size` and `dbms.schema` which are compatible in 3.5 and 4.4.

https://neo4j.com/docs/cypher-manual/current/functions/scalar/
https://neo4j.com/docs/upgrade-migration-guide/current/migration/surface-changes/procedures/

More PRs to come to address the code migration in #838

