### PR TITLE
Fix #1042: AWS: only specify profile_name when syncing multiple accounts

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -155,11 +155,11 @@ def _sync_multiple_accounts(
     for profile_name, account_id in accounts.items():
         logger.info("Syncing AWS account with ID '%s' using configured profile '%s'.", account_id, profile_name)
         common_job_parameters["AWS_ID"] = account_id
-        # if num_accounts == 1:
-        #     # Use the default boto3 session because boto3 gets confused if you give it a profile name with 1 account
-        #     boto3_session = boto3.Session()
-        # else:
-        boto3_session = boto3.Session(profile_name=profile_name)
+        if num_accounts == 1:
+            # Use the default boto3 session because boto3 gets confused if you give it a profile name with 1 account
+            boto3_session = boto3.Session()
+        else:
+            boto3_session = boto3.Session(profile_name=profile_name)
 
         _autodiscover_accounts(neo4j_session, boto3_session, account_id, sync_tag, common_job_parameters)
 

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -222,8 +222,6 @@ def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     else:
         aws_accounts = organizations.get_aws_account_default(boto3_session)
 
-    logger.info(aws_accounts)
-
     if not aws_accounts:
         logger.warning(
             "No valid AWS credentials could be found. No AWS accounts can be synced. Exiting AWS sync stage.",

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -150,9 +150,15 @@ def _sync_multiple_accounts(
     failed_account_ids = []
     exception_tracebacks = []
 
+    num_accounts = len(accounts)
+
     for profile_name, account_id in accounts.items():
         logger.info("Syncing AWS account with ID '%s' using configured profile '%s'.", account_id, profile_name)
         common_job_parameters["AWS_ID"] = account_id
+        # if num_accounts == 1:
+        #     # Use the default boto3 session because boto3 gets confused if you give it a profile name with 1 account
+        #     boto3_session = boto3.Session()
+        # else:
         boto3_session = boto3.Session(profile_name=profile_name)
 
         _autodiscover_accounts(neo4j_session, boto3_session, account_id, sync_tag, common_job_parameters)
@@ -215,6 +221,8 @@ def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         aws_accounts = organizations.get_aws_accounts_from_botocore_config(boto3_session)
     else:
         aws_accounts = organizations.get_aws_account_default(boto3_session)
+
+    logger.info(aws_accounts)
 
     if not aws_accounts:
         logger.warning(


### PR DESCRIPTION
Bandaid fix for #1042: specifies `profile_name` when creating a boto3 session only if we are syncing more than one AWS account. This ensures that boto3 is able to properly find credentials.