### PR TITLE
Check boto3 session allows calling 'inspector2' client service

### DIFF
--- a/cartography/intel/aws/inspector.py
+++ b/cartography/intel/aws/inspector.py
@@ -18,12 +18,12 @@ logger = logging.getLogger(__name__)
 @timeit
 @aws_handle_regions
 def get_inspector_findings(session: boto3.session.Session, region: str) -> List[Dict]:
-    client = session.client('inspector2', region_name=region)
-    paginator = client.get_paginator('list_findings')
     findings = []
-
-    for page in paginator.paginate():
-        findings.extend(page['findings'])
+    if 'inspector2' in session.get_available_services():
+        client = session.client('inspector2', region_name=region)
+        paginator = client.get_paginator('list_findings')
+        for page in paginator.paginate():
+            findings.extend(page['findings'])
     return findings
 
 

--- a/tests/unit/cartography/intel/aws/test_inspector.py
+++ b/tests/unit/cartography/intel/aws/test_inspector.py
@@ -16,6 +16,7 @@ TEST_UPDATE_TAG = 123456789
 
 def test_get_inspector_findings():
     mock_boto = mock.MagicMock()
+    mock_boto.get_available_services = mock.MagicMock(return_value=['inspector2'])
 
     ret = get_inspector_findings(mock_boto, 'us-east-1')
 


### PR DESCRIPTION
Considering not all accounts might have 'inspector2' configured, this avoids breaking the AWS import module unless the service is available.