### PR TITLE
Reorder inspector cleanup statements

### DIFF
--- a/cartography/data/jobs/cleanup/aws_import_inspector_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_inspector_cleanup.json
@@ -1,16 +1,6 @@
 {
     "statements": [
       {
-        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSInspectorFinding) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
-        "iterative": true,
-        "iterationsize": 100
-      },
-      {
-        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSInspectorPackage) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
-        "iterative": true,
-        "iterationsize": 100
-      },
-      {
         "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSInspectorFinding)-[r:AFFECTS]->(:EC2Instance) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
         "iterative": true,
         "iterationsize": 100
@@ -27,6 +17,16 @@
       },
       {
         "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(:AWSInspectorFinding)-[r:HAS]->(:AWSInspectorPackage) WHERE r.lastupdated <> {UPDATE_TAG} WITH r LIMIT {LIMIT_SIZE} DELETE (r)",
+        "iterative": true,
+        "iterationsize": 100
+      },
+      {
+        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSInspectorFinding) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
+        "iterative": true,
+        "iterationsize": 100
+      },
+      {
+        "query": "MATCH (:AWSAccount{id: {AWS_ID}})-[:RESOURCE]->(n:AWSInspectorPackage) WHERE n.lastupdated <> {UPDATE_TAG} WITH n LIMIT {LIMIT_SIZE} DETACH DELETE (n)",
         "iterative": true,
         "iterationsize": 100
       }


### PR DESCRIPTION
Puts longest path cleanups first because with the previous ordering we would leave behind orphaned nodes after cleaning up a stale InspectorFinding because the paths after that would no longer be matched.