### PR TITLE
Allow user to specify which sync modules to run from CLI

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -3,13 +3,13 @@ import getpass
 import logging
 import os
 import sys
-from typing import Optional, List
+from typing import Optional
 
 import cartography.config
 import cartography.sync
 import cartography.util
 from cartography.intel.aws.util.common import parse_and_validate_aws_requested_syncs
-from cartography.sync import parse_and_validate_selected_modules
+
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +121,7 @@ class CLI:
                 'If not specified, cartography by default will run all modules available and log warnings when it '
                 'does not find credentials configured for them. '
                 # TODO remove this mention about the create-indexes module when everything is using auto-indexes.
-                'We recommend that you always specify the `create-indexes` module first in this list. ' 
+                'We recommend that you always specify the `create-indexes` module first in this list. '
                 'If you specify the `analysis` module, we recommend that you include it as the LAST item of this list, '
                 '(because it does not make sense to perform analysis on an empty/out-of-date graph).'
             ),

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -3,12 +3,13 @@ import getpass
 import logging
 import os
 import sys
+from typing import Optional, List
 
 import cartography.config
 import cartography.sync
 import cartography.util
 from cartography.intel.aws.util.common import parse_and_validate_aws_requested_syncs
-
+from cartography.sync import parse_and_validate_selected_modules
 
 logger = logging.getLogger(__name__)
 
@@ -21,9 +22,9 @@ class CLI:
     :param prog: The name of the command line program. This will be displayed in usage and help output.
     """
 
-    def __init__(self, sync, prog=None):
+    def __init__(self, sync: Optional[cartography.sync.Sync] = None, prog: Optional[str] = None):
+        self.sync = sync if sync else cartography.sync.build_default_sync()
         self.prog = prog
-        self.sync = sync
         self.parser = self._build_parser()
 
     def _build_parser(self):
@@ -108,6 +109,21 @@ class CLI:
                 'The name of the database in Neo4j to connect to. If not specified, uses the config settings of your '
                 'Neo4j database itself to infer which database is set to default. '
                 'See https://neo4j.com/docs/api/python-driver/4.4/api.html#database.'
+            ),
+        )
+        parser.add_argument(
+            '--selected-modules',
+            type=str,
+            default=None,
+            help=(
+                'Comma-separated list of cartography top-level modules to sync. Example 1: "aws,gcp" to run AWS and GCP'
+                'modules. See the full list available in source code at cartography.sync. '
+                'If not specified, cartography by default will run all modules available and log warnings when it '
+                'does not find credentials configured for them. '
+                # TODO remove this mention about the create-indexes module when everything is using auto-indexes.
+                'We recommend that you always specify the `create-indexes` module first in this list. ' 
+                'If you specify the `analysis` module, we recommend that you include it as the LAST item of this list, '
+                '(because it does not make sense to perform analysis on an empty/out-of-date graph).'
             ),
         )
         # TODO add the below parameters to a 'sync' subparser
@@ -457,6 +473,10 @@ class CLI:
         else:
             config.neo4j_password = None
 
+        # Selected modules
+        if config.selected_modules:
+            self.sync = cartography.sync.build_sync(config.selected_modules)
+
         # AWS config
         if config.aws_requested_syncs:
             # No need to store the returned value; we're using this for input validation.
@@ -577,5 +597,4 @@ def main(argv=None):
     logging.getLogger('googleapiclient').setLevel(logging.WARNING)
     logging.getLogger('neo4j').setLevel(logging.WARNING)
     argv = argv if argv is not None else sys.argv[1:]
-    default_sync = cartography.sync.build_default_sync()
-    sys.exit(CLI(default_sync, prog='cartography').main(argv))
+    sys.exit(CLI(prog='cartography').main(argv))

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -19,6 +19,8 @@ class Config:
     :param neo4j_database: The name of the database in Neo4j to connect to. If not specified, uses your Neo4j database
     settings to infer which database is set to default.
     See https://neo4j.com/docs/api/python-driver/4.4/api.html#database. Optional.
+    :type selected_modules: str
+    :param selected_modules: Comma-separated list of cartography top-level modules to sync. Optional.
     :type update_tag: int
     :param update_tag: Update tag for a cartography sync run. Optional.
     :type aws_sync_all_profiles: bool
@@ -94,6 +96,7 @@ class Config:
         neo4j_password=None,
         neo4j_max_connection_lifetime=None,
         neo4j_database=None,
+        selected_modules=None,
         update_tag=None,
         aws_sync_all_profiles=False,
         aws_best_effort_mode=False,
@@ -136,6 +139,7 @@ class Config:
         self.neo4j_password = neo4j_password
         self.neo4j_max_connection_lifetime = neo4j_max_connection_lifetime
         self.neo4j_database = neo4j_database
+        self.selected_modules = selected_modules
         self.update_tag = update_tag
         self.aws_sync_all_profiles = aws_sync_all_profiles
         self.aws_best_effort_mode = aws_best_effort_mode

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -33,6 +33,24 @@ from cartography.util import STATUS_SUCCESS
 logger = logging.getLogger(__name__)
 
 
+TOP_LEVEL_MODULES = OrderedDict({  # preserve order so that the default sync always runs `analysis` at the very end
+    'create-indexes': cartography.intel.create_indexes.run,
+    'aws': cartography.intel.aws.start_aws_ingestion,
+    'azure': cartography.intel.azure.start_azure_ingestion,
+    'crowdstrike': cartography.intel.crowdstrike.start_crowdstrike_ingestion,
+    'gcp': cartography.intel.gcp.start_gcp_ingestion,
+    'gsuite': cartography.intel.gsuite.start_gsuite_ingestion,
+    'crxcavator': cartography.intel.crxcavator.start_extension_ingestion,
+    'cve': cartography.intel.cve.start_cve_ingestion,
+    'oci': cartography.intel.oci.start_oci_ingestion,
+    'okta': cartography.intel.okta.start_okta_ingestion,
+    'github': cartography.intel.github.start_github_ingestion,
+    'digitalocean': cartography.intel.digitalocean.start_digitalocean_ingestion,
+    'kubernetes': cartography.intel.kubernetes.start_k8s_ingestion,
+    'analysis': cartography.intel.analysis.run,
+})
+
+
 class Sync:
     """
     A cartography sync task.
