### PR TITLE
Fix #1098: replace elasticsearch hardcoded region list

### DIFF
--- a/cartography/intel/aws/elasticsearch.py
+++ b/cartography/intel/aws/elasticsearch.py
@@ -15,27 +15,6 @@ from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
-# TODO get this programmatically
-# https://docs.aws.amazon.com/general/latest/gr/rande.html#elasticsearch-service-regions
-es_regions = [
-    'us-east-2',
-    'us-east-1',
-    'us-west-1',
-    'us-west-2',
-    'ap-northeast-1',
-    'ap-northeast-2',
-    'ap-south-1',
-    'ap-southeast-1',
-    'ca-central-1',
-    # 'cn-northwest-1',  -- intentionally ignored. need specific token
-    'eu-central-1',
-    'eu-west-1',
-    'eu-west-2',
-    'eu-west-3',
-    'sa-east-1',
-    # 'us-gov-west-1', -- intentionally ignored, need specific token
-]
-
 
 # TODO memoize this
 def _get_botocore_config() -> botocore.config.Config:
@@ -233,7 +212,7 @@ def sync(
     neo4j_session: neo4j.Session, boto3_session: boto3.session.Session, regions: List[str], current_aws_account_id: str,
     update_tag: int, common_job_parameters: Dict,
 ) -> None:
-    for region in es_regions:
+    for region in regions:
         logger.info("Syncing Elasticsearch Service for region '%s' in account '%s'.", region, current_aws_account_id)
         client = boto3_session.client('es', region_name=region, config=_get_botocore_config())
         data = _get_es_domains(client)


### PR DESCRIPTION
Fixes https://github.com/lyft/cartography/issues/1098. 

The original elasticsearch sync used a hardcoded list of regions. This PR uses our dynamically auto-discovered ones instead.

There was a link to an AWS reference that no longer exists, so I'm assuming that the reason why we needed to have it hardcoded is no longer valid.