### PR TITLE
ECR: add ecr test_cleanup_repositories

### DIFF
--- a/tests/integration/cartography/intel/aws/test_ecr.py
+++ b/tests/integration/cartography/intel/aws/test_ecr.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 import cartography.intel.aws.ecr
 import tests.data.aws.ecr
@@ -50,6 +51,8 @@ def test_cleanup_repositories(neo4j_session):
     create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
     repo_data = {**tests.data.aws.ecr.DESCRIBE_REPOSITORIES}
     # add additional repository noes, for a total of 103, since
+    cleanup_jobs = json.load(open('./cartography/data/jobs/cleanup/aws_import_ecr_cleanup.json'))
+    iter_size = cleanup_jobs['statements'][-1]['iterationsize']
     repo_data['repositories'].extend([
         {
             'repositoryArn': f'arn:aws:ecr:us-east-1:000000000000:repository/test-repository{i}',
@@ -58,7 +61,7 @@ def test_cleanup_repositories(neo4j_session):
             'repositoryUri': '000000000000.dkr.ecr.us-east-1/test-repository',
             'createdAt': datetime.datetime(2019, 1, 1, 0, 0, 1),
         }
-        for i in range(100)
+        for i in range(iter_size)
     ])
 
     # Act

--- a/tests/integration/cartography/intel/aws/test_ecr.py
+++ b/tests/integration/cartography/intel/aws/test_ecr.py
@@ -40,7 +40,7 @@ def test_cleanup_repositories(neo4j_session):
     '''
     Ensure that after the cleanup job runs, all ECRRepository nodes
     with a different UPDATE_TAG are removed from the AWSAccount node.
-    We load 100 additional nodes, becase the cleanup job is configured
+    We load 100 additional nodes, because the cleanup job is configured
     to run iteratively, processing 100 nodes at a time. So this test also ensures
     that iterative cleanups do work.
     '''

--- a/tests/integration/cartography/intel/aws/test_ecr.py
+++ b/tests/integration/cartography/intel/aws/test_ecr.py
@@ -1,4 +1,5 @@
 import datetime
+
 import cartography.intel.aws.ecr
 import tests.data.aws.ecr
 from tests.integration.cartography.intel.aws.common import create_test_account
@@ -36,6 +37,7 @@ def test_load_ecr_repositories(neo4j_session):
     actual_nodes = {n['r.arn'] for n in nodes}
     assert actual_nodes == expected_nodes
 
