### PR TITLE
#1106: Test we can load data with subset of node schema fields

### DIFF
--- a/tests/data/graph/querybuilder/sample_data/simple_node_missing_fields.py
+++ b/tests/data/graph/querybuilder/sample_data/simple_node_missing_fields.py
@@ -5,11 +5,13 @@ SIMPLE_NODE_MISSING_PROPS = [
     },
     {
         'Id': 'SimpleNode2',
+        'property1': None,
         'property2': 'Quick',
     },
     {
         'Id': 'SimpleNode3',
         'property1': 'Brown',
+        'property2': None,
     },
     {
         'Id': 'SimpleNode4',

--- a/tests/data/graph/querybuilder/sample_data/simple_node_missing_fields.py
+++ b/tests/data/graph/querybuilder/sample_data/simple_node_missing_fields.py
@@ -1,0 +1,18 @@
+SIMPLE_NODE_MISSING_PROPS = [
+    {
+        'Id': 'SimpleNode1',
+        'property1': 'The',
+    },
+    {
+        'Id': 'SimpleNode2',
+        'property2': 'Quick',
+    },
+    {
+        'Id': 'SimpleNode3',
+        'property1': 'Brown',
+    },
+    {
+        'Id': 'SimpleNode4',
+        'property2': 'Fox',
+    },
+]

--- a/tests/integration/cartography/graph/test_querybuilder_missing_fields_in_data.py
+++ b/tests/integration/cartography/graph/test_querybuilder_missing_fields_in_data.py
@@ -6,7 +6,7 @@ from tests.integration.util import check_nodes
 
 def test_load_missing_fields_in_data(neo4j_session):
     # Act: load our sample data where some items only have `property1` defined and other items only have `property2`
-    # defined.
+    # defined. `SimpleNodeSchema` includes both `property1` and `property2`.
     load(neo4j_session, SimpleNodeSchema(), SIMPLE_NODE_MISSING_PROPS, lastupdated=1)
 
     # Assert that if we ingest a dict that has fewer fields than defined on the node schema, then the missing fields

--- a/tests/integration/cartography/graph/test_querybuilder_missing_fields_in_data.py
+++ b/tests/integration/cartography/graph/test_querybuilder_missing_fields_in_data.py
@@ -1,0 +1,19 @@
+from cartography.client.core.tx import load
+from tests.data.graph.querybuilder.sample_data.simple_node_missing_fields import SIMPLE_NODE_MISSING_PROPS
+from tests.data.graph.querybuilder.sample_models.simple_node import SimpleNodeSchema
+from tests.integration.util import check_nodes
+
+
+def test_load_missing_fields_in_data(neo4j_session):
+    # Act: load our sample data where some items only have `property1` defined and other items only have `property2`
+    # defined.
+    load(neo4j_session, SimpleNodeSchema(), SIMPLE_NODE_MISSING_PROPS, lastupdated=1)
+
+    # Assert that if we ingest a dict that has fewer fields than defined on the node schema, then the missing fields
+    # will be treated as None.
+    assert check_nodes(neo4j_session, 'SimpleNode', ['property1', 'property2']) == {
+        ('The', None),
+        (None, 'Quick'),
+        ('Brown', None),
+        (None, 'Fox'),
+    }


### PR DESCRIPTION
Follow-up of https://github.com/lyft/cartography/issues/1106#issuecomment-1420335812: 

This PR adds a formal test to validate this claim:

> The cartography data model also correctly handles the case where we try to ingest data that has only a subset of the fields defined on its schema.

Put another way, we test that if a node schema has more fields defined than the dict being loaded, then we correctly treat those missing fields as None.