### PR TITLE
0.63.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.63.0rc4'
+__version__ = '0.63.0'
 
 
 setup(


### PR DESCRIPTION
Raise the version to 0.63.0

Regarding the Neo4j 3.5 End of Life, we are still working to officially upgrade cartography to use the new Neo4j 4.x versions. This upgrade requires both a python driver upgrade, which has some [breaking changes](https://neo4j.com/docs/api/python-driver/current/breaking_changes.html), and [query syntax changes](https://neo4j.com/docs/cypher-manual/current/syntax/parameters/).

In the mean time
- Implemented an auto-patcher, which will both do run-time implementations the new driver's breaking changes, and can do syntax upgrades if it detects that you are using the new Neo4j 4.x database, #861 
- We have upgrade the python driver to neo4j>=4.4.4, #885 

As in our [updated Installation docs](https://lyft.github.io/cartography/install.html):
To use the autopatcher, simply have the new Neo4j 4.x databse, and set an [environment variable or cli switch](https://github.com/lyft/cartography/blob/master/cartography/experimental_neo4j_4x_support.py#L28-L29) to cartography.
