### PR TITLE
Fix #1085: iam get_role_list data shape

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -165,7 +165,7 @@ def get_role_managed_policy_data(boto3_session: boto3.session.Session, role_list
 
 @timeit
 def get_role_tags(boto3_session: boto3.session.Session) -> List[Dict]:
-    role_list = get_role_list_data(boto3_session)
+    role_list = get_role_list_data(boto3_session)['Roles']
     resource_client = boto3_session.resource('iam')
     role_tag_data: List[Dict] = []
     for role in role_list:

--- a/tests/unit/cartography/intel/aws/iam/test_iam.py
+++ b/tests/unit/cartography/intel/aws/iam/test_iam.py
@@ -39,12 +39,14 @@ def test_get_account_from_arn():
 
 def test__get_role_tags_valid_tags(mocker):
     mocker.patch(
-        'cartography.intel.aws.iam.get_role_list_data', return_value=[
-            {
-                'RoleName': 'test-role',
-                'Arn': 'test-arn',
-            },
-        ],
+        'cartography.intel.aws.iam.get_role_list_data', return_value={
+            'Roles': [
+                {
+                    'RoleName': 'test-role',
+                    'Arn': 'test-arn',
+                },
+            ],
+        },
     )
     mocker.patch('boto3.session.Session')
     mock_session = mocker.Mock()
@@ -72,12 +74,14 @@ def test__get_role_tags_valid_tags(mocker):
 
 def test__get_role_tags_no_tags(mocker):
     mocker.patch(
-        'cartography.intel.aws.iam.get_role_list_data', return_value=[
-            {
-                'RoleName': 'test-role',
-                'Arn': 'test-arn',
-            },
-        ],
+        'cartography.intel.aws.iam.get_role_list_data', return_value={
+            'Roles': [
+                {
+                    'RoleName': 'test-role',
+                    'Arn': 'test-arn',
+                },
+            ],
+        },
     )
     mocker.patch('boto3.session.Session')
     mock_session = mocker.Mock()


### PR DESCRIPTION
fix for https://github.com/lyft/cartography/pull/1081, reported in https://github.com/lyft/cartography/issues/1085#issuecomment-1397309331

Root cause: get_role_list_data returns a dict {'Roles': roles} https://github.com/lyft/cartography/blob/master/cartography/intel/aws/iam.py#L216 previous code treated return as a list