### PR TITLE
python library neo4j>=4.4.4,<5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "boto3>=1.15.1",
         "botocore>=1.18.1",
         "dnspython>=1.15.0",
-        "neo4j>=4.4.4",
+        "neo4j>=4.4.4,<5.0.0",
         "policyuniverse>=1.1.0.0",
         "google-api-python-client>=1.7.8",
         "oauth2client>=4.1.3",


### PR DESCRIPTION
neo4j==5.0.0 was just released today and seems to break some of our CI's tests around cleanup jobs.
Previously we've tracked the latest version with neo4j>=4.4.4, but this PR fixes the version to also not use 5.0.0.
The more recent 4.4.7 still works, so we can assume there will be no more breaking changes in neo4j==4.x.x.

Error:
```
...
E           neo4j.exceptions.ResultConsumedError: The result is out of scope. The associated transaction has been closed. Results can only be used while the transaction is open.
```

changelogs
* https://github.com/neo4j/neo4j-python-driver/wiki/4.4-changelog#447
* https://github.com/neo4j/neo4j-python-driver/wiki/5.0-changelog#500