### PR TITLE
feat: add oauth support to gsuite

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -417,7 +417,7 @@ class CLI:
             type=str,
             default='GSUITE_GOOGLE_APPLICATION_CREDENTIALS',
             help=(
-                'The method used by GSuite to authenticate. delegated is the legacy one.'
+                'The name of environment variable containing secrets for GSuite authentication.'
             ),
         )
         return parser

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -403,6 +403,23 @@ class CLI:
                 'The crowdstrike URL, if using self-hosted. Defaults to the public crowdstrike API URL otherwise.'
             ),
         )
+        parser.add_argument(
+            '--gsuite-auth-method',
+            type=str,
+            default='delegated',
+            choices=['delegated', 'oauth'],
+            help=(
+                'The method used by GSuite to authenticate. delegated is the legacy one.'
+            ),
+        )
+        parser.add_argument(
+            '--gsuite-tokens-env-var',
+            type=str,
+            default='GSUITE_GOOGLE_APPLICATION_CREDENTIALS',
+            help=(
+                'The method used by GSuite to authenticate. delegated is the legacy one.'
+            ),
+        )
         return parser
 
     def main(self, argv: str) -> int:

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -549,6 +549,13 @@ class CLI:
         else:
             config.crowdstrike_client_secret = None
 
+        # GSuite config
+        if config.gsuite_tokens_env_var:
+            logger.debug(f"Reading config string for GSuite from environment variable {config.gsuite_tokens_env_var}")
+            config.gsuite_config = os.environ.get(config.gsuite_tokens_env_var)
+        else:
+            config.github_config = None
+
         # Run cartography
         try:
             return cartography.sync.run_with_config(self.sync, config)

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -81,6 +81,10 @@ class Config:
     :param pagerduty_request_timeout: Seconds to timeout for pagerduty session requests. Optional
     :type: nist_cve_url: str
     :param nist_cve_url: NIST CVE data provider base URI, e.g. https://nvd.nist.gov/feeds/json/cve/1.1. Optional.
