### PR TITLE
Data model: allow case-insensitive property match

### DIFF
--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -168,9 +168,7 @@ def _build_attach_sub_resource_statement(sub_resource_link: Optional[Cartography
     sub_resource_attach_template = Template(
         """
         WITH i, item
-        OPTIONAL MATCH (j:$SubResourceLabel)
-        WHERE
-            $WhereClause
+        OPTIONAL MATCH (j:$SubResourceLabel{$MatchClause})
         WITH i, item, j WHERE j IS NOT NULL
         $RelMergeClause
         ON CREATE SET r.firstseen = timestamp()
@@ -190,7 +188,7 @@ def _build_attach_sub_resource_statement(sub_resource_link: Optional[Cartography
 
     attach_sub_resource_statement = sub_resource_attach_template.safe_substitute(
         SubResourceLabel=sub_resource_link.target_node_label,
-        WhereClause=_build_where_clause_for_rel_match("j", sub_resource_link.target_node_matcher),
+        MatchClause=_build_match_clause(sub_resource_link.target_node_matcher),
         RelMergeClause=rel_merge_clause,
         SubResourceRelLabel=sub_resource_link.rel_label,
         set_rel_properties_statement=_build_rel_properties_statement('r', rel_props_as_dict),

--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -117,15 +117,16 @@ def _build_where_clause_for_rel_match(node_var: str, matcher: TargetNodeMatcher)
     :return: a Neo4j where clause
     """
     match = Template("$node_var.$key = $prop_ref")
-    imatch = Template("toLower($node_var.$key) = toLower($prop_ref)")
+    case_insensitive_match = Template("toLower($node_var.$key) = toLower($prop_ref)")
 
     matcher_asdict = asdict(matcher)
 
     result = []
     for key, prop_ref in matcher_asdict.items():
-        prop_line = match.safe_substitute(node_var=node_var, key=key, prop_ref=prop_ref)
         if prop_ref.ignore_case:
-            prop_line = imatch.safe_substitute(node_var=node_var, key=key, prop_ref=prop_ref)
+            prop_line = case_insensitive_match.safe_substitute(node_var=node_var, key=key, prop_ref=prop_ref)
+        else:
+            prop_line = match.safe_substitute(node_var=node_var, key=key, prop_ref=prop_ref)
         result.append(prop_line)
     return ' AND\n'.join(result)
 

--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -167,6 +167,7 @@ def _build_attach_sub_resource_statement(sub_resource_link: Optional[Cartography
 
     sub_resource_attach_template = Template(
         """
+        WITH i, item
         OPTIONAL MATCH (j:$SubResourceLabel)
         WHERE
             $WhereClause
@@ -284,7 +285,6 @@ def _build_attach_relationships_statement(
         """
         WITH i, item
         CALL {
-            WITH i, item
             $attach_relationships_statement
         }
         """,

--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -117,16 +117,15 @@ def _build_where_clause_for_rel_match(node_var: str, matcher: TargetNodeMatcher)
     :return: a Neo4j where clause
     """
     match = Template("$node_var.$key = $prop_ref")
-    case_insensitive_match = Template("toLower($node_var.$key) = toLower($prop_ref)")
+    imatch = Template("toLower($node_var.$key) = toLower($prop_ref)")
 
     matcher_asdict = asdict(matcher)
 
     result = []
     for key, prop_ref in matcher_asdict.items():
+        prop_line = match.safe_substitute(node_var=node_var, key=key, prop_ref=prop_ref)
         if prop_ref.ignore_case:
-            prop_line = case_insensitive_match.safe_substitute(node_var=node_var, key=key, prop_ref=prop_ref)
-        else:
-            prop_line = match.safe_substitute(node_var=node_var, key=key, prop_ref=prop_ref)
+            prop_line = imatch.safe_substitute(node_var=node_var, key=key, prop_ref=prop_ref)
         result.append(prop_line)
     return ' AND\n'.join(result)
 

--- a/cartography/models/core/common.py
+++ b/cartography/models/core/common.py
@@ -30,7 +30,7 @@ class PropertyRef:
             case-insensitive. Suppose your company's internal personnel database stores GitHub usernames all as
             lowercase. If you wanted to map your company's employees to their GitHub identities, you would need to
             perform a case-insensitive match between your company's record of a user's GitHub username and your
-            cartography catalog of GitHubUser nodes. Therefore, you would need `ignore_case=False` in the PropertyRef
+            cartography catalog of GitHubUser nodes. Therefore, you would need `ignore_case=True` in the PropertyRef
             that points to the GitHubUser node's name field, otherwise if one of your employees' GitHub usernames
             contains capital letters, you would not be able to map them properly to a GitHubUser node in your graph.
         """

--- a/cartography/models/core/common.py
+++ b/cartography/models/core/common.py
@@ -23,7 +23,8 @@ class PropertyRef:
           - All properties included in target node matchers will always have indexes created for them.
             Defaults to False.
         :param ignore_case: If True, performs a case-insensitive match when comparing the value of this property during
-        relationship creation. Defaults to False. This only has effect as part of a TargetNodeMatcher.
+        relationship creation. Defaults to False. This only has effect as part of a TargetNodeMatcher, and this is not
+        supported for the sub resource relationship.
             Example on why you would set this to True:
             GitHub usernames can have both uppercase and lowercase characters, but GitHub itself treats usernames as
             case-insensitive. Suppose your company's internal personnel database stores GitHub usernames all as

--- a/cartography/models/core/common.py
+++ b/cartography/models/core/common.py
@@ -8,7 +8,7 @@ class PropertyRef:
     (PropertyRef.set_in_kwargs=True).
     """
 
-    def __init__(self, name: str, set_in_kwargs=False, extra_index=False):
+    def __init__(self, name: str, set_in_kwargs=False, extra_index=False, ignore_case=False):
         """
         :param name: The name of the property
         :param set_in_kwargs: Optional. If True, the property is not defined on the data dict, and we expect to find the
@@ -22,10 +22,21 @@ class PropertyRef:
             `ensure_indexes()`.
           - All properties included in target node matchers will always have indexes created for them.
             Defaults to False.
+        :param ignore_case: If True, performs a case-insensitive match when comparing the value of this property during
+        relationship creation. Defaults to False. This only has effect as part of a TargetNodeMatcher.
+            Example on why you would set this to True:
+            GitHub usernames can have both uppercase and lowercase characters, but GitHub itself treats usernames as
+            case-insensitive. Suppose your company's internal personnel database stores GitHub usernames all as
+            lowercase. If you wanted to map your company's employees to their GitHub identities, you would need to
+            perform a case-insensitive match between your company's record of a user's GitHub username and your
+            cartography catalog of GitHubUser nodes. Therefore, you would need `ignore_case=False` in the PropertyRef
+            that points to the GitHubUser node's name field, otherwise if one of your employees' GitHub usernames
+            contains capital letters, you would not be able to map them properly to a GitHubUser node in your graph.
         """
         self.name = name
         self.set_in_kwargs = set_in_kwargs
         self.extra_index = extra_index
+        self.ignore_case = ignore_case
 
     def _parameterize_name(self) -> str:
         return f"${self.name}"

--- a/cartography/models/core/common.py
+++ b/cartography/models/core/common.py
@@ -30,7 +30,7 @@ class PropertyRef:
             case-insensitive. Suppose your company's internal personnel database stores GitHub usernames all as
             lowercase. If you wanted to map your company's employees to their GitHub identities, you would need to
             perform a case-insensitive match between your company's record of a user's GitHub username and your
-            cartography catalog of GitHubUser nodes. Therefore, you would need `ignore_case=True` in the PropertyRef
+            cartography catalog of GitHubUser nodes. Therefore, you would need `ignore_case=False` in the PropertyRef
             that points to the GitHubUser node's name field, otherwise if one of your employees' GitHub usernames
             contains capital letters, you would not be able to map them properly to a GitHubUser node in your graph.
         """

--- a/tests/data/graph/querybuilder/sample_data/case_insensitive_prop_ref.py
+++ b/tests/data/graph/querybuilder/sample_data/case_insensitive_prop_ref.py
@@ -1,0 +1,48 @@
+FAKE_GITHUB_USER_DATA = [
+    {
+        'hasTwoFactorEnabled': None,
+        'node': {
+            'url': 'https://example.com/hjsimpson',
+            'login': 'HjsimPson',  # Upper and lowercase
+            'name': 'Homer Simpson',
+            'isSiteAdmin': False,
+            'email': 'hjsimpson@example.com',
+            'company': 'Springfield Nuclear Power Plant',
+        },
+        'role': 'MEMBER',
+    }, {
+        'hasTwoFactorEnabled': None,
+        'node': {
+            'url': 'https://example.com/mbsimpson',
+            'login': 'mbsimp-son',  # All lowercase
+            'name': 'Marge Simpson',
+            'isSiteAdmin': False,
+            'email': 'mbsimpson@example.com',
+            'company': 'Simpson Residence',
+        },
+        'role': 'ADMIN',
+    },
+]
+
+FAKE_GITHUB_ORG_DATA = {
+    'url': 'https://example.com/my_org',
+    'login': 'my_org',
+}
+
+FAKE_EMPLOYEE_DATA = [
+    {
+        'id': 123,
+        'email': 'hjsimpson@example.com',
+        'first_name': 'Homer',
+        'last_name': 'Simpson',
+        'name': 'Homer Simpson',
+        'github_username': 'hjsimpson',  # pure lowercase
+    },
+    {
+        'id': 456,
+        'email': 'mbsimpson@example.com',
+        'first_name': 'Marge',
+        'last_name': 'Simpson',
+        'github_username': 'mbsimp-son',  # pure lowercase
+    },
+]

--- a/tests/data/graph/querybuilder/sample_models/fake_emps_githubusers.py
+++ b/tests/data/graph/querybuilder/sample_models/fake_emps_githubusers.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class FakeEmpToGitHubUserRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class FakeEmpToGitHubUser(CartographyRelSchema):
+    target_node_label: str = 'GitHubUser'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'username': PropertyRef('github_username', ignore_case=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "IDENTITY_GITHUB"
+    properties: FakeEmpToGitHubUserRelProperties = FakeEmpToGitHubUserRelProperties()
+
+
+@dataclass(frozen=True)
+class FakeEmpNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('id')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+    email: PropertyRef = PropertyRef('email')
+    github_username: PropertyRef = PropertyRef('github_username')
+
+
+@dataclass(frozen=True)
+class FakeEmpSchema(CartographyNodeSchema):
+    label: str = 'FakeEmployee'
+    properties: FakeEmpNodeProperties = FakeEmpNodeProperties()
+    other_relationships: OtherRelationships = OtherRelationships([
+        FakeEmpToGitHubUser(),
+    ])

--- a/tests/integration/cartography/graph/test_querybuilder_case_insensitive.py
+++ b/tests/integration/cartography/graph/test_querybuilder_case_insensitive.py
@@ -1,0 +1,27 @@
+from cartography.client.core.tx import load
+from cartography.intel.github.users import load_organization_users
+from tests.data.graph.querybuilder.sample_data.case_insensitive_prop_ref import FAKE_EMPLOYEE_DATA
+from tests.data.graph.querybuilder.sample_data.case_insensitive_prop_ref import FAKE_GITHUB_ORG_DATA
+from tests.data.graph.querybuilder.sample_data.case_insensitive_prop_ref import FAKE_GITHUB_USER_DATA
+from tests.data.graph.querybuilder.sample_models.fake_emps_githubusers import FakeEmpSchema
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def test_load_team_members_data(neo4j_session):
+    # Arrange: Load some fake GitHubUser nodes to the graph
+    load_organization_users(
+        neo4j_session,
+        FAKE_GITHUB_USER_DATA,
+        FAKE_GITHUB_ORG_DATA,
+        TEST_UPDATE_TAG,
+    )
+
+    # Act: Create team members
+    load(neo4j_session, FakeEmpSchema(), FAKE_EMPLOYEE_DATA, lastupdated=TEST_UPDATE_TAG)
+
+    # Assert we can create relationships using a case insensitive match
+    assert check_rels(neo4j_session, 'FakeEmployee', 'email', 'GitHubUser', 'username', 'IDENTITY_GITHUB') == {
+        ('hjsimpson@example.com', 'HjsimPson'), ('mbsimpson@example.com', 'mbsimp-son'),
+    }

--- a/tests/unit/cartography/graph/test_querybuilder_complex.py
+++ b/tests/unit/cartography/graph/test_querybuilder_complex.py
@@ -20,9 +20,7 @@ def test_build_ingestion_query_complex():
             WITH i, item
             CALL {
                 WITH i, item
-                OPTIONAL MATCH (j:SubResource)
-                WHERE
-                    j.id = $sub_resource_id
+                OPTIONAL MATCH (j:SubResource{id: $sub_resource_id})
                 WITH i, item, j WHERE j IS NOT NULL
                 MERGE (i)<-[r:RELATIONSHIP_LABEL]-(j)
                 ON CREATE SET r.firstseen = timestamp()

--- a/tests/unit/cartography/graph/test_querybuilder_complex.py
+++ b/tests/unit/cartography/graph/test_querybuilder_complex.py
@@ -20,7 +20,9 @@ def test_build_ingestion_query_complex():
             WITH i, item
             CALL {
                 WITH i, item
-                OPTIONAL MATCH (j:SubResource{id: $sub_resource_id})
+                OPTIONAL MATCH (j:SubResource)
+                WHERE
+                    j.id = $sub_resource_id
                 WITH i, item, j WHERE j IS NOT NULL
                 MERGE (i)<-[r:RELATIONSHIP_LABEL]-(j)
                 ON CREATE SET r.firstseen = timestamp()
@@ -31,7 +33,9 @@ def test_build_ingestion_query_complex():
 
                 UNION
                 WITH i, item
-                OPTIONAL MATCH (n0:HelloAsset{id: item.hello_asset_id})
+                OPTIONAL MATCH (n0:HelloAsset)
+                WHERE
+                    n0.id = item.hello_asset_id
                 WITH i, item, n0 WHERE n0 IS NOT NULL
                 MERGE (i)-[r0:ASSOCIATED_WITH]->(n0)
                 ON CREATE SET r0.firstseen = timestamp()
@@ -40,7 +44,9 @@ def test_build_ingestion_query_complex():
 
                 UNION
                 WITH i, item
-                OPTIONAL MATCH (n1:WorldAsset{id: item.world_asset_id})
+                OPTIONAL MATCH (n1:WorldAsset)
+                WHERE
+                    n1.id = item.world_asset_id
                 WITH i, item, n1 WHERE n1 IS NOT NULL
                 MERGE (i)<-[r1:CONNECTED]-(n1)
                 ON CREATE SET r1.firstseen = timestamp()

--- a/tests/unit/cartography/graph/test_querybuilder_simple.py
+++ b/tests/unit/cartography/graph/test_querybuilder_simple.py
@@ -45,9 +45,7 @@ def test_build_ingestion_query_with_sub_resource():
             WITH i, item
             CALL {
                 WITH i, item
-                OPTIONAL MATCH (j:SubResource)
-                WHERE
-                    j.id = $sub_resource_id
+                OPTIONAL MATCH (j:SubResource{id: $sub_resource_id})
                 WITH i, item, j WHERE j IS NOT NULL
                 MERGE (i)<-[r:RELATIONSHIP_LABEL]-(j)
                 ON CREATE SET r.firstseen = timestamp()

--- a/tests/unit/cartography/graph/test_querybuilder_simple.py
+++ b/tests/unit/cartography/graph/test_querybuilder_simple.py
@@ -65,7 +65,6 @@ def test_build_ingestion_query_with_sub_resource():
 def test_build_ingestion_query_case_insensitive_match():
     query = build_ingestion_query(FakeEmpSchema())
 
-    # TODO - if there is just one relationship, then we repeat `WITH i, item`. Functionally it still works but fix this.
     expected = """
         UNWIND $DictList AS item
             MERGE (i:FakeEmployee{id: item.id})
@@ -77,7 +76,6 @@ def test_build_ingestion_query_case_insensitive_match():
 
             WITH i, item
             CALL {
-                WITH i, item
                 WITH i, item
                 OPTIONAL MATCH (n0:GitHubUser)
                 WHERE

--- a/tests/unit/cartography/graph/test_querybuilder_simple.py
+++ b/tests/unit/cartography/graph/test_querybuilder_simple.py
@@ -1,4 +1,5 @@
 from cartography.graph.querybuilder import build_ingestion_query
+from tests.data.graph.querybuilder.sample_models.fake_emps_githubusers import FakeEmpSchema
 from tests.data.graph.querybuilder.sample_models.simple_node import SimpleNodeSchema
 from tests.data.graph.querybuilder.sample_models.simple_node import SimpleNodeWithSubResourceSchema
 from tests.unit.cartography.graph.helpers import remove_leading_whitespace_and_empty_lines
@@ -44,12 +45,48 @@ def test_build_ingestion_query_with_sub_resource():
             WITH i, item
             CALL {
                 WITH i, item
-                OPTIONAL MATCH (j:SubResource{id: $sub_resource_id})
+                OPTIONAL MATCH (j:SubResource)
+                WHERE
+                    j.id = $sub_resource_id
                 WITH i, item, j WHERE j IS NOT NULL
                 MERGE (i)<-[r:RELATIONSHIP_LABEL]-(j)
                 ON CREATE SET r.firstseen = timestamp()
                 SET
                     r.lastupdated = $lastupdated
+            }
+    """
+
+    # Assert: compare query outputs while ignoring leading whitespace.
+    actual_query = remove_leading_whitespace_and_empty_lines(query)
+    expected_query = remove_leading_whitespace_and_empty_lines(expected)
+    assert actual_query == expected_query
+
+
+def test_build_ingestion_query_case_insensitive_match():
+    query = build_ingestion_query(FakeEmpSchema())
+
+    # TODO - if there is just one relationship, then we repeat `WITH i, item`. Functionally it still works but fix this.
+    expected = """
+        UNWIND $DictList AS item
+            MERGE (i:FakeEmployee{id: item.id})
+            ON CREATE SET i.firstseen = timestamp()
+            SET
+                i.lastupdated = $lastupdated,
+                i.email = item.email,
+                i.github_username = item.github_username
+
+            WITH i, item
+            CALL {
+                WITH i, item
+                WITH i, item
+                OPTIONAL MATCH (n0:GitHubUser)
+                WHERE
+                    toLower(n0.username) = toLower(item.github_username)
+                WITH i, item, n0 WHERE n0 IS NOT NULL
+                MERGE (i)-[r0:IDENTITY_GITHUB]->(n0)
+                ON CREATE SET r0.firstseen = timestamp()
+                SET
+                    r0.lastupdated = $lastupdated
             }
     """
 


### PR DESCRIPTION
Updates PropertyRef class and querybuilder to allow for case insensitive property matching when creating new relationships. Note that this is not supported for sub resource relationships.

Also fixes a bug where our generated query outputs `WITH i, item\nWITH i, item` if no sub resource relationship is defined but an OtherRelationship is.