### PR TITLE
Add test helpers check_nodes() and check_rels()

### DIFF
--- a/tests/integration/cartography/intel/aws/test_emr.py
+++ b/tests/integration/cartography/intel/aws/test_emr.py
@@ -58,5 +58,4 @@ def test_load_emr_clusters_relationships(neo4j_session):
         'EMRCluster',
         'arn',
         'RESOURCE',
-        rel_direction_left=False,
     ) == expected

--- a/tests/integration/test_util.py
+++ b/tests/integration/test_util.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
@@ -25,6 +27,7 @@ def test_check_rels(neo4j_session):
 
 
 def test_check_nodes(neo4j_session):
+    # Arrange
     neo4j_session.run(
         """
         MERGE (w:WorldAsset{id: "the-worldasset-id-1"})
@@ -34,15 +37,18 @@ def test_check_nodes(neo4j_session):
         """,
     )
 
+    # Act and assert
     expected = {
         ('the-worldasset-id-1', 1),
         ('the-worldasset-id-2', 1),
     }
-
     assert check_nodes(
         neo4j_session,
         'WorldAsset',
         ['id', 'lastupdated'],
     ) == expected
 
-    assert check_nodes(neo4j_session, 'WorldAsset', []) is None
+
+def test_check_nodes_empty_list_raises_exc(neo4j_session):
+    with pytest.raises(ValueError):
+        check_nodes(neo4j_session, 'WorldAsset', [])

--- a/tests/integration/test_util.py
+++ b/tests/integration/test_util.py
@@ -21,7 +21,7 @@ def test_check_rels(neo4j_session):
         ('Homer', 'Lisa'),
         ('Homer', 'Bart'),
     }
-    assert check_rels(neo4j_session, 'Human', 'id', 'Human', 'id', 'PARENT') == expected
+    assert check_rels(neo4j_session, 'Human', 'id', 'Human', 'id', 'PARENT', False) == expected
 
 
 def test_check_nodes(neo4j_session):

--- a/tests/integration/test_util.py
+++ b/tests/integration/test_util.py
@@ -1,0 +1,47 @@
+from tests.integration.util import check_rels, check_nodes
+
+
+def test_check_rels(neo4j_session):
+    # Arrange
+    neo4j_session.run(
+        """
+        MERGE (homer:Human{id: "Homer"})
+
+        MERGE (bart:Human{id: "Bart"})
+        MERGE (homer)<-[:PARENT]-(bart)
+
+        MERGE (lisa:Human{id: "Lisa"})
+        MERGE (homer)<-[:PARENT]-(lisa)
+        """
+    )
+
+    # Act and assert
+    expected = {
+        ('Homer', 'Lisa'),
+        ('Homer', 'Bart'),
+    }
+    assert check_rels(neo4j_session, 'Human', 'id', 'Human', 'id', 'PARENT') == expected
+
+
+def test_check_nodes(neo4j_session):
+    neo4j_session.run(
+        """
+        MERGE (w:WorldAsset{id: "the-worldasset-id-1"})
+        ON CREATE SET w.lastupdated = 1
+        MERGE (w2:WorldAsset{id: "the-worldasset-id-2"})
+        ON CREATE SET w2.lastupdated = 1
+        """
+    )
+
+    expected = {
+        ('the-worldasset-id-1', 1),
+        ('the-worldasset-id-2', 1),
+    }
+
+    assert check_nodes(
+        neo4j_session,
+        'WorldAsset',
+        ['id', 'lastupdated'],
+    ) == expected
+
+    assert check_nodes(neo4j_session, 'WorldAsset', []) is None

--- a/tests/integration/test_util.py
+++ b/tests/integration/test_util.py
@@ -1,4 +1,5 @@
-from tests.integration.util import check_rels, check_nodes
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
 
 
 def test_check_rels(neo4j_session):
@@ -12,7 +13,7 @@ def test_check_rels(neo4j_session):
 
         MERGE (lisa:Human{id: "Lisa"})
         MERGE (homer)<-[:PARENT]-(lisa)