@@ -172,19 +190,42 @@ def build_default_sync() -> Sync:
     """
     sync = Sync()
     sync.add_stages([
-        ('create-indexes', cartography.intel.create_indexes.run),
-        ('aws', cartography.intel.aws.start_aws_ingestion),
-        ('azure', cartography.intel.azure.start_azure_ingestion),
-        ('crowdstrike', cartography.intel.crowdstrike.start_crowdstrike_ingestion),
-        ('gcp', cartography.intel.gcp.start_gcp_ingestion),
-        ('gsuite', cartography.intel.gsuite.start_gsuite_ingestion),
-        ('crxcavator', cartography.intel.crxcavator.start_extension_ingestion),
-        ('cve', cartography.intel.cve.start_cve_ingestion),
-        ('oci', cartography.intel.oci.start_oci_ingestion),
-        ('okta', cartography.intel.okta.start_okta_ingestion),
-        ('github', cartography.intel.github.start_github_ingestion),
-        ('digitalocean', cartography.intel.digitalocean.start_digitalocean_ingestion),
-        ('kubernetes', cartography.intel.kubernetes.start_k8s_ingestion),
-        ('analysis', cartography.intel.analysis.run),
+        (stage_name, stage_func) for stage_name, stage_func in TOP_LEVEL_MODULES.items()
     ])
+    return sync
+
+
+def parse_and_validate_selected_modules(selected_modules: str) -> List[str]:
+    """
+    Ensures that user-selected modules passed through the CLI are valid and parses them to a list of str.
+    :param selected_modules: comma separated string of module names provided by user
+    :return: A validated list of module names that we will run
+    """
+    validated_modules: List[str] = []
+    for module in selected_modules.split(','):
+        module = module.strip()
+
+        if module in TOP_LEVEL_MODULES.keys():
+            validated_modules.append(module)
+        else:
+            valid_modules = ', '.join(TOP_LEVEL_MODULES.keys())
+            raise ValueError(
+                f'Error parsing `selected_modules`. You specified "{selected_modules}". '
+                f'Please check that your string is formatted properly. '
+                f'Example valid input looks like "aws,gcp,analysis" or "azure, oci, crowdstrike". '
+                f'Our full list of valid values is: {valid_modules}.'
+            )
+    return validated_modules
+
+
+def build_sync(selected_modules_as_str: str) -> Sync:
+    """
+    Returns a cartography sync object where all the sync stages are from the user-specified comma separated list of
+    modules to run.
+    """
+    selected_modules = parse_and_validate_selected_modules(selected_modules_as_str)
+    sync = Sync()
+    sync.add_stages(
+        [(sync_name, TOP_LEVEL_MODULES[sync_name]) for sync_name in selected_modules]
+    )
     return sync

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -213,7 +213,7 @@ def parse_and_validate_selected_modules(selected_modules: str) -> List[str]:
                 f'Error parsing `selected_modules`. You specified "{selected_modules}". '
                 f'Please check that your string is formatted properly. '
                 f'Example valid input looks like "aws,gcp,analysis" or "azure, oci, crowdstrike". '
-                f'Our full list of valid values is: {valid_modules}.'
+                f'Our full list of valid values is: {valid_modules}.',
             )
     return validated_modules
 
@@ -226,6 +226,6 @@ def build_sync(selected_modules_as_str: str) -> Sync:
     selected_modules = parse_and_validate_selected_modules(selected_modules_as_str)
     sync = Sync()
     sync.add_stages(
-        [(sync_name, TOP_LEVEL_MODULES[sync_name]) for sync_name in selected_modules]
+        [(sync_name, TOP_LEVEL_MODULES[sync_name]) for sync_name in selected_modules],
     )
     return sync

--- a/tests/unit/cartography/test_sync.py
+++ b/tests/unit/cartography/test_sync.py
@@ -1,6 +1,9 @@
 import pytest
 
-from cartography.sync import TOP_LEVEL_MODULES, build_default_sync, build_sync, parse_and_validate_selected_modules
+from cartography.sync import build_default_sync
+from cartography.sync import build_sync
+from cartography.sync import parse_and_validate_selected_modules
+from cartography.sync import TOP_LEVEL_MODULES
 
 
 def test_build_default_sync():

--- a/tests/unit/cartography/test_sync.py
+++ b/tests/unit/cartography/test_sync.py
@@ -1,0 +1,48 @@
+import pytest
+
+from cartography.sync import TOP_LEVEL_MODULES, build_default_sync, build_sync, parse_and_validate_selected_modules
+
+
+def test_build_default_sync():
+    sync = build_default_sync()
+    # Use list because order matters
+    assert [name for name in sync._stages.keys()] == list(TOP_LEVEL_MODULES.keys())
+
+
+def test_build_sync():
+    # Arrange
+    selected_modules = 'aws, gcp, analysis'
+
+    # Act
+    sync = build_sync(selected_modules)
+
+    # Assert
+    assert [name for name in sync._stages.keys()] == selected_modules.split(', ')
+
+
+# TODO - this test enforces that we put analysis at the end. idk if we want to own this logic though.
+# def test_build_sync_out_of_order_args():
+#     # Arrange
+#     selected_modules = 'analysis,aws,gcp'
+#
+#     # Act
+#     sync = build_sync(selected_modules)
+#
+#     # Assert
+#     assert [name for name in sync._stages.keys()] == ['aws', 'gcp', 'analysis']
+
+
+def test_parse_and_validate_selected_modules():
+    no_spaces = "aws,gcp,oci,analysis"
+    assert parse_and_validate_selected_modules(no_spaces) == ['aws', 'gcp', 'oci', 'analysis']
+
+    mismatch_spaces = 'gcp, oci,analysis'
+    assert parse_and_validate_selected_modules(mismatch_spaces) == ['gcp', 'oci', 'analysis']
+
+    sync_that_does_not_exist = 'gcp, thisdoesnotexist, aws'
+    with pytest.raises(ValueError):
+        parse_and_validate_selected_modules(sync_that_does_not_exist)
+
+    absolute_garbage = '#@$@#RDFFHKjsdfkjsd,KDFJHW#@,'
+    with pytest.raises(ValueError):
+        parse_and_validate_selected_modules(absolute_garbage)

--- a/tests/unit/cartography/test_sync.py
+++ b/tests/unit/cartography/test_sync.py
@@ -23,18 +23,6 @@ def test_build_sync():
     assert [name for name in sync._stages.keys()] == selected_modules.split(', ')
 
 
-# TODO - this test enforces that we put analysis at the end. idk if we want to own this logic though.
-# def test_build_sync_out_of_order_args():
-#     # Arrange
-#     selected_modules = 'analysis,aws,gcp'
-#
-#     # Act
-#     sync = build_sync(selected_modules)
-#
-#     # Assert
-#     assert [name for name in sync._stages.keys()] == ['aws', 'gcp', 'analysis']
-
-
 def test_parse_and_validate_selected_modules():
     no_spaces = "aws,gcp,oci,analysis"
     assert parse_and_validate_selected_modules(no_spaces) == ['aws', 'gcp', 'oci', 'analysis']


### PR DESCRIPTION
The Cartography CLI currently runs all modules regardless of whether creds are configured for them or not. We've instructed users wanting to configure this behavior can implement a custom sync command as a workaround: https://lyft.github.io/cartography/dev/developer-guide.html#implementing-custom-sync-commands.

This PR makes it so that users can control this behavior from the CLI if they want.

This makes it easier for us to include extra functionality that may not be directly related to a sync job within cartography, e.g. vuln scanners. Future work will add sub-parsers to the CLI to make configuration cleaner.