### PR TITLE
Fix #1030: add neo4j_database param to CLI, 0.66.1

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -100,6 +100,16 @@ class CLI:
                 '.'
             ),
         )
+        parser.add_argument(
+            '--neo4j-database',
+            type=str,
+            default=None,
+            help=(
+                'The name of the database in Neo4j to connect to. If not specified, uses the config settings of your '
+                'Neo4j database itself to infer which database is set to default. '
+                'See https://neo4j.com/docs/api/python-driver/4.4/api.html#database.'
+            ),
+        )
         # TODO add the below parameters to a 'sync' subparser
         parser.add_argument(
             '--update-tag',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.66.0'
+__version__ = '0.66.1'
 
 
 setup(


### PR DESCRIPTION
When adding a new config option, we need to update config.py _and_ cli.py (which I missed). This PR fixes that.