### PR TITLE
Log warning when exc is encountered in aws-best-effort-mode

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -179,6 +179,12 @@ def _sync_multiple_accounts(
                 exception_traceback = traceback.TracebackException.from_exception(e)
                 traceback_string = ''.join(exception_traceback.format())
                 exception_tracebacks.append(f'{timestamp} - Exception for account ID: {account_id}\n{traceback_string}')
+                logger.warning(
+                    f"Caught exception syncing account {account_id}. aws-best-effort-mode is on so we are continuing "
+                    f"on to the next AWS account. All exceptions will be aggregated and re-logged at the end of the "
+                    f"sync.",
+                    exc_info=True,
+                )
                 continue
             else:
                 raise


### PR DESCRIPTION
Currently with --aws-best-effort-mode, exceptions raised during the AWS sync get caught by [this handler](https://github.com/lyft/cartography/blob/3ae3ad1f9740f3f69894f2d0514125f908bd5f8d/cartography/intel/aws/__init__.py#L175-L182), which just collects the traceback and allows the job to continue on, so we will not actually be able to view the full exception until the [very end](https://github.com/lyft/cartography/blob/3ae3ad1f9740f3f69894f2d0514125f908bd5f8d/cartography/intel/aws/__init__.py#L186-L188). This can make it confusing to use logs to trace what happened during a sync run.

This PR logs the exception as a warning and then continues on.