### PR TITLE
Populate AWS Tags for IAM roles

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -162,8 +162,9 @@ def get_role_managed_policy_data(boto3_session: boto3.session.Session, role_list
             )
     return policies
 
+
 @timeit
-def get_role_tag_data(boto3_session: boto3.session.Session) -> List[Dict]:
+def get_role_tags(boto3_session: boto3.session.Session) -> List[Dict]:
     role_list = get_role_list_data(boto3_session)
     resource_client = boto3_session.resource('iam')
     role_tag_data: List[Dict] = []
@@ -182,6 +183,7 @@ def get_role_tag_data(boto3_session: boto3.session.Session) -> List[Dict]:
         role_tag_data.append(tag_data)
 
     return role_tag_data
+
 
 @timeit
 def get_user_list_data(boto3_session: boto3.session.Session) -> Dict:

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -162,6 +162,26 @@ def get_role_managed_policy_data(boto3_session: boto3.session.Session, role_list
             )
     return policies
 
+@timeit
+def get_role_tag_data(boto3_session: boto3.session.Session) -> List[Dict]:
+    role_list = get_role_list_data(boto3_session)
+    resource_client = boto3_session.resource('iam')
+    role_tag_data: List[Dict] = []
+    for role in role_list:
+        name = role["RoleName"]
+        role_arn = role["Arn"]
+        resource_role = resource_client.Role(name)
+        role_tags = resource_role.tags
+        if not role_tags:
+            continue
+
+        tag_data = {
+            'ResourceARN': role_arn,
+            'Tags': resource_role.tags,
+        }
+        role_tag_data.append(tag_data)
+
+    return role_tag_data
 
 @timeit
 def get_user_list_data(boto3_session: boto3.session.Session) -> Dict:

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -6,6 +6,7 @@ from typing import List
 import boto3
 import neo4j
 
+from cartography.intel.aws.iam import get_iam_role_tags
 from cartography.util import aws_handle_regions
 from cartography.util import batch
 from cartography.util import run_cleanup_job