-        """
+        """,
     )
 
     # Act and assert
@@ -30,7 +31,7 @@ def test_check_nodes(neo4j_session):
         ON CREATE SET w.lastupdated = 1
         MERGE (w2:WorldAsset{id: "the-worldasset-id-2"})
         ON CREATE SET w2.lastupdated = 1
-        """
+        """,
     )
 
     expected = {

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -15,7 +15,8 @@ def check_nodes(neo4j_session: neo4j.Session, node_label: str, attrs: List[str])
     tuples.
     """
     if not attrs:
-        return None
+        raise ValueError("`attrs` passed to check_nodes() must have at least one element.")
+
     attrs = ", ".join(f"n.{attr}" for attr in attrs)
     query_template = Template("MATCH (n:$NodeLabel) RETURN $Attrs")
     result = neo4j_session.run(

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,5 +1,8 @@
 from string import Template
-from typing import Set, Optional, List, Any
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import Set
 from typing import Tuple
 
 import neo4j
@@ -16,7 +19,7 @@ def check_nodes(neo4j_session: neo4j.Session, node_label: str, attrs: List[str])
     attrs = ", ".join(f"n.{attr}" for attr in attrs)
     query_template = Template("MATCH (n:$NodeLabel) RETURN $Attrs")
     result = neo4j_session.run(
-        query_template.safe_substitute(NodeLabel=node_label, Attrs=attrs)
+        query_template.safe_substitute(NodeLabel=node_label, Attrs=attrs),
     )
     return {tuple(row.values()) for row in result}
 

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,0 +1,57 @@
+from string import Template
+from typing import Set, Optional, List, Any
+from typing import Tuple
+
+import neo4j
+
+
+def check_nodes(neo4j_session: neo4j.Session, node_label: str, attrs: List[str]) -> Optional[Set[Tuple[Any, ...]]]:
+    """
+    Helper function for checking nodes in cartography integration tests.
+    Returns the result of a neo4j match query on the given node label and the given list of attributes as a set of
+    tuples.
+    """
+    if not attrs:
+        return None
+    attrs = ", ".join(f"n.{attr}" for attr in attrs)
+    query_template = Template("MATCH (n:$NodeLabel) RETURN $Attrs")
+    result = neo4j_session.run(
+        query_template.safe_substitute(NodeLabel=node_label, Attrs=attrs)
+    )
+    return {tuple(row.values()) for row in result}
+
+
+def check_rels(
+        neo4j_session: neo4j.Session,
+        node_1_label: str,
+        node_1_attr: str,
+        node_2_label: str,
+        node_2_attr: str,
+        rel_label: str,
+        rel_direction_left: Optional[bool] = True,
+) -> Set[Tuple]:
+    """
+    Helper function to test a given relationship between node 1 and node 2.
+    Returns the result of a neo4j match query as a set of tuples when given the node labels of 2 nodes, an attribute to
+    return from each of them, the label of the relationship between them, and the direction of that relationship.
+    :param neo4j_session: The neo4j session
+    :param node_1_label: The label of the first node to check
+    :param node_1_attr: The attribute of the first node to check
+    :param node_2_label: The label of the second node to check
+    :param node_2_attr: The attribute of the second node to check
+    :param rel_label: The str label of the relationship between node 1 and node 2.
+    :param rel_direction_left: The direction of the node is to the left (default=True). Else it is to the right.
+    :return: A set of tuples with the shape {(n1.node_1_attr, n2.node_2_attr), ...}
+    """
+    relationship = f"<-[r:{rel_label}]-" if rel_direction_left else f"-[r:{rel_label}]->"
+
+    query_template = Template('MATCH (n1:$Node1Label)$Rel(n2:$Node2Label) RETURN n1.$Node1Attr, n2.$Node2Attr;')
+    query = query_template.safe_substitute(
+        Node1Label=node_1_label,
+        Rel=relationship,
+        Node2Label=node_2_label,
+        Node1Attr=node_1_attr,
+        Node2Attr=node_2_attr,
+    )
+    result = neo4j_session.run(query)
+    return {(r[f'n1.{node_1_attr}'], r[f'n2.{node_2_attr}']) for r in result}

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -31,7 +31,7 @@ def check_rels(
         node_2_label: str,
         node_2_attr: str,
         rel_label: str,
-        rel_direction_left: Optional[bool] = True,
+        rel_direction_right: Optional[bool] = True,
 ) -> Set[Tuple]:
     """
     Helper function to test a given relationship between node 1 and node 2.
@@ -43,10 +43,10 @@ def check_rels(
     :param node_2_label: The label of the second node to check
     :param node_2_attr: The attribute of the second node to check
     :param rel_label: The str label of the relationship between node 1 and node 2.
-    :param rel_direction_left: The direction of the node is to the left (default=True). Else it is to the right.
+    :param rel_direction_right: The direction of the node is to the right (default=True). Else it is to the left.
     :return: A set of tuples with the shape {(n1.node_1_attr, n2.node_2_attr), ...}
     """
-    relationship = f"<-[r:{rel_label}]-" if rel_direction_left else f"-[r:{rel_label}]->"
+    relationship = f"-[r:{rel_label}]->" if rel_direction_right else f"<-[r:{rel_label}]-"
 
     query_template = Template('MATCH (n1:$Node1Label)$Rel(n2:$Node2Label) RETURN n1.$Node1Attr, n2.$Node2Attr;')
     query = query_template.safe_substitute(

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -1,4 +1,3 @@
-from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -8,7 +7,6 @@ import pytest
 from cartography import util
 from cartography.util import aws_handle_regions
 from cartography.util import batch
-from tests.integration.util import check_nodes
 
 
 def test_run_analysis_job_default_package(mocker):
@@ -94,9 +92,3 @@ def test_batch(mocker):
     assert actual == expected
     # Also check for empty input
     assert batch([], 3) == []
-
-
-def test_check_nodes_empty_list_raises_exc():
-    neo4j_session = MagicMock()
-    with pytest.raises(ValueError):
-        check_nodes(neo4j_session, 'NodeLabel', [])

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -7,6 +8,7 @@ import pytest
 from cartography import util
 from cartography.util import aws_handle_regions
 from cartography.util import batch
+from tests.integration.util import check_nodes
 
 
 def test_run_analysis_job_default_package(mocker):
@@ -92,3 +94,9 @@ def test_batch(mocker):
     assert actual == expected
     # Also check for empty input
     assert batch([], 3) == []
+
+
+def test_check_nodes_empty_list_raises_exc():
+    neo4j_session = MagicMock()
+    with pytest.raises(ValueError):
+        check_nodes(neo4j_session, 'NodeLabel', [])


### PR DESCRIPTION
This helps make writing repetitive tests a bit less annoying: the module author no longer needs to remember how to manipulate or index into a neo4j.Result object to check if their expected rels and nodes are connected properly.

## Examples

### Nodes
Before:
```python
nodes = neo4j_session.run(
    """
    MATCH (r:EMRCluster) RETURN r.arn;
    """,
)
actual_nodes = {n['r.arn'] for n in nodes}

assert actual_nodes == expected_nodes
```

After:
```python
assert check_nodes(neo4j_session, 'EMRCluster', ['arn']) == expected_nodes
```
-------

### Relationships

Before:
```python
# Fetch relationships
result = neo4j_session.run(
    """
    MATCH (n1:AWSAccount)-[:RESOURCE]->(n2:EMRCluster) RETURN n1.id, n2.arn;
    """,
)
actual = {
    (r['n1.id'], r['n2.arn']) for r in result
}

assert actual == expected
```

After:
```python
assert check_rels(
    neo4j_session,
    'AWSAccount',
    'id',
    'EMRCluster',
    'arn',
    'RESOURCE',
    rel_direction_right=True,
) == expected
```