+
 def test_cleanup_repositories(neo4j_session):
     '''
     Ensure that after the cleanup job runs, all ECRRepository nodes
@@ -50,11 +52,11 @@ def test_cleanup_repositories(neo4j_session):
     # add additional repository noes, for a total of 103, since
     repo_data['repositories'].extend([
         {
-        'repositoryArn': f'arn:aws:ecr:us-east-1:000000000000:repository/test-repository{i}',
-        'registryId': '000000000000',
-        'repositoryName': f'test-repository{i}',
-        'repositoryUri': '000000000000.dkr.ecr.us-east-1/test-repository',
-        'createdAt': datetime.datetime(2019, 1, 1, 0, 0, 1),
+            'repositoryArn': f'arn:aws:ecr:us-east-1:000000000000:repository/test-repository{i}',
+            'registryId': '000000000000',
+            'repositoryName': f'test-repository{i}',
+            'repositoryUri': '000000000000.dkr.ecr.us-east-1/test-repository',
+            'createdAt': datetime.datetime(2019, 1, 1, 0, 0, 1),
         }
         for i in range(100)
     ])
@@ -69,7 +71,7 @@ def test_cleanup_repositories(neo4j_session):
     )
     common_job_params = {
         'AWS_ID': TEST_ACCOUNT_ID,
-        'UPDATE_TAG': TEST_UPDATE_TAG
+        'UPDATE_TAG': TEST_UPDATE_TAG,
     }
     nodes = neo4j_session.run(
         f"""
@@ -79,7 +81,7 @@ def test_cleanup_repositories(neo4j_session):
     )
     # there should be 103 nodes
     expected_nodes = {
-        len(repo_data['repositories'])
+        len(repo_data['repositories']),
     }
     actual_nodes = {(n['count(repo)']) for n in nodes}
     # Assert
@@ -87,15 +89,15 @@ def test_cleanup_repositories(neo4j_session):
 
     # Arrange
     additional_repo_data = {
-        'repositories' : [
+        'repositories': [
             {
                 'repositoryArn': 'arn:aws:ecr:us-east-1:000000000000:repository/test-repositoryX',
                 'registryId': '000000000000',
                 'repositoryName': 'test-repositoryX',
                 'repositoryUri': '000000000000.dkr.ecr.us-east-1/test-repository',
                 'createdAt': datetime.datetime(2019, 1, 1, 0, 0, 1),
-            }
-        ]
+            },
+        ],
     }
     additional_update_tag = 2
     common_job_params['UPDATE_TAG'] = additional_update_tag
@@ -121,8 +123,8 @@ def test_cleanup_repositories(neo4j_session):
     expected_nodes = {
         (
             'arn:aws:ecr:us-east-1:000000000000:repository/test-repositoryX',
-            additional_update_tag
-        )
+            additional_update_tag,
+        ),
     }
 
     # Assert

--- a/tests/integration/cartography/intel/aws/test_ecr.py
+++ b/tests/integration/cartography/intel/aws/test_ecr.py
@@ -1,5 +1,7 @@
+import datetime
 import cartography.intel.aws.ecr
 import tests.data.aws.ecr
+from tests.integration.cartography.intel.aws.common import create_test_account
 
 TEST_ACCOUNT_ID = '000000000000'
 TEST_REGION = 'us-east-1'
@@ -33,6 +35,98 @@ def test_load_ecr_repositories(neo4j_session):
     )
     actual_nodes = {n['r.arn'] for n in nodes}
     assert actual_nodes == expected_nodes
+
+def test_cleanup_repositories(neo4j_session):
+    '''
+    Ensure that after the cleanup job runs, all ECRRepository nodes
+    with a different UPDATE_TAG are removed from the AWSAccount node.
+    We load 100 additional nodes, becase the cleanup job is configured
+    to run iteratively, processing 100 nodes at a time. So this test also ensures
+    that iterative cleanups do work.
+    '''
+    # Arrange
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    repo_data = {**tests.data.aws.ecr.DESCRIBE_REPOSITORIES}
+    # add additional repository noes, for a total of 103, since
+    repo_data['repositories'].extend([
+        {
+        'repositoryArn': f'arn:aws:ecr:us-east-1:000000000000:repository/test-repository{i}',
+        'registryId': '000000000000',
+        'repositoryName': f'test-repository{i}',
+        'repositoryUri': '000000000000.dkr.ecr.us-east-1/test-repository',
+        'createdAt': datetime.datetime(2019, 1, 1, 0, 0, 1),
+        }
+        for i in range(100)
+    ])
+
+    # Act
+    cartography.intel.aws.ecr.load_ecr_repositories(
+        neo4j_session,
+        repo_data['repositories'],
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    common_job_params = {
+        'AWS_ID': TEST_ACCOUNT_ID,
+        'UPDATE_TAG': TEST_UPDATE_TAG
+    }
+    nodes = neo4j_session.run(
+        f"""
+        MATCH (a:AWSAccount{{id:'{TEST_ACCOUNT_ID}'}})--(repo:ECRRepository)
+        RETURN count(repo)
+        """,
+    )
+    # there should be 103 nodes
+    expected_nodes = {
+        len(repo_data['repositories'])
+    }
+    actual_nodes = {(n['count(repo)']) for n in nodes}
+    # Assert
+    assert expected_nodes == actual_nodes
+
+    # Arrange
+    additional_repo_data = {
+        'repositories' : [
+            {
+                'repositoryArn': 'arn:aws:ecr:us-east-1:000000000000:repository/test-repositoryX',
+                'registryId': '000000000000',
+                'repositoryName': 'test-repositoryX',
+                'repositoryUri': '000000000000.dkr.ecr.us-east-1/test-repository',
+                'createdAt': datetime.datetime(2019, 1, 1, 0, 0, 1),
+            }
+        ]
+    }
+    additional_update_tag = 2
+    common_job_params['UPDATE_TAG'] = additional_update_tag
+    # Act
+    # load an additional node with a different update_tag
+    cartography.intel.aws.ecr.load_ecr_repositories(
+        neo4j_session,
+        additional_repo_data['repositories'],
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        additional_update_tag,
+    )
+    # run the cleanup job
+    cartography.intel.aws.ecr.cleanup(neo4j_session, common_job_params)
+    nodes = neo4j_session.run(
+        f"""
+        MATCH (a:AWSAccount{{id:'{TEST_ACCOUNT_ID}'}})--(repo:ECRRepository)
+        RETURN repo.arn, repo.lastupdated
+        """,
+    )
+    actual_nodes = {(n['repo.arn'], n['repo.lastupdated']) for n in nodes}
+    # there should be just one remaining node with the new update_tag
+    expected_nodes = {
+        (
+            'arn:aws:ecr:us-east-1:000000000000:repository/test-repositoryX',
+            additional_update_tag
+        )
+    }
+
+    # Assert
+    assert expected_nodes == actual_nodes
 
 
 def test_load_ecr_repository_images(neo4j_session):


### PR DESCRIPTION
Ensure that after the cleanup job runs, all ECRRepository nodes with a different UPDATE_TAG are removed from the AWSAccount node. We load 100 additional nodes, because the cleanup job is configured to run iteratively, processing 100 nodes at a time. So this test also ensures that iterative cleanups do work.