@@ -117,17 +118,24 @@ TAG_RESOURCE_TYPE_MAPPINGS: Dict = {
 
 @timeit
 @aws_handle_regions
-def get_tags(boto3_session: boto3.session.Session, resource_types: List[str], region: str) -> List[Dict]:
+def get_tags(boto3_session: boto3.session.Session, resource_type: str, region: str) -> List[Dict]:
     """
     Create boto3 client and retrieve tag data.
     """
+    # this is a temporary workaround to populate AWS tags for IAM roles.
+    # resourcegroupstaggingapi does not support IAM roles and no ETA is provided
+    # TODO: when AWS supports iam:role in resourcegroupstaggingapi, remove the following line
+    #  and add 'iam:role' to TAG_RESOURCE_TYPE_MAPPINGS in resourcegroupstaggingapi.py
+    if resource_type == 'iam:role':
+        return get_iam_role_tags(boto3_session)
+    
     client = boto3_session.client('resourcegroupstaggingapi', region_name=region)
     paginator = client.get_paginator('get_resources')
     resources: List[Dict] = []
     for page in paginator.paginate(
         # Only ingest tags for resources that Cartography supports.
         # This is just a starting list; there may be others supported by this API.
-        ResourceTypeFilters=resource_types,
+        ResourceTypeFilters=[resource_type],
     ):
         resources.extend(page['ResourceTagMappingList'])
     return resources
@@ -224,7 +232,7 @@ def sync(
     for region in regions:
         logger.info(f"Syncing AWS tags for account {current_aws_account_id} and region {region}")
         for resource_type in tag_resource_type_mappings.keys():
-            tag_data = get_tags(boto3_session, [resource_type], region)
+            tag_data = get_tags(boto3_session, resource_type, region)
             transform_tags(tag_data, resource_type)  # type: ignore
             logger.info(f"Loading {len(tag_data)} tags for resource type {resource_type}")
             load_tags(

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -6,7 +6,7 @@ from typing import List
 import boto3
 import neo4j
 
-from cartography.intel.aws.iam import get_iam_role_tags
+from cartography.intel.aws.iam import get_role_tags
 from cartography.util import aws_handle_regions
 from cartography.util import batch
 from cartography.util import run_cleanup_job
@@ -124,11 +124,10 @@ def get_tags(boto3_session: boto3.session.Session, resource_type: str, region: s
     """
     # this is a temporary workaround to populate AWS tags for IAM roles.
     # resourcegroupstaggingapi does not support IAM roles and no ETA is provided
-    # TODO: when AWS supports iam:role in resourcegroupstaggingapi, remove the following line
-    #  and add 'iam:role' to TAG_RESOURCE_TYPE_MAPPINGS in resourcegroupstaggingapi.py
+    # TODO: when resourcegroupstaggingapi supports iam:role, remove this condition block
     if resource_type == 'iam:role':
-        return get_iam_role_tags(boto3_session)
-    
+        return get_role_tags(boto3_session)
+
     client = boto3_session.client('resourcegroupstaggingapi', region_name=region)
     paginator = client.get_paginator('get_resources')
     resources: List[Dict] = []

--- a/tests/unit/cartography/intel/aws/iam/test_iam.py
+++ b/tests/unit/cartography/intel/aws/iam/test_iam.py
@@ -1,3 +1,6 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
 from cartography.intel.aws import iam
 
 SINGLE_STATEMENT = {
@@ -35,3 +38,58 @@ def test__parse_principal_entries():
 def test_get_account_from_arn():
     result = iam.get_account_from_arn("arn:aws:iam::081157660428:role/TestRole")
     assert result == "081157660428"
+
+
+def test__get_role_tags_valid_tags(mocker):
+    mocker.patch(
+        'cartography.intel.aws.iam.get_role_list_data', return_value=[
+            {
+                'RoleName': 'test-role',
+                'Arn': 'test-arn',
+            },
+        ],
+    )
+    mocker.patch('boto3.session.Session')
+    mock_session = mocker.Mock()
+    mock_client = mocker.Mock()
+    mock_role = mocker.Mock()
+    mock_role.tags = [
+        {
+            'Key': 'k1', 'Value': 'v1',
+        },
+    ]
+    mock_client.Role.return_value = mock_role
+    mock_session.resource.return_value = mock_client
+    result = iam.get_role_tags(mock_session)
+
+    assert result == [{
+        'ResourceARN': 'test-arn',
+        'Tags': [
+            {
+                'Key': 'k1',
+                'Value': 'v1',
+            },
+        ],
+    }]
+
+
+def test__get_role_tags_no_tags(mocker):
+    mocker.patch(
+        'cartography.intel.aws.iam.get_role_list_data', return_value=[
+            {
+                'RoleName': 'test-role',
+                'Arn': 'test-arn',
+            },
+        ],
+    )
+    mocker.patch('boto3.session.Session')
+    mock_session = mocker.Mock()
+    mock_client = mocker.Mock()
+    mock_role = mocker.Mock()
+    mock_role.tags = [
+    ]
+    mock_client.Role.return_value = mock_role
+    mock_session.resource.return_value = mock_client
+    result = iam.get_role_tags(mock_session)
+
+    assert result == []

--- a/tests/unit/cartography/intel/aws/iam/test_iam.py
+++ b/tests/unit/cartography/intel/aws/iam/test_iam.py
@@ -1,6 +1,3 @@
-from unittest.mock import Mock
-from unittest.mock import patch
-
 from cartography.intel.aws import iam
 
 SINGLE_STATEMENT = {


### PR DESCRIPTION
Alternative approach: https://github.com/lyft/cartography/pull/1080

According to AWS support, resourcegroupstaggingapi does not work for IAM role yet and currently there's no ETA for it. This is a temporary workaround so that AWS tags can be populated for AWS roles via IAM client/resource instead of resourcegroupstaggingapi