### PR TITLE
fix inspector api issues

### DIFF
--- a/docs/root/modules/aws/config.md
+++ b/docs/root/modules/aws/config.md
@@ -6,7 +6,7 @@ Follow these steps to analyze AWS assets with Cartography.
 
 ### Single AWS Account Setup
 
-1. Set up an AWS identity (user, group, or role) for Cartography to use.  Ensure that this identity has the built-in AWS [SecurityAudit policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html#jf_security-auditor) (arn:aws:iam::aws:policy/SecurityAudit) attached.  This policy grants access to read security config metadata.
+1. Set up an AWS identity (user, group, or role) for Cartography to use.  Ensure that this identity has the built-in AWS [SecurityAudit policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_job-functions.html#jf_security-auditor) (arn:aws:iam::aws:policy/SecurityAudit) attached.  This policy grants access to read security config metadata. The SecurityAudit policy does not yet containe permissions for `inspector2`, so you will also need the [AmazonInspector2ReadOnlyAccess policy](https://docs.aws.amazon.com/inspector/latest/user/security-iam-awsmanpol.html#security-iam-awsmanpol-AmazonInspector2ReadOnlyAccess).
 1. Set up AWS credentials to this identity on your server, using a `config` and `credential` file.  For details, see AWS' [official guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
 1. [Optional] Configure AWS Retry settings using `AWS_MAX_ATTEMPTS` and `AWS_RETRY_MODE` environment variables. This helps in API Rate Limit throttling and TooManyRequestException related errors. For details, see AWS' [official guide](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables).
 


### PR DESCRIPTION
Redo of #997 

The aws inspector api has some performance issues. This PR addresses those.

- The normal `SecurityAudit` aws policy does not have `inspector2` permissions, so we update our docs to mention that your aws identity must also include the `AmazonInspector2ReadOnlyAccess` policy.
- The inspector2 service is not available in the `ap-northeast-3` region, so we add `InternalServerErrorException` to `aws_handle_regions`, so we can bypass. Fixes #988 
- The inspector2 api will hang unless you specify some `filterCriteria`. Here we filter by both a list of known accounts, and by a finding's `status`.
- As far as we can tell, findings cannot be deleted, so if we were to fetch all findings, this is potentially millions of items. Instead, we only fetch findings that are either `OPEN` or `SUPPRESSED`, not `CLOSED`.
- I've also created a helper function `aws_paginate` to help with the boilerplate pagination code.
- The finding objects need to be loaded to Neo4j in batches, because they are a lot of data, and we don't want to exceed our databases' transaction size limit.
- 

I have some additional concerns about the `:HAS` relationship between findings and packages, but we will address that ina. future pr.