### PR TITLE
Set BlockPublicPolicy property on S3 nodes

### DIFF
--- a/cartography/intel/aws/s3.py
+++ b/cartography/intel/aws/s3.py
@@ -345,7 +345,7 @@ def _load_s3_public_access_block(
     MATCH (s:S3Bucket) where s.name = public_access_block.bucket
     SET s.block_public_acls = public_access_block.block_public_acls,
         s.ignore_public_acls = public_access_block.ignore_public_acls,
-        s.block_public_acls = public_access_block.block_public_acls,
+        s.block_public_policy = public_access_block.block_public_policy,
         s.restrict_public_buckets = public_access_block.restrict_public_buckets,
         s.lastupdated = $UpdateTag
     """


### PR DESCRIPTION
Fixes a likely copy-n-paste error in `_load_s3_public_access_block` where `s.block_public_acls` gets set twice but `s.block_public_policy` does not get set at all.