### PR TITLE
Removing `return count(*) as TotalCompleted from AWS Cleanup files

### DIFF
--- a/cartography/data/jobs/cleanup/aws_apigateway_details.json
+++ b/cartography/data/jobs/cleanup/aws_apigateway_details.json
@@ -1,7 +1,7 @@
 {
   "statements": [
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(s:RestAPI) WHERE EXISTS(s.anonymous_access)\n WITH s LIMIT {LIMIT_SIZE}\nREMOVE s.anonymous_access, s.anonymous_actions return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(s:RestAPI) WHERE EXISTS(s.anonymous_access)\n WITH s LIMIT {LIMIT_SIZE}\nREMOVE s.anonymous_access, s.anonymous_actions",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_account_access_key_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_account_access_key_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (n:AccountAccessKey)<-[:AWS_ACCESS_KEY]-(:AWSUser)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AccountAccessKey)<-[:AWS_ACCESS_KEY]-(:AWSUser)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_apigateway_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_apigateway_cleanup.json
@@ -1,42 +1,42 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:APIGatewayClientCertificate)<-[:HAS_CERTIFICATE]-(:APIGatewayStage)<-[:ASSOCIATED_WITH]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:APIGatewayClientCertificate)<-[:HAS_CERTIFICATE]-(:APIGatewayStage)<-[:ASSOCIATED_WITH]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:APIGatewayClientCertificate)<-[r:HAS_CERTIFICATE]-(:APIGatewayStage)<-[:ASSOCIATED_WITH]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:APIGatewayClientCertificate)<-[r:HAS_CERTIFICATE]-(:APIGatewayStage)<-[:ASSOCIATED_WITH]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:APIGatewayStage)<-[:ASSOCIATED_WITH]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:APIGatewayStage)<-[:ASSOCIATED_WITH]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:APIGatewayStage)<-[r:ASSOCIATED_WITH]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:APIGatewayStage)<-[r:ASSOCIATED_WITH]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:APIGatewayResource)<-[:RESOURCE]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:APIGatewayResource)<-[:RESOURCE]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:APIGatewayResource)<-[r:RESOURCE]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:APIGatewayResource)<-[r:RESOURCE]-(:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:APIGatewayRestAPI)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:APIGatewayRestAPI)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_config_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_config_cleanup.json
@@ -1,17 +1,17 @@
 {
   "statements": [
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSConfigurationRecorder) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSConfigurationRecorder) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSConfigDeliveryChannel) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSConfigDeliveryChannel) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSConfigRule) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSConfigRule) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_dynamodb_tables_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_dynamodb_tables_cleanup.json
@@ -1,17 +1,17 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:DynamoDBTable)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:DynamoDBTable)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (g:DynamoDBGlobalSecondaryIndex)<-[:GLOBAL_SECONDARY_INDEX]-(:DynamoDBTable)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE g.lastupdated <> {UPDATE_TAG} WITH g LIMIT {LIMIT_SIZE} DETACH DELETE (g) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (g:DynamoDBGlobalSecondaryIndex)<-[:GLOBAL_SECONDARY_INDEX]-(:DynamoDBTable)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE g.lastupdated <> {UPDATE_TAG} WITH g LIMIT {LIMIT_SIZE} DETACH DELETE (g)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:DynamoDBGlobalSecondaryIndex)<-[r:GLOBAL_SECONDARY_INDEX]-(:DynamoDBTable)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:DynamoDBGlobalSecondaryIndex)<-[r:GLOBAL_SECONDARY_INDEX]-(:DynamoDBTable)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_ec2_images_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_ec2_images_cleanup.json
@@ -1,12 +1,12 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:EC2Image)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:EC2Image)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:EC2Image)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:EC2Image)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_ec2_instances_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_ec2_instances_cleanup.json
@@ -1,66 +1,66 @@
 {
   "statements": [{
-      "query": "MATCH (n:EC2Reservation)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:EC2Reservation)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:EC2Subnet)<-[:PART_OF_SUBNET]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:EC2Subnet)<-[:PART_OF_SUBNET]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:EC2Subnet)<-[r:PART_OF_SUBNET]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:EC2Subnet)<-[r:PART_OF_SUBNET]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:MEMBER_OF_EC2_RESERVATION]->(:EC2Reservation) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:MEMBER_OF_EC2_RESERVATION]->(:EC2Reservation) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:NetworkInterface)<-[:NETWORK_INTERFACE]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:NetworkInterface)<-[:NETWORK_INTERFACE]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:NETWORK_INTERFACE]->(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:NETWORK_INTERFACE]->(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:NetworkInterface)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:NetworkInterface)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:EC2Instance)-[r:STS_ASSUMEROLE_ALLOW]->(:AWSRole)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:EC2Instance)-[r:STS_ASSUMEROLE_ALLOW]->(:AWSRole)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:EBSVolume)-[:ATTACHED_TO]->(:EC2Instance) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:EBSVolume)-[:ATTACHED_TO]->(:EC2Instance) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EBSVolume)-[r:ATTACHED_TO]->(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EBSVolume)-[r:ATTACHED_TO]->(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[r:RESOURCE]->(:EBSVolume)-[:ATTACHED_TO]->(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[r:RESOURCE]->(:EBSVolume)-[:ATTACHED_TO]->(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }],

--- a/cartography/data/jobs/cleanup/aws_import_ec2_key_pairs_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_ec2_key_pairs_cleanup.json
@@ -1,16 +1,16 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:EC2KeyPair) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:EC2KeyPair) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:EC2Instance)<-[r:SSH_LOGIN_TO]-(:EC2KeyPair) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:EC2Instance)<-[r:SSH_LOGIN_TO]-(:EC2KeyPair) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[r:RESOURCE]->(:EC2KeyPair) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[r:RESOURCE]->(:EC2KeyPair) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_ec2_launch_configurations_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_ec2_launch_configurations_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (n:LaunchConfiguration)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:LaunchConfiguration)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_ec2_launch_templates_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_ec2_launch_templates_cleanup.json
@@ -1,11 +1,11 @@
 {
   "statements": [{
-    "query": "MATCH (n:LaunchTemplateVersion)<-[:VERSION]-(:LaunchTemplate)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:LaunchTemplateVersion)<-[:VERSION]-(:LaunchTemplate)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:LaunchTemplate)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:LaunchTemplate)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_ec2_security_groupinfo_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_ec2_security_groupinfo_cleanup.json
@@ -1,27 +1,27 @@
 {
   "statements": [
   {
-      "query": "MATCH (n:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
   },
   {
-      "query": "MATCH (n:IpRule)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:IpRule)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
   },
   {
-      "query": "MATCH (n:IpRange)-[:MEMBER_OF_IP_RULE]->(:IpRule)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:IpRange)-[:MEMBER_OF_IP_RULE]->(:IpRule)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
   },
   {
-    "query": "MATCH (:IpRule)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:IpRule)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:IpRange)-[r:MEMBER_OF_IP_RULE]->(:IpRule)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:IpRange)-[r:MEMBER_OF_IP_RULE]->(:IpRule)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_ecr_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_ecr_cleanup.json
@@ -1,27 +1,27 @@
 {
   "statements": [
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:ECRRepository)-[:REPO_IMAGE]->(:ECRRepositoryImage)-[:IMAGE]->(n:ECRImage) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:ECRRepository)-[:REPO_IMAGE]->(:ECRRepositoryImage)-[:IMAGE]->(n:ECRImage) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:ECRRepository)-[:REPO_IMAGE]->(:ECRRepositoryImage)-[r:IMAGE]->(:ECRImage) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) AS TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:ECRRepository)-[:REPO_IMAGE]->(:ECRRepositoryImage)-[r:IMAGE]->(:ECRImage) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:ECRRepository)-[:REPO_IMAGE]->(n:ECRRepositoryImage) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:ECRRepository)-[:REPO_IMAGE]->(n:ECRRepositoryImage) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:ECRRepository)-[r:REPO_IMAGE]->(:ECRRepositoryImage) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) AS TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:ECRRepository)-[r:REPO_IMAGE]->(:ECRRepositoryImage) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:ECRRepository) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:ECRRepository) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_eks_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_eks_cleanup.json
@@ -1,12 +1,12 @@
 {
     "statements": [
         {
-            "query": "MATCH (n:EKSCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:EKSCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:EKSCluster)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:EKSCluster)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         }

--- a/cartography/data/jobs/cleanup/aws_import_elastic_ip_addresses_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_elastic_ip_addresses_cleanup.json
@@ -1,22 +1,22 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:ElasticIpAddress)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:ElasticIpAddress)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:ElasticIpAddress)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:ElasticIpAddress)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:ElasticIpAddress)<-[r:ELASTIC_IP_ADDRESS]-(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:ElasticIpAddress)<-[r:ELASTIC_IP_ADDRESS]-(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:ElasticIpAddress)<-[r:ELASTIC_IP_ADDRESS]-(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:ElasticIpAddress)<-[r:ELASTIC_IP_ADDRESS]-(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_elasticache_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_elasticache_cleanup.json
@@ -1,22 +1,22 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:ElasticacheCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:ElasticacheCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:ElasticacheCluster)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:ElasticacheCluster)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:ElasticacheTopic)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:ElasticacheTopic)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:ElasticacheTopic)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:ElasticacheTopic)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_emr_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_emr_cleanup.json
@@ -1,7 +1,7 @@
 {
     "statements": [
         {
-            "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:EMRCluster) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:EMRCluster) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         }

--- a/cartography/data/jobs/cleanup/aws_import_es_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_es_cleanup.json
@@ -1,12 +1,12 @@
 {
   "statements": [
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:ESDomain) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:ESDomain) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:ESDomain)<-[:DNS_POINTS_TO]-(n:DNSRecord) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:ESDomain)<-[:DNS_POINTS_TO]-(n:DNSRecord) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100,
     "__comment__": "Clean up DNSRecords pointing to ESDomains within the current AWS account"

--- a/cartography/data/jobs/cleanup/aws_import_groups_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_groups_cleanup.json
@@ -1,11 +1,11 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSGroup) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSGroup) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[r:AWS_GROUP]->(:AWSGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[r:AWS_GROUP]->(:AWSGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_groups_membership_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_groups_membership_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSUser)-[r:MEMBER_AWS_GROUP]->(:AWSGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSUser)-[r:MEMBER_AWS_GROUP]->(:AWSGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_groups_policy_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_groups_policy_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSGroup)-[r:STS_ASSUMEROLE_ALLOW]->(:AWSRole) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSGroup)-[r:STS_ASSUMEROLE_ALLOW]->(:AWSRole) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_internet_gateways_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_internet_gateways_cleanup.json
@@ -1,7 +1,7 @@
 {
     "statements": [
       {
-        "query": "MATCH (:AWSAccount{id:{AWS_ID}})-[:RESOURCE]->(n:AWSInternetGateway) WHERE n.lastupdated <> {UPDATE_TAG} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+        "query": "MATCH (:AWSAccount{id:{AWS_ID}})-[:RESOURCE]->(n:AWSInternetGateway) WHERE n.lastupdated <> {UPDATE_TAG} DETACH DELETE (n)",
         "iterative": true,
         "iterationsize": 100
       }

--- a/cartography/data/jobs/cleanup/aws_import_kms_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_kms_cleanup.json
@@ -1,32 +1,32 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:KMSKey)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:KMSKey)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:KMSKey)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:KMSKey)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:KMSGrant)-[:APPLIED_ON]->(:KMSKey)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:KMSGrant)-[:APPLIED_ON]->(:KMSKey)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:KMSGrant)-[r:APPLIED_ON]->(:KMSKey)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:KMSGrant)-[r:APPLIED_ON]->(:KMSKey)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:KMSAlias)-[:KNOWN_AS]->(:KMSKey)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:KMSAlias)-[:KNOWN_AS]->(:KMSKey)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:KMSAlias)-[r:KNOWN_AS]->(:KMSKey)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:KMSAlias)-[r:KNOWN_AS]->(:KMSKey)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_lambda_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_lambda_cleanup.json
@@ -1,47 +1,47 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:AWSLambdaFunctionAlias)<-[:KNOWN_AS]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:AWSLambdaFunctionAlias)<-[:KNOWN_AS]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSLambdaFunctionAlias)<-[r:KNOWN_AS]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSLambdaFunctionAlias)<-[r:KNOWN_AS]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:AWSLambdaEventSourceMapping)<-[:RESOURCE]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:AWSLambdaEventSourceMapping)<-[:RESOURCE]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSLambdaEventSourceMapping)<-[r:RESOURCE]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSLambdaEventSourceMapping)<-[r:RESOURCE]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:AWSLambdaLayer)<-[:HAS]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:AWSLambdaLayer)<-[:HAS]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSLambdaLayer)<-[r:HAS]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSLambdaLayer)<-[r:HAS]-(:AWSLambda)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSLambda)-[r:STS_ASSUME_ROLE_ALLOW]->(:AWSPrincipal) WITH r LIMIT {LIMIT_SIZE} DELETE r return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSLambda)-[r:STS_ASSUME_ROLE_ALLOW]->(:AWSPrincipal) WITH r LIMIT {LIMIT_SIZE} DELETE r",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSLambda) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSLambda) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[r:RESOURCE]->(:AWSLambda) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[r:RESOURCE]->(:AWSLambda) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_principals_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_principals_cleanup.json
@@ -1,27 +1,27 @@
 {
   "statements": [
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSPrincipal)-[:POLICY]->(:AWSPolicy)-[:STATEMENT]->(n:AWSPolicyStatement) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSPrincipal)-[:POLICY]->(:AWSPolicy)-[:STATEMENT]->(n:AWSPolicyStatement) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSPrincipal)-[:POLICY]->(:AWSPolicy)-[r:STATEMENT]->(:AWSPolicyStatement) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSPrincipal)-[:POLICY]->(:AWSPolicy)-[r:STATEMENT]->(:AWSPolicyStatement) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSPrincipal)-[:POLICY]->(n:AWSPolicy) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSPrincipal)-[:POLICY]->(n:AWSPolicy) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSPrincipal)-[r:POLICY]->(:AWSPolicy) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSPrincipal)-[r:POLICY]->(:AWSPolicy) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSPrincipal) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSPrincipal) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   }

--- a/cartography/data/jobs/cleanup/aws_import_rds_clusters_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_rds_clusters_cleanup.json
@@ -1,19 +1,19 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:RDSCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:RDSCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete RDS clusters that no longer exist and DETACH them from all nodes they were previously connected to."
     },
     {
-      "query": "MATCH (:RDSCluster)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:RDSCluster)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "If an RDS cluster still exists but is no longer associated with its old AWS Account, delete the relationship between them."
     },
     {
-      "query": "MATCH (:RDSCluster)<-[r:IS_CLUSTER_MEMBER_OF]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:RDSCluster)<-[r:IS_CLUSTER_MEMBER_OF]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "If an RDS instance still exists and is no longer a member of an RDS cluster, delete the relationship between them."

--- a/cartography/data/jobs/cleanup/aws_import_rds_instances_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_rds_instances_cleanup.json
@@ -1,43 +1,43 @@
 {
   "statements": [
     {
-      "query": "MATCH (sng:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE sng.lastupdated <> {UPDATE_TAG} WITH sng LIMIT {LIMIT_SIZE} DETACH DELETE (sng) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (sng:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE sng.lastupdated <> {UPDATE_TAG} WITH sng LIMIT {LIMIT_SIZE} DETACH DELETE (sng)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete DBSubnetGroups that no longer exist and DETACH them from their RDS instances."
     },
     {
-      "query": "MATCH (:DBSubnetGroup)<-[r:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:DBSubnetGroup)<-[r:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete the link between orphaned DB Subnet Groups and their RDS Instances."
     },
     {
-      "query": "MATCH (:EC2Subnet)<-[r:RESOURCE]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:EC2Subnet)<-[r:RESOURCE]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete the link between orphaned DB Subnet Groups and their EC2 Subnets."
     },
     {
-      "query": "MATCH (n:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete RDS instances that no longer exist and DETACH them from all nodes they were previously connected to."
     },
     {
-      "query": "MATCH (:RDSInstance)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:RDSInstance)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "If an RDS instance still exists but is no longer associated with its old AWS Account, delete the relationship between them."
     },
     {
-      "query": "MATCH (:EC2SecurityGroup)<-[r:MEMBER_OF_EC2_SECURITY_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:EC2SecurityGroup)<-[r:MEMBER_OF_EC2_SECURITY_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "If an RDS instance still exists and is no longer a part of its old EC2SecurityGroup, delete the relationship between them."
     },
     {
-      "query": "MATCH (:RDSInstance)<-[r:IS_READ_REPLICA_OF]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:RDSInstance)<-[r:IS_READ_REPLICA_OF]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "If an RDS instance still exists and is no longer a read replica of another RDS instance, delete the relationship between them."

--- a/cartography/data/jobs/cleanup/aws_import_redshift_clusters_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_redshift_clusters_cleanup.json
@@ -1,31 +1,31 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete RedshiftClusters that no longer exist and DETACH them from all nodes they were previously connected to."
     },
     {
-      "query": "MATCH (:RedshiftCluster)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:RedshiftCluster)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "If a RedshiftCluster still exists but is no longer associated with its old AWS Account, delete the relationship between them."
     },
     {
-      "query": "MATCH (:EC2SecurityGroup)<-[r:MEMBER_OF_EC2_SECURITY_GROUP]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:EC2SecurityGroup)<-[r:MEMBER_OF_EC2_SECURITY_GROUP]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "If a RedshiftCluster still exists and is no longer a part of its old EC2SecurityGroup, delete the relationship between them."
     },
     {
-      "query": "MATCH (:AWSPrincipal)<-[r:STS_ASSUMEROLE_ALLOW]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSPrincipal)<-[r:STS_ASSUMEROLE_ALLOW]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "If a RedshiftCluster still exists but can no longer assume a previously set IAM role, delete the relationship between them."
     },
     {
-      "query": "MATCH (:AWSVpc)<-[r:MEMBER_OF_AWS_VPC]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSVpc)<-[r:MEMBER_OF_AWS_VPC]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale relationships between RedshiftClusters and VPCs."

--- a/cartography/data/jobs/cleanup/aws_import_reserved_instances_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_reserved_instances_cleanup.json
@@ -1,12 +1,12 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:EC2ReservedInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:EC2ReservedInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:EC2ReservedInstance)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:EC2ReservedInstance)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_roles_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_roles_cleanup.json
@@ -1,11 +1,11 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSRole) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSRole) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSRole)-[r:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSRole)-[r:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_roles_policy_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_roles_policy_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSRole)-[r:STS_ASSUMEROLE_ALLOW]->(:AWSRole) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSRole)-[r:STS_ASSUMEROLE_ALLOW]->(:AWSRole) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_s3_acl_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_s3_acl_cleanup.json
@@ -1,12 +1,12 @@
 {
   "statements": [
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:S3Bucket)<-[:APPLIES_TO]-(n:S3Acl) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:S3Bucket)<-[:APPLIES_TO]-(n:S3Acl) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:S3Bucket)<-[r:APPLIES_TO]-(:S3Acl) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:S3Bucket)<-[r:APPLIES_TO]-(:S3Acl) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_s3_buckets_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_s3_buckets_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:S3Bucket) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:S3Bucket) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_secrets_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_secrets_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(s:SecretsManagerSecret) WHERE s.lastupdated <> {UPDATE_TAG} WITH s LIMIT {LIMIT_SIZE} DETACH DELETE (s) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(s:SecretsManagerSecret) WHERE s.lastupdated <> {UPDATE_TAG} WITH s LIMIT {LIMIT_SIZE} DETACH DELETE (s)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_securityhub_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_securityhub_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:SecurityHub) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:SecurityHub) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_snapshots_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_snapshots_cleanup.json
@@ -1,27 +1,27 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:EBSSnapshot)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:EBSSnapshot)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:EBSSnapshot)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:EBSSnapshot)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:EBSSnapshot)-[:CREATED_FROM]->(n:EBSVolume)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:EBSSnapshot)-[:CREATED_FROM]->(n:EBSVolume)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:EBSSnapshot)-[r:CREATED_FROM]->(:EBSVolume)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:EBSSnapshot)-[r:CREATED_FROM]->(:EBSVolume)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:EBSSnapshot)-[:CREATED_FROM]->(:EBSVolume)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:EBSSnapshot)-[:CREATED_FROM]->(:EBSVolume)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_sqs_queues_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_sqs_queues_cleanup.json
@@ -1,12 +1,12 @@
 {
   "statements": [
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(q:SQSQueue) WHERE q.lastupdated <> {UPDATE_TAG} WITH q LIMIT {LIMIT_SIZE} DETACH DELETE (q) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(q:SQSQueue) WHERE q.lastupdated <> {UPDATE_TAG} WITH q LIMIT {LIMIT_SIZE} DETACH DELETE (q)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:SQSQueue)-[r:HAS_DEADLETTER_QUEUE]->(:SQSQueue) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:SQSQueue)-[r:HAS_DEADLETTER_QUEUE]->(:SQSQueue) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Cleanup HAS_DEADLETTER_QUEUE for queues that no longer have a deadletter queue."

--- a/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
@@ -56,52 +56,52 @@
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:ESDomain)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:ESDomain)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RedshiftCluster) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RedshiftCluster) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:DBSubnetGroup)<-[:MEMBER_OF_DB_SUBNET_GROUP]-(:RDSInstance)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (:AWSTag)<-[r:TAGGED]-(:S3Bucket)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
             "iterative": true,
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag) WHERE NOT (n)--() AND n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) RETURN COUNT(*) as TotalCompleted",
+            "query": "MATCH (n:AWSTag) WHERE NOT (n)--() AND n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         }

--- a/cartography/data/jobs/cleanup/aws_import_tgw_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tgw_cleanup.json
@@ -1,42 +1,42 @@
 {
   "statements": [
     {
-      "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DETACH DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DETACH DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:AWSTransitGateway)-[r:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:AWSTransitGatewayAttachment)<-[r:RESOURCE]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:ATTACHED_TO]->(:AWSTransitGateway)-[:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:ATTACHED_TO]->(:AWSTransitGateway)-[:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:ATTACHED_TO]->(:AWSTransitGateway)-[:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (n:AWSTransitGatewayAttachment)-[r:ATTACHED_TO]->(:AWSTransitGateway)-[:RESOURCE|SHARED_WITH]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     }],

--- a/cartography/data/jobs/cleanup/aws_import_users_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_users_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSUser) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSUser) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_vpc_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_vpc_cleanup.json
@@ -1,21 +1,21 @@
 {
   "statements": [{
-    "query": "MATCH (n:CidrBlock)<-[:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:CidrBlock)<-[:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:CidrBlock)<-[r:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:CidrBlock)<-[r:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AWSVpc)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSVpc)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSVpc)<-[r:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_import_vpc_peering_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_vpc_peering_cleanup.json
@@ -1,41 +1,41 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:ACCEPTER_VPC]-(n:AWSPeeringConnection) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:ACCEPTER_VPC]-(n:AWSPeeringConnection) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:REQUESTER_VPC]-(n:AWSPeeringConnection) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:REQUESTER_VPC]-(n:AWSPeeringConnection) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:AWSCidrBlock)<-[:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AWSCidrBlock)<-[:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSCidrBlock)<-[r:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSCidrBlock)<-[r:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSVpc)<-[r:RESOURCE]-(:AWSAccount{foreign: true}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSVpc)<-[r:RESOURCE]-(:AWSAccount{foreign: true}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSVpc)-[r:VPC_PEERING]-(:AWSVpc) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSVpc)-[r:VPC_PEERING]-(:AWSVpc) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:AWSAccount{foreign: true}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AWSAccount{foreign: true}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_ingest_ec2_auto_scaling_groups_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_ec2_auto_scaling_groups_cleanup.json
@@ -1,36 +1,36 @@
 {
   "statements": [{
-    "query": "MATCH (n:AutoScalingGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AutoScalingGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AutoScalingGroup)-[:VPC_IDENTIFIER]->(n:EC2Subnet) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AutoScalingGroup)-[:VPC_IDENTIFIER]->(n:EC2Subnet) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AutoScalingGroup)-[r:VPC_IDENTIFIER]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AutoScalingGroup)-[r:VPC_IDENTIFIER]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:MEMBER_AUTO_SCALE_GROUP]->(:AutoScalingGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:MEMBER_AUTO_SCALE_GROUP]->(:AutoScalingGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:LaunchTemplate)<-[r:HAS_LAUNCH_TEMPLATE]-(:AutoScalingGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:LaunchTemplate)<-[r:HAS_LAUNCH_TEMPLATE]-(:AutoScalingGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:LaunchConfiguration)<-[r:HAS_LAUNCH_CONFIG]-(:AutoScalingGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:LaunchConfiguration)<-[r:HAS_LAUNCH_CONFIG]-(:AutoScalingGroup)<-[:RESOURCE]-(:AWSAccount{id: {AWS_ID}}) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_ingest_load_balancers_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_load_balancers_cleanup.json
@@ -1,36 +1,36 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:LoadBalancer) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:LoadBalancer) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:SUBNET]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:SUBNET]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:SOURCE_SECURITY_GROUP]->(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:SOURCE_SECURITY_GROUP]->(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:EXPOSE]->(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:EXPOSE]->(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[:ELB_LISTENER]->(n:ELBListener) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[:ELB_LISTENER]->(n:ELBListener) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:ELB_LISTENER]->(:ELBListener) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:ELB_LISTENER]->(:ELBListener) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_ingest_load_balancers_v2_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_load_balancers_v2_cleanup.json
@@ -1,31 +1,31 @@
 {
     "statements": [{
-        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:LoadBalancerV2) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:LoadBalancerV2) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
         "iterative": true,
         "iterationsize": 100
     },
     {
-        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancerV2)-[r:SUBNET]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancerV2)-[r:SUBNET]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
         "iterative": true,
         "iterationsize": 100
     },
     {
-        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancerV2)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancerV2)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(:EC2SecurityGroup) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
         "iterative": true,
         "iterationsize": 100
     },
     {
-        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancerV2)-[r:EXPOSE]->(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancerV2)-[r:EXPOSE]->(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
         "iterative": true,
         "iterationsize": 100
     },
     {
-        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancerV2)-[:ELBV2_LISTENER]->(n:ELBV2Listener) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancerV2)-[:ELBV2_LISTENER]->(n:ELBV2Listener) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
         "iterative": true,
         "iterationsize": 100
     },
     {
-        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancerV2)-[r:ELBV2_LISTENER]->(:ELBV2Listener) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancerV2)-[r:ELBV2_LISTENER]->(:ELBV2Listener) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
         "iterative": true,
         "iterationsize": 100
     }],

--- a/cartography/data/jobs/cleanup/aws_ingest_network_interfaces_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_network_interfaces_cleanup.json
@@ -1,42 +1,42 @@
 {
   "statements": [
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:MEMBER_OF_AWS_VPC]-(:EC2Subnet)<-[:PART_OF_SUBNET]-(:NetworkInterface)-[:PRIVATE_IP_ADDRESS]->(n:EC2PrivateIp) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:MEMBER_OF_AWS_VPC]-(:EC2Subnet)<-[:PART_OF_SUBNET]-(:NetworkInterface)-[:PRIVATE_IP_ADDRESS]->(n:EC2PrivateIp) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:MEMBER_OF_AWS_VPC]-(:EC2Subnet)<-[:PART_OF_SUBNET]-(:NetworkInterface)-[r:PRIVATE_IP_ADDRESS]->(:EC2PrivateIp) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:MEMBER_OF_AWS_VPC]-(:EC2Subnet)<-[:PART_OF_SUBNET]-(:NetworkInterface)-[r:PRIVATE_IP_ADDRESS]->(:EC2PrivateIp) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:MEMBER_OF_AWS_VPC]-(:EC2Subnet)<-[:PART_OF_SUBNET]-(n:NetworkInterface) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:MEMBER_OF_AWS_VPC]-(:EC2Subnet)<-[:PART_OF_SUBNET]-(n:NetworkInterface) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterationsize": 100,
       "iterative": true
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:MEMBER_OF_AWS_VPC]-(:EC2Subnet)<-[r:PART_OF_SUBNET]-(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[:MEMBER_OF_AWS_VPC]-(:EC2Subnet)<-[r:PART_OF_SUBNET]-(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterationsize": 100,
       "iterative": true
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:PART_OF_SUBNET]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:EC2Instance)-[r:PART_OF_SUBNET]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterationsize": 100,
       "iterative": true
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:PART_OF_SUBNET]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:LoadBalancer)-[r:PART_OF_SUBNET]->(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterationsize": 100,
       "iterative": true
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:NetworkInterface) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:NetworkInterface) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[r:RESOURCE]->(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[r:RESOURCE]->(:NetworkInterface) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_ingest_subnets_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_ingest_subnets_cleanup.json
@@ -1,10 +1,10 @@
 {
   "statements": [{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[r:MEMBER_OF_AWS_VPC]-(n:EC2Subnet) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[r:MEMBER_OF_AWS_VPC]-(n:EC2Subnet) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },{
-    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[r:MEMBER_OF_AWS_VPC]-(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSVpc)<-[r:MEMBER_OF_AWS_VPC]-(:EC2Subnet) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }

--- a/cartography/data/jobs/cleanup/aws_kms_details.json
+++ b/cartography/data/jobs/cleanup/aws_kms_details.json
@@ -1,7 +1,7 @@
 {
   "statements": [
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(s:KMSKey) WHERE EXISTS(s.anonymous_access)\n WITH s LIMIT {LIMIT_SIZE}\nREMOVE s.anonymous_access, s.anonymous_actions return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(s:KMSKey) WHERE EXISTS(s.anonymous_access)\n WITH s LIMIT {LIMIT_SIZE}\nREMOVE s.anonymous_access, s.anonymous_actions",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_post_ingestion_principals_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_post_ingestion_principals_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (n:AWSPrincipal) WHERE NOT (n)<-[:RESOURCE]-(:AWSAccount) AND n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n) return COUNT(*) as TotalCompleted",
+    "query": "MATCH (n:AWSPrincipal) WHERE NOT (n)<-[:RESOURCE]-(:AWSAccount) AND n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/aws_s3_details.json
+++ b/cartography/data/jobs/cleanup/aws_s3_details.json
@@ -1,7 +1,7 @@
 {
   "statements": [
     {
-      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(s:S3Bucket) WHERE EXISTS(s.anonymous_access)\n WITH s LIMIT {LIMIT_SIZE}\nREMOVE s.anonymous_access, s.anonymous_actions return COUNT(*) as TotalCompleted",
+      "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(s:S3Bucket) WHERE EXISTS(s.anonymous_access)\n WITH s LIMIT {LIMIT_SIZE}\nREMOVE s.anonymous_access, s.anonymous_actions",
       "iterative": true,
       "iterationsize": 100
     }


### PR DESCRIPTION
This PR removes the `return COUNT(*) as TotalCompleted from the AWS Cleanup files.

Reasons for this are mentioned in https://github.com/lyft/cartography/pull/680 and https://github.com/lyft/cartography/pull/735.

I'll open a separate PR for Azure. Thought would keep these PRs service specific.