+    :type: gsuite_auth_method: str
+    :param gsuite_auth_method: Auth method (delegated, oauth) used for Google Workspace. Optional.
+    :type gsuite_config: str
+    :param gsuite_config: Base64 encoded config object or config file path for Google Workspace. Optional.
     """
 
     def __init__(
@@ -124,6 +128,8 @@ class Config:
         crowdstrike_client_id=None,
         crowdstrike_client_secret=None,
         crowdstrike_api_url=None,
+        gsuite_auth_method=None,
+        gsuite_config=None,
     ):
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user
@@ -164,3 +170,5 @@ class Config:
         self.crowdstrike_client_id = crowdstrike_client_id
         self.crowdstrike_client_secret = crowdstrike_client_secret
         self.crowdstrike_api_url = crowdstrike_api_url
+        self.gsuite_auth_method = gsuite_auth_method
+        self.gsuite_config = gsuite_config

--- a/cartography/intel/gsuite/__init__.py
+++ b/cartography/intel/gsuite/__init__.py
@@ -1,6 +1,9 @@
 import logging
 import os
 from collections import namedtuple
+import json
+import base64
+import httplib2
 
 import googleapiclient.discovery
 import neo4j
@@ -11,10 +14,6 @@ from oauth2client.client import GoogleCredentials
 from cartography.config import Config
 from cartography.intel.gsuite import api
 from cartography.util import timeit
-
-# GSuite Delegated admin e-mail https://developers.google.com/admin-sdk/directory/v1/guides/delegation
-GSUITE_DELEGATED_ADMIN = os.environ.get('GSUITE_DELEGATED_ADMIN')
-GSUITE_CREDS = os.environ.get('GSUITE_GOOGLE_APPLICATION_CREDENTIALS')
 
 OAUTH_SCOPE = [
     'https://www.googleapis.com/auth/admin.directory.user.readonly',
@@ -62,23 +61,43 @@ def start_gsuite_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         "UPDATE_TAG": config.update_tag,
     }
 
-    try:
-        credentials = GoogleCredentials.from_stream(GSUITE_CREDS)
-        credentials = credentials.create_scoped(OAUTH_SCOPE)
-        credentials = credentials.create_delegated(GSUITE_DELEGATED_ADMIN)
+    # Legacy delegated method
+    if config.gsuite_auth_method == 'delegated':
+        try:
+            credentials = GoogleCredentials.from_stream(os.environ.get(config.gsuite_tokens_env_var))
+            credentials = credentials.create_scoped(OAUTH_SCOPE)
+            credentials = credentials.create_delegated(os.environ.get('GSUITE_DELEGATED_ADMIN'))
 
-    except ApplicationDefaultCredentialsError as e:
-        logger.debug('Error occurred calling GoogleCredentials.get_application_default().', exc_info=True)
-        logger.error(
-            (
-                "Unable to initialize GSuite creds. If you don't have GSuite data or don't want to load "
-                'Gsuite data then you can ignore this message. Otherwise, the error code is: %s '
-                'Make sure your GSuite credentials are configured correctly, your credentials file (if any) is valid. '
-                'For more details see README'
-            ),
-            e,
-        )
-        return
+        except ApplicationDefaultCredentialsError as e:
+            logger.debug('Error occurred calling GoogleCredentials.get_application_default().', exc_info=True)
+            logger.error(
+                (
+                    "Unable to initialize GSuite creds. If you don't have GSuite data or don't want to load "
+                    'Gsuite data then you can ignore this message. Otherwise, the error code is: %s '
+                    'Make sure your GSuite credentials are configured correctly, your credentials file (if any) is valid. '
+                    'For more details see README'
+                ),
+                e,
+            )
+            return
+    elif config.gsuite_auth_method == 'oauth':
+        auth_tokens = json.loads(base64.b64decode(os.environ.get(config.gsuite_tokens_env_var)).decode())
+        logger.info('SO GOOD SO FAR')
+        try:
+            credentials = GoogleCredentials(None, auth_tokens['client_id'], auth_tokens['client_secret'], auth_tokens['refresh_token'], None, auth_tokens['token_uri'], 'Cartography')
+            credentials.refresh(httplib2.Http())
+            credentials = credentials.create_scoped(OAUTH_SCOPE)
+        except ApplicationDefaultCredentialsError as e:
+            logger.debug('Error occurred calling GoogleCredentials.get_application_default().', exc_info=True)
+            logger.error(
+                (
+                    "Unable to initialize GSuite creds. If you don't have GSuite data or don't want to load "
+                    'Gsuite data then you can ignore this message. Otherwise, the error code is: %s '
+                    'Make sure your GSuite credentials are configured correctly, your credentials are valid. '
+                    'For more details see README'
+                ),
+                e,
+            )
 
     resources = _initialize_resources(credentials)
     api.sync_gsuite_users(neo4j_session, resources.admin, config.update_tag, common_job_parameters)

--- a/cartography/intel/gsuite/api.py
+++ b/cartography/intel/gsuite/api.py
@@ -131,8 +131,7 @@ def load_gsuite_groups(neo4j_session: neo4j.Session, groups: List[Dict], gsuite_
         MERGE (g:GSuiteGroup{id: group.id})
         ON CREATE SET
         g.firstseen = $UpdateTag
-        ON MATCH SET
-        g.group_id = group.id,
+        SET g.group_id = group.id,
         g.admin_created = group.adminCreated,
         g.description = group.description,
         g.direct_members_count = group.directMembersCount,
@@ -153,8 +152,7 @@ def load_gsuite_users(neo4j_session: neo4j.Session, users: List[Dict], gsuite_up
         MERGE (u:GSuiteUser{id: user.id})
         ON CREATE SET
         u.firstseen = $UpdateTag
-        ON MATCH SET
-        u.user_id = user.id,
+        SET u.user_id = user.id,
         u.agreed_to_terms = user.agreedToTerms,
         u.archived = user.archived,
         u.change_password_at_next_login = user.changePasswordAtNextLogin,

--- a/cartography/intel/gsuite/api.py
+++ b/cartography/intel/gsuite/api.py
@@ -131,7 +131,7 @@ def load_gsuite_groups(neo4j_session: neo4j.Session, groups: List[Dict], gsuite_
         MERGE (g:GSuiteGroup{id: group.id})
         ON CREATE SET
         g.firstseen = $UpdateTag
-        ON MATCH SET 
+        ON MATCH SET
         g.group_id = group.id,
         g.admin_created = group.adminCreated,
         g.description = group.description,

--- a/cartography/intel/gsuite/api.py
+++ b/cartography/intel/gsuite/api.py
@@ -131,7 +131,8 @@ def load_gsuite_groups(neo4j_session: neo4j.Session, groups: List[Dict], gsuite_
         MERGE (g:GSuiteGroup{id: group.id})
         ON CREATE SET
         g.firstseen = $UpdateTag
-        SET g.group_id = group.id,
+        ON MATCH SET 
+        g.group_id = group.id,
         g.admin_created = group.adminCreated,
         g.description = group.description,
         g.direct_members_count = group.directMembersCount,
@@ -152,7 +153,8 @@ def load_gsuite_users(neo4j_session: neo4j.Session, users: List[Dict], gsuite_up
         MERGE (u:GSuiteUser{id: user.id})
         ON CREATE SET
         u.firstseen = $UpdateTag
-        SET u.user_id = user.id,
+        ON MATCH SET
+        u.user_id = user.id,
         u.agreed_to_terms = user.agreedToTerms,
         u.archived = user.archived,
         u.change_password_at_next_login = user.changePasswordAtNextLogin,

--- a/docs/root/modules/gsuite/config.md
+++ b/docs/root/modules/gsuite/config.md
@@ -5,7 +5,7 @@
 This module allows authentication from a service account or via oauth tokens.
 
 1. Using service account (legacy)
-    
+
     Ingesting GSuite Users and Groups utilizes the [Google Admin SDK](https://developers.google.com/admin-sdk/).
 
     1. [Enable Google API access](https://support.google.com/a/answer/60757?hl=en)

--- a/docs/root/modules/gsuite/config.md
+++ b/docs/root/modules/gsuite/config.md
@@ -16,7 +16,7 @@ This module allows authentication from a service account or via oauth tokens.
         1. `GSUITE_GOOGLE_APPLICATION_CREDENTIALS` - location of the credentials file.
         1. `GSUITE_DELEGATED_ADMIN` - email address that you created in step 2
 
-1. Using Oauth
+## Method 2: Using OAuth
 
     1. Create an App on [Google Cloud Console](https://console.cloud.google.com/)
     1. Refer to follow documentation if needed:

--- a/docs/root/modules/gsuite/config.md
+++ b/docs/root/modules/gsuite/config.md
@@ -2,7 +2,7 @@
 
 .. _gsuite_config:
 
-This module allows authentication from a service account or via oauth tokens.
+This module allows authentication from a service account or via OAuth tokens.
 
 1. Using service account (legacy)
 

--- a/docs/root/modules/gsuite/config.md
+++ b/docs/root/modules/gsuite/config.md
@@ -2,10 +2,10 @@
 
 .. _gsuite_config:
 
-Follow these steps to analyze GSuite users and groups with Cartography.
+This module allows authentication from a service account or via oauth tokens.
 
-1.  Prepare your GSuite Credential.
-
+1. Using service account (legacy)
+    
     Ingesting GSuite Users and Groups utilizes the [Google Admin SDK](https://developers.google.com/admin-sdk/).
 
     1. [Enable Google API access](https://support.google.com/a/answer/60757?hl=en)
@@ -15,3 +15,77 @@ Follow these steps to analyze GSuite users and groups with Cartography.
     1.  Export the environmental variables:
         1. `GSUITE_GOOGLE_APPLICATION_CREDENTIALS` - location of the credentials file.
         1. `GSUITE_DELEGATED_ADMIN` - email address that you created in step 2
+
+1. Using Oauth
+
+    1. Create an App on [Google Cloud Console](https://console.cloud.google.com/)
+    1. Refer to follow documentation if needed:
+        1. https://developers.google.com/admin-sdk/directory/v1/quickstart/python
+        1. https://developers.google.com/workspace/guides/get-started
+        1. https://support.google.com/a/answer/7281227?hl=fr
+    1. Download credentials file
+    1. Use helper script for OAuth flow to obtain refresh_token
+    1. Serialize needed secret
+        ```
+        import json
+        import base64
+        auth_json = json.dumps({"client_id":"xxxxx.apps.googleusercontent.com","client_secret":"ChangeMe", "refresh_token":"ChangeMe", "token_uri": "https://oauth2.googleapis.com/token"})
+        base64.b64encode(auth_json.encode())
+        ```
+    1. Populate an environment variable of your choice with the contents of the base64 output from the previous step.
+    1. Call the `cartography` CLI with `--gsuite-tokens-env-var YOUR_ENV_VAR_HERE` and `--gsuite-auth-method oauth`.
+
+
+
+
+Google Oauth Helper :
+```json
+from __future__ import print_function
+import json
+
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+
+scopes = ["https://www.googleapis.com/auth/admin.directory.userreadonly", "https://www.googleapis.com/auth/admin.directory.group.readonly", "https://www.googleapis.com/auth/admin.directory.group.member"]
+
+print('Go to https://console.cloud.google.com/ > API & Services > Credentials and download secrets')
+project_id = input('Provide your project ID:')
+client_id = input('Provide you Client ID:')
+client_secret = input('Provide you Client Secret:')
+with open('credentials.json', 'w', encoding='utf-8') as fc:
+    data = {
+        "installed": {
+            "client_id": client_id,
+            "project_id": project_id,
+            "auth_uri":"https://accounts.google.com/o/oauth2/auth",
+            "token_uri":"https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs",
+            "client_secret":"client_secret",
+            "redirect_uris":["http://localhost"]
+        }}
+    json.dump(data, fc)
+flow = InstalledAppFlow.from_client_secrets_file(
+    'credentials.json', scopes)
+flow.redirect_uri = 'http://localhost'
+auth_url, _ = flow.authorization_url(prompt='consent')
+print(f'Please go to this URL: {auth_url}')
+code = input('Enter the authorization code: ')
+flow.fetch_token(code=code)
+creds = flow.credentials
+print('Testing your credentials by gettings first 10 users in the domain ...')
+service = build('admin', 'directory_v1', credentials=creds)
+print('Getting the first 10 users in the domain')
+results = service.users().list(customer='my_customer', maxResults=10,
+                                orderBy='email').execute()
+users = results.get('users', [])
+if not users:
+    print('No users in the domain.')
+else:
+    print('Users:')
+    for user in users:
+        print(u'{0} ({1})'.format(user['primaryEmail'],
+                                    user['name']['fullName']))
+print('Your credentials:')
+print(json.dumps(creds.to_json(), indent=2))
+```

--- a/docs/root/modules/gsuite/config.md
+++ b/docs/root/modules/gsuite/config.md
@@ -39,7 +39,7 @@ This module allows authentication from a service account or via oauth tokens.
 
 
 Google Oauth Helper :
-```json
+```python
 from __future__ import print_function
 import json
 

--- a/docs/root/modules/gsuite/config.md
+++ b/docs/root/modules/gsuite/config.md
@@ -4,7 +4,7 @@
 
 This module allows authentication from a service account or via OAuth tokens.
 
-1. Using service account (legacy)
+Method 1: Using service account (legacy)
 
     Ingesting GSuite Users and Groups utilizes the [Google Admin SDK](https://developers.google.com/admin-sdk/).
 
@@ -24,9 +24,9 @@ This module allows authentication from a service account or via OAuth tokens.
         1. https://developers.google.com/workspace/guides/get-started
         1. https://support.google.com/a/answer/7281227?hl=fr
     1. Download credentials file
-    1. Use helper script for OAuth flow to obtain refresh_token
+    1. Use helper script below for OAuth flow to obtain refresh_token
     1. Serialize needed secret
-        ```
+        ```python
         import json
         import base64
         auth_json = json.dumps({"client_id":"xxxxx.apps.googleusercontent.com","client_secret":"ChangeMe", "refresh_token":"ChangeMe", "token_uri": "https://oauth2.googleapis.com/token"})
@@ -51,8 +51,8 @@ scopes = ["https://www.googleapis.com/auth/admin.directory.userreadonly", "https
 
 print('Go to https://console.cloud.google.com/ > API & Services > Credentials and download secrets')
 project_id = input('Provide your project ID:')
-client_id = input('Provide you Client ID:')
-client_secret = input('Provide you Client Secret:')
+client_id = input('Provide your client ID:')
+client_secret = input('Provide your client secret:')
 with open('credentials.json', 'w', encoding='utf-8') as fc:
     data = {
         "installed": {

--- a/docs/root/modules/gsuite/config.md
+++ b/docs/root/modules/gsuite/config.md
@@ -6,34 +6,34 @@ This module allows authentication from a service account or via OAuth tokens.
 
 Method 1: Using service account (legacy)
 
-    Ingesting GSuite Users and Groups utilizes the [Google Admin SDK](https://developers.google.com/admin-sdk/).
+Ingesting GSuite Users and Groups utilizes the [Google Admin SDK](https://developers.google.com/admin-sdk/).
 
-    1. [Enable Google API access](https://support.google.com/a/answer/60757?hl=en)
-    1. Create a new G Suite user account and accept the Terms of Service. This account will be used as the domain-wide delegated access.
-    1. [Perform G Suite Domain-Wide Delegation of Authority](https://developers.google.com/admin-sdk/directory/v1/guides/delegation)
-    1.  Download the service account's credentials
-    1.  Export the environmental variables:
-        1. `GSUITE_GOOGLE_APPLICATION_CREDENTIALS` - location of the credentials file.
-        1. `GSUITE_DELEGATED_ADMIN` - email address that you created in step 2
+1. [Enable Google API access](https://support.google.com/a/answer/60757?hl=en)
+1. Create a new G Suite user account and accept the Terms of Service. This account will be used as the domain-wide delegated access.
+1. [Perform G Suite Domain-Wide Delegation of Authority](https://developers.google.com/admin-sdk/directory/v1/guides/delegation)
+1.  Download the service account's credentials
+1.  Export the environmental variables:
+    1. `GSUITE_GOOGLE_APPLICATION_CREDENTIALS` - location of the credentials file.
+    1. `GSUITE_DELEGATED_ADMIN` - email address that you created in step 2
 
 ## Method 2: Using OAuth
 
-    1. Create an App on [Google Cloud Console](https://console.cloud.google.com/)
-    1. Refer to follow documentation if needed:
-        1. https://developers.google.com/admin-sdk/directory/v1/quickstart/python
-        1. https://developers.google.com/workspace/guides/get-started
-        1. https://support.google.com/a/answer/7281227?hl=fr
-    1. Download credentials file
-    1. Use helper script below for OAuth flow to obtain refresh_token
-    1. Serialize needed secret
-        ```python
-        import json
-        import base64
-        auth_json = json.dumps({"client_id":"xxxxx.apps.googleusercontent.com","client_secret":"ChangeMe", "refresh_token":"ChangeMe", "token_uri": "https://oauth2.googleapis.com/token"})
-        base64.b64encode(auth_json.encode())
-        ```
-    1. Populate an environment variable of your choice with the contents of the base64 output from the previous step.
-    1. Call the `cartography` CLI with `--gsuite-tokens-env-var YOUR_ENV_VAR_HERE` and `--gsuite-auth-method oauth`.
+1. Create an App on [Google Cloud Console](https://console.cloud.google.com/)
+1. Refer to follow documentation if needed:
+    1. https://developers.google.com/admin-sdk/directory/v1/quickstart/python
+    1. https://developers.google.com/workspace/guides/get-started
+    1. https://support.google.com/a/answer/7281227?hl=fr
+1. Download credentials file
+1. Use helper script below for OAuth flow to obtain refresh_token
+1. Serialize needed secret
+    ```python
+    import json
+    import base64
+    auth_json = json.dumps({"client_id":"xxxxx.apps.googleusercontent.com","client_secret":"ChangeMe", "refresh_token":"ChangeMe", "token_uri": "https://oauth2.googleapis.com/token"})
+    base64.b64encode(auth_json.encode())
+    ```
+1. Populate an environment variable of your choice with the contents of the base64 output from the previous step.
+1. Call the `cartography` CLI with `--gsuite-tokens-env-var YOUR_ENV_VAR_HERE` and `--gsuite-auth-method oauth`.
 
 
 
@@ -42,6 +42,7 @@ Google Oauth Helper :
 ```python
 from __future__ import print_function
 import json
+import os
 
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
@@ -88,4 +89,5 @@ else:
                                     user['name']['fullName']))
 print('Your credentials:')
 print(json.dumps(creds.to_json(), indent=2))
+os.remove('credentials.json')
 ```


### PR DESCRIPTION
Allow gsuite to use oauth credentials.

Legacy method is used by default for backward compatibility.