### PR TITLE
mypy to 0.981, use flake8 github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     -   id: debug-statements
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8
@@ -39,7 +39,7 @@ repos:
     -   id: reorder-python-imports
         args: [--py3-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.981
     hooks:
     -   id: mypy
         additional_dependencies:


### PR DESCRIPTION
- Bumping mypy to 0.981 because we need python/mypy#13398 for https://github.com/lyft/cartography/pull/1038.
- Use flake8 github instead of gitlab because it's failing now.