### PR TITLE
Fixes #906, #907: Neo4j 4.4 support by default

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Neo4j setup
         run: |
           wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
-          echo 'deb https://debian.neo4j.com stable 3.5' | sudo tee /etc/apt/sources.list.d/neo4j.list
+          echo 'deb https://debian.neo4j.com stable 4.4' | sudo tee /etc/apt/sources.list.d/neo4j.list
           sudo apt-get update
       - name: Install Neo4j
         run: sudo apt-get install neo4j

--- a/cartography/__init__.py
+++ b/cartography/__init__.py
@@ -1,5 +1,4 @@
-__all__ = ['EXPERIMENTAL_NEO4J_4X_SUPPORT', 'patch_session_obj']
+__all__ = ['patch_session_obj']
 
 # experimental neo4j 4.x support
-from cartography.experimental_neo4j_4x_support import EXPERIMENTAL_NEO4J_4X_SUPPORT
 from cartography.experimental_neo4j_4x_support import patch_session_obj

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -7,7 +7,6 @@ import sys
 import cartography.config
 import cartography.sync
 import cartography.util
-from cartography.experimental_neo4j_4x_support import patch_driver
 from cartography.intel.aws.util.common import parse_and_validate_aws_requested_syncs
 
 
@@ -525,8 +524,10 @@ class CLI:
             config.crowdstrike_client_secret = None
 
         if config.experimental_neo4j_4x_support:
-            cartography.EXPERIMENTAL_NEO4J_4X_SUPPORT = True
-            patch_driver()
+            logger.warning(
+                'EXPERIMENTAL_NEO4J_4X_SUPPORT is now enabled by default,'
+                ' and this option will be removed when code hard-coded syntax upgrades are completed'
+            )
 
         # Run cartography
         try:

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -526,7 +526,7 @@ class CLI:
         if config.experimental_neo4j_4x_support:
             logger.warning(
                 'EXPERIMENTAL_NEO4J_4X_SUPPORT is now enabled by default,'
-                ' and this option will be removed when code hard-coded syntax upgrades are completed'
+                ' and this option will be removed when code hard-coded syntax upgrades are completed',
             )
 
         # Run cartography

--- a/cartography/experimental_neo4j_4x_support.py
+++ b/cartography/experimental_neo4j_4x_support.py
@@ -1,19 +1,20 @@
-# Implement the Moneky Patching described in
-# https://github.com/lyft/cartography/issues/838 and in
-# https://docs.google.com/document/d/1DR-XPzEpd5o_aqvgH28mdIJG-2WSeektx2V9hETFXuM/edit#heading=h.cqtqxkjjli6n
-# To really use these patches, you also need the 4.x python driver installed.
-# $ pip install neo4j==4.4.4
-# For now, this version is not included in our setup.py, so you must manually install it later,
-# or we may cut pre-releases with a special siuffix, like cartography==0.61.0-neo4j-4x-rc1
-# The library patches here automatically detect the driver versions and do some patching on library paths
-# We must auto-patch libraries because the typing hints are loaded before the cli is loaded.
-# The driver patch can also auto-detect the database version, and determine if the query upgrades are needed.
-# Once EXPERIMENTAL_NEO4J_4X_SUPPORT is True, the driver patches apply automatically.
-# But for your own forks of cartography, you can directly driver patch like this:
-# experimental neo4j 4.x support
-# from cartography import EXPERIMENTAL_NEO4J_4X_SUPPORT, patch_session_obj
-# if EXPERIMENTAL_NEO4J_4X_SUPPORT:
-#     patch_session_obj(neo4j_session)
+'''
+Implement the Moneky Patching described in
+https://github.com/lyft/cartography/issues/838 and in
+https://docs.google.com/document/d/1DR-XPzEpd5o_aqvgH28mdIJG-2WSeektx2V9hETFXuM/edit#heading=h.cqtqxkjjli6n
+
+The driver patch can also auto-detect the database version,
+and determine if the query upgrades are needed.
+By default, the driver patches apply automatically.
+But for your own forks of cartography, you can directly driver patch like this:
+experimental neo4j 4.x support
+
+```
+from cartography import patch_session_obj
+patch_session_obj(neo4j_session)
+```
+'''
+
 import logging
 import os
 import re
@@ -23,14 +24,8 @@ from typing import Callable
 import neo4j.exceptions
 from distutils.util import strtobool
 
