### PR TITLE
Neo4j 4.x upgrade: special branch, enable experimental-neo4j-4x-support by default

### DIFF
--- a/cartography/experimental_neo4j_4x_support.py
+++ b/cartography/experimental_neo4j_4x_support.py
@@ -28,7 +28,7 @@ from distutils.util import strtobool
 # Initially is set by the environment variable
 # but then can also be set to true by the cli switch --experimental-neo4j-4x-support
 EXPERIMENTAL_NEO4J_4X_SUPPORT = bool(strtobool(os.getenv("EXPERIMENTAL_NEO4J_4X_SUPPORT", "False")))
-# EXPERIMENTAL_NEO4J_4X_SUPPORT = True
+EXPERIMENTAL_NEO4J_4X_SUPPORT = True
 
 # Detect the driver version
 USING_4_X_DRIVER = neo4j.__version__ >= '4.0.0'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.62.0'
+__version__ = '0.62.0-neo4j-4x-rc1'
 
 
 setup(
@@ -31,7 +31,7 @@ setup(
         "boto3>=1.15.1",
         "botocore>=1.18.1",
         "dnspython>=1.15.0",
-        "neo4j>=1.7.6,<4.0.0",
+        "neo4j==4.4.4",
         "neobolt>=1.7.0,<4.0.0",
         "policyuniverse>=1.1.0.0",
         "google-api-python-client>=1.7.8",


### PR DESCRIPTION
Continuing the Neo4j 4.x upgrade effort described in #838

This branch `master-enable-experimental-neo4j-4x-support` will serve as an easy way to start using cartography with Neo4j 4.x.

Releases from this branch keep up with `master` will be pre-releases, named like `0.62.0-neo4j-4x-rc1`.

README.MD updates to come

