### PR TITLE
Remove explicit cryptography dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         "requests>=2.22.0",
         "statsd",
         "packaging",
-        "cryptography<3.4,>=3.2",
         "python-digitalocean>=1.16.0",
         "adal>=1.2.4",
         "azure-cli-core>=2.26.0",


### PR DESCRIPTION
Fixes an error when trying to run `pip install -e .` on Python 3.8 (M1 Mac; if that's relevant).

```
Building wheels for collected packages: cryptography, neobolt, pyyaml, cffi, psutil
  Building wheel for cryptography (pyproject.toml) ... error
  ERROR: Command errored out with exit status 1:
   command: /Users/achantavy/src/cartography/venv/bin/python /Users/achantavy/src/cartography/venv/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py build_wheel /var/folders/1f/7xzh95l17qx06dg7jxxdsj640000gp/T/tmpfi84eocs
       cwd: /private/var/folders/1f/7xzh95l17qx06dg7jxxdsj640000gp/T/pip-install-ttnw7_7d/cryptography_b5fa870fa1174b639ac16828682dc322
  Complete output (49 lines):
  running bdist_wheel
  running build
  running build_py
  running egg_info
  writing src/cryptography.egg-info/PKG-INFO
  writing dependency_links to src/cryptography.egg-info/dependency_links.txt
  writing requirements to src/cryptography.egg-info/requires.txt
  writing top-level names to src/cryptography.egg-info/top_level.txt
  reading manifest file 'src/cryptography.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  no previously-included directories found matching 'docs/_build'
  warning: no previously-included files found matching 'vectors'
  warning: no previously-included files matching '*' found under directory 'vectors'
  warning: no previously-included files matching '*' found under directory '.github'
  warning: no previously-included files found matching 'release.py'
  warning: no previously-included files found matching '.coveragerc'
  warning: no previously-included files found matching 'codecov.yml'
  warning: no previously-included files found matching '.readthedocs.yml'
  warning: no previously-included files found matching 'dev-requirements.txt'
  warning: no previously-included files found matching 'rtd-requirements.txt'
  warning: no previously-included files found matching 'tox.ini'
  warning: no previously-included files matching '*' found under directory '.zuul.d'
  warning: no previously-included files matching '*' found under directory '.zuul.playbooks'
  adding license file 'LICENSE'
  adding license file 'LICENSE.APACHE'
  adding license file 'LICENSE.BSD'
  adding license file 'LICENSE.PSF'
  adding license file 'AUTHORS.rst'
  running build_ext
  generating cffi module 'build/temp.macosx-10.14-arm64-cpython-38/_padding.c'
  generating cffi module 'build/temp.macosx-10.14-arm64-cpython-38/_openssl.c'
  building '_openssl' extension
  build/temp.macosx-10.14-arm64-cpython-38/_openssl.c:575:10: fatal error: 'openssl/opensslv.h' file not found
  #include <openssl/opensslv.h>
           ^~~~~~~~~~~~~~~~~~~~
  1 error generated.

      =============================DEBUG ASSISTANCE=============================
      If you are seeing a compilation error please try the following steps to
      successfully install cryptography:
      1) Upgrade to the latest pip and try again. This will fix errors for most
         users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
      2) Read https://cryptography.io/en/latest/installation.html for specific
         instructions for your platform.
      3) Check our frequently asked questions for more information:
         https://cryptography.io/en/latest/faq.html
      =============================DEBUG ASSISTANCE=============================

  error: command '/usr/bin/clang' failed with exit code 1
  ----------------------------------------
  ERROR: Failed building wheel for cryptography
```

The install works after this.