-# Enable these patches
-# Initially is set by the environment variable
-# but then can also be set to true by the cli switch --experimental-neo4j-4x-support
-EXPERIMENTAL_NEO4J_4X_SUPPORT = bool(strtobool(os.getenv("EXPERIMENTAL_NEO4J_4X_SUPPORT", "False")))
-# EXPERIMENTAL_NEO4J_4X_SUPPORT = True
-
-# Detect the driver version
-USING_4_X_DRIVER = neo4j.__version__ >= '4.0.0'
+# Enable these patches, by default
+EXPERIMENTAL_NEO4J_4X_SUPPORT = True
 
 # Detect the database version
 USING_4x_DATABASE = None
@@ -43,35 +38,6 @@ LOG_QUERIES = False
 
 
 logger = logging.getLogger(__name__)
-
-
-# def patch_libraries():
-# Logging
-# https://github.com/neo4j/neo4j-python-driver/search?q=getLogger
-# neo4j.bolt = neo4j
-
-# Breaking Changes
-# https://neo4j.com/docs/api/python-driver/current/breaking_changes.html
-
-# Argument Renaming Changes
-# https://neo4j.com/docs/api/python-driver/current/breaking_changes.html#class-renaming-changes
-# neo4j.Result = neo4j.Result
-# neo4j.StatementResult = neo4j.Result
-# neo4j.BoltStatementResultSummary = neo4j.ResultSummary
-# neo4j.StatementResultSummary = neo4j.ResultSummary
-# neo4j.Statement = neo4j.Query
-
-# API Changes
-# https://neo4j.com/docs/api/python-driver/current/breaking_changes.html#api-changes
-# neo4j.Result.summary = neo4j.Result.consume
-
-# Dependency Changes
-# https://neo4j.com/docs/api/python-driver/current/breaking_changes.html#dependency-changes
-# neo4j.exceptions = neo4j.exceptions
-
-
-# if USING_4_X_DRIVER:
-#     patch_libraries()
 
 # Helper functions that patch the neo4j.GraphDatabase.driver().session().run()
 # codepath to include the query conversions:

--- a/cartography/experimental_neo4j_4x_support.py
+++ b/cartography/experimental_neo4j_4x_support.py
@@ -14,15 +14,12 @@ from cartography import patch_session_obj
 patch_session_obj(neo4j_session)
 ```
 '''
-
 import logging
-import os
 import re
 from functools import wraps
 from typing import Callable
 
 import neo4j.exceptions
-from distutils.util import strtobool
 
 # Enable these patches, by default
 EXPERIMENTAL_NEO4J_4X_SUPPORT = True

--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -81,7 +81,7 @@ def build_relationship_ingestion_query(
     :param dict_key_b: The dict key on what value of `search_property_b` to search for.
     :param rel_label: The $RELATIONSHIP_NAME from $NodeA to $NodeB.
     :param rel_property_map: Optional mapping of relationship property names to set and their
-    corresponding keys on the input data dict. Note: relationships in Neo4j 3.5 cannot be indexed
+    corresponding keys on the input data dict. Note: relationships in cartography are not indexed
     so performing searches on them is slow. Reconsider your schema design if you expect to need
     to run queries using relationship fields as search keys.
     :return: Neo4j query string to draw relationships between $NodeA and $NodeB. This exposes 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,5 @@ services:
     restart: on-failure
     depends_on:
       - neo4j
-    environment:
-      - EXPERIMENTAL_NEO4J_4X_SUPPORT=True
     volumes:
       - ~/.aws:/cartography/.aws/

--- a/docs/root/install.md
+++ b/docs/root/install.md
@@ -23,10 +23,6 @@ Time to set up the server that will run Cartography.  Cartography _should_ work 
 
     1. Run `pip install cartography` to install our code.
 
-    1. Set up Neo4j 4.x support: Set environment variable to true with `export EXPERIMENTAL_NEO4J_4X_SUPPORT=True`
-
-            ⚠️ This is a temporary fix that is necessary for cartography to support the new query syntax of Neo4j 4.x. A more permanent solution is in progress. ⚠️
-
     1. Finally, to sync your data:
 
         - For one account using the `default` profile defined in your AWS config file, run


### PR DESCRIPTION
This PR enables Neo4j 4.x syntax support by default. For now, this support exists as an automatic syntax upgrader, converting query strings from `{my_param}` to `$my_param`. Soon we will begin migrating all of the queries with hard-coded changes. 

This also upgrades the CI builds to use Neo4j 4.4.