### PR TITLE
Fix #1126: Ecs update task definitions import to greatly improve sync speed

### DIFF
--- a/cartography/data/indexes.cypher
+++ b/cartography/data/indexes.cypher
@@ -140,6 +140,7 @@ CREATE INDEX IF NOT EXISTS FOR (n:ECSContainerInstance) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:ECSService) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:ECSService) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:ECSTaskDefinition) ON (n.id);
+CREATE INDEX IF NOT EXISTS FOR (n:ECSTaskDefinition) ON (n.arn);
 CREATE INDEX IF NOT EXISTS FOR (n:ECSTaskDefinition) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:ECSTask) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:ECSTask) ON (n.lastupdated);

--- a/cartography/intel/aws/ecs.py
+++ b/cartography/intel/aws/ecs.py
@@ -94,7 +94,7 @@ def get_ecs_services(cluster_arn: str, boto3_session: boto3.session.Session, reg
 def get_ecs_task_definitions(
     boto3_session: boto3.session.Session,
     region: str,
-    tasks: List[Dict[str, Any]]
+    tasks: List[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
     client = boto3_session.client('ecs', region_name=region)
     task_definitions: List[Dict[str, Any]] = []
@@ -600,7 +600,7 @@ def sync(
             task_definitions = get_ecs_task_definitions(
                 boto3_session,
                 region,
-                tasks
+                tasks,
             )
             load_ecs_task_definitions(
                 neo4j_session,

--- a/cartography/intel/aws/ecs.py
+++ b/cartography/intel/aws/ecs.py
@@ -100,7 +100,7 @@ def get_ecs_task_definitions(
     task_definitions: List[Dict[str, Any]] = []
     for task in tasks:
         task_definition = client.describe_task_definition(
-            taskDefinition=task.get('taskDefinitionArn'),
+            taskDefinition=task['taskDefinitionArn'],
         )
         task_definitions.append(task_definition['taskDefinition'])
     return task_definitions

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -3063,6 +3063,12 @@ Representation of an AWS ECS [Task Definition](https://docs.aws.amazon.com/Amazo
         (AWSAccount)-[RESOURCE]->(ECSTaskDefinition)
         ```
 
+- An ECSTask has an ECSTaskDefinition.
+
+        ```
+        (ECSTask)-[HAS_TASK_DEFINITION]->(ECSTaskDefinition)
+        ```
+
 ### ECSContainerDefinition
 
 Representation of an AWS ECS [Container Definition](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html)
@@ -3162,7 +3168,7 @@ Representation of an AWS ECS [Task](https://docs.aws.amazon.com/AmazonECS/latest
 - ECSTasks have ECSTaskDefinitions
 
         ```
-        (ECSContainerInstance)-[HAS_TASK_DEFINITION]->(ECSTask)
+        (ECSTask)-[HAS_TASK_DEFINITION]->(ECSTaskDefinition)
         ```
 
 ### ECSContainer

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.74.0'
+__version__ = '0.75.0rc1'
 
 
 setup(

--- a/tests/data/aws/ecs.py
+++ b/tests/data/aws/ecs.py
@@ -143,7 +143,7 @@ GET_ECS_SERVICES = [
 
 GET_ECS_TASK_DEFINITIONS = [
     {
-        'taskDefinitionArn': 'arn:aws:ecs:us-east-1:000000000000:task-definition/test:0',
+        'taskDefinitionArn': 'arn:aws:ecs:us-east-1:000000000000:task-definition/test_definition:0',
         'containerDefinitions': [
             {
                 'name': 'test',

--- a/tests/integration/cartography/intel/aws/test_ecs.py
+++ b/tests/integration/cartography/intel/aws/test_ecs.py
@@ -147,7 +147,6 @@ def test_load_ecs_services(neo4j_session, *args):
         assert n["c"] == 1
 
 
-
 def test_load_ecs_task_definitions(neo4j_session, *args):
     task_data = tests.data.aws.ecs.GET_ECS_TASKS
     cartography.intel.aws.ecs.load_ecs_tasks(
@@ -227,7 +226,7 @@ def test_load_ecs_task_definitions(neo4j_session, *args):
     )
     for n in nodes:
         assert n["c"] == 1
-    
+
     nodes = neo4j_session.run(
         """
         MATCH (:ECSTaskDefinition)<-[:HAS_TASK_DEFINITION]-(n:ECSTask)

--- a/tests/integration/cartography/intel/aws/test_ecs.py
+++ b/tests/integration/cartography/intel/aws/test_ecs.py
@@ -147,7 +147,17 @@ def test_load_ecs_services(neo4j_session, *args):
         assert n["c"] == 1
 
 
+
 def test_load_ecs_task_definitions(neo4j_session, *args):
+    task_data = tests.data.aws.ecs.GET_ECS_TASKS
+    cartography.intel.aws.ecs.load_ecs_tasks(
+        neo4j_session,
+        CLUSTER_ARN,
+        task_data,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
     data = tests.data.aws.ecs.GET_ECS_TASK_DEFINITIONS
     cartography.intel.aws.ecs.load_ecs_task_definitions(
         neo4j_session,
@@ -159,7 +169,7 @@ def test_load_ecs_task_definitions(neo4j_session, *args):
 
     expected_nodes = {
         (
-            "arn:aws:ecs:us-east-1:000000000000:task-definition/test:0",
+            "arn:aws:ecs:us-east-1:000000000000:task-definition/test_definition:0",
             "test_family",
             "ACTIVE",
             4,
@@ -187,7 +197,7 @@ def test_load_ecs_task_definitions(neo4j_session, *args):
 
     expected_nodes = {
         (
-            "arn:aws:ecs:us-east-1:000000000000:task-definition/test:0-test",
+            "arn:aws:ecs:us-east-1:000000000000:task-definition/test_definition:0-test",
             "test",
             "test/test:latest",
         ),
@@ -212,6 +222,15 @@ def test_load_ecs_task_definitions(neo4j_session, *args):
     nodes = neo4j_session.run(
         """
         MATCH (:ECSTaskDefinition)-[:HAS_CONTAINER_DEFINITION]->(n:ECSContainerDefinition)
+        RETURN count(n.id) AS c
+        """,
+    )
+    for n in nodes:
+        assert n["c"] == 1
+    
+    nodes = neo4j_session.run(
+        """
+        MATCH (:ECSTaskDefinition)<-[:HAS_TASK_DEFINITION]-(n:ECSTask)
         RETURN count(n.id) AS c
         """,
     )

--- a/tests/integration/cartography/intel/aws/test_ecs.py
+++ b/tests/integration/cartography/intel/aws/test_ecs.py
@@ -147,16 +147,82 @@ def test_load_ecs_services(neo4j_session, *args):
         assert n["c"] == 1
 
 
-def test_load_ecs_task_definitions(neo4j_session, *args):
-    task_data = tests.data.aws.ecs.GET_ECS_TASKS
+def test_load_ecs_tasks(neo4j_session, *args):
+    data = tests.data.aws.ecs.GET_ECS_TASKS
     cartography.intel.aws.ecs.load_ecs_tasks(
         neo4j_session,
         CLUSTER_ARN,
-        task_data,
+        data,
         TEST_REGION,
         TEST_ACCOUNT_ID,
         TEST_UPDATE_TAG,
     )
+
+    expected_nodes = {
+        (
+            "arn:aws:ecs:us-east-1:000000000000:task/test_task/00000000000000000000000000000000",
+            "arn:aws:ecs:us-east-1:000000000000:task-definition/test_definition:0",
+            "arn:aws:ecs:us-east-1:000000000000:cluster/test_cluster",
+            "service:test_service",
+            1640673743,
+        ),
+    }
+
+    nodes = neo4j_session.run(
+        """
+        MATCH (n:ECSTask)
+        RETURN n.id, n.task_definition_arn, n.cluster_arn, n.group, n.created_at
+        """,
+    )
+    actual_nodes = {
+        (
+            n['n.id'],
+            n['n.task_definition_arn'],
+            n['n.cluster_arn'],
+            n['n.group'],
+            n['n.created_at'],
+        )
+        for n in nodes
+    }
+    assert actual_nodes == expected_nodes
+
+    expected_nodes = {
+        (
+            "arn:aws:ecs:us-east-1:000000000000:container/test_instance/00000000000000000000000000000000/00000000-0000-0000-0000-000000000000",  # noqa:E501
+            "test-task_container",
+            "000000000000.dkr.ecr.us-east-1.amazonaws.com/test-image:latest",
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ),
+    }
+
+    nodes = neo4j_session.run(
+        """
+        MATCH (n:ECSContainer)
+        RETURN n.id, n.name, n.image, n.image_digest
+        """,
+    )
+    actual_nodes = {
+        (
+            n['n.id'],
+            n['n.name'],
+            n['n.image'],
+            n['n.image_digest'],
+        )
+        for n in nodes
+    }
+    assert actual_nodes == expected_nodes
+
+    nodes = neo4j_session.run(
+        """
+        MATCH (:ECSTask)-[:HAS_CONTAINER]->(n:ECSContainer)
+        RETURN count(n.id) AS c
+        """,
+    )
+    for n in nodes:
+        assert n["c"] == 1
+
+
+def test_load_ecs_task_definitions(neo4j_session, *args):
     data = tests.data.aws.ecs.GET_ECS_TASK_DEFINITIONS
     cartography.intel.aws.ecs.load_ecs_task_definitions(
         neo4j_session,
@@ -230,81 +296,6 @@ def test_load_ecs_task_definitions(neo4j_session, *args):
     nodes = neo4j_session.run(
         """
         MATCH (:ECSTaskDefinition)<-[:HAS_TASK_DEFINITION]-(n:ECSTask)
-        RETURN count(n.id) AS c
-        """,
-    )
-    for n in nodes:
-        assert n["c"] == 1
-
-
-def test_load_ecs_tasks(neo4j_session, *args):
-    data = tests.data.aws.ecs.GET_ECS_TASKS
-    cartography.intel.aws.ecs.load_ecs_tasks(
-        neo4j_session,
-        CLUSTER_ARN,
-        data,
-        TEST_REGION,
-        TEST_ACCOUNT_ID,
-        TEST_UPDATE_TAG,
-    )
-
-    expected_nodes = {
-        (
-            "arn:aws:ecs:us-east-1:000000000000:task/test_task/00000000000000000000000000000000",
-            "arn:aws:ecs:us-east-1:000000000000:task-definition/test_definition:0",
-            "arn:aws:ecs:us-east-1:000000000000:cluster/test_cluster",
-            "service:test_service",
-            1640673743,
-        ),
-    }
-
-    nodes = neo4j_session.run(
-        """
-        MATCH (n:ECSTask)
-        RETURN n.id, n.task_definition_arn, n.cluster_arn, n.group, n.created_at
-        """,
-    )
-    actual_nodes = {
-        (
-            n['n.id'],
-            n['n.task_definition_arn'],
-            n['n.cluster_arn'],
-            n['n.group'],
-            n['n.created_at'],
-        )
-        for n in nodes
-    }
-    assert actual_nodes == expected_nodes
-
-    expected_nodes = {
-        (
-            "arn:aws:ecs:us-east-1:000000000000:container/test_instance/00000000000000000000000000000000/00000000-0000-0000-0000-000000000000",  # noqa:E501
-            "test-task_container",
-            "000000000000.dkr.ecr.us-east-1.amazonaws.com/test-image:latest",
-            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
-        ),
-    }
-
-    nodes = neo4j_session.run(
-        """
-        MATCH (n:ECSContainer)
-        RETURN n.id, n.name, n.image, n.image_digest
-        """,
-    )
-    actual_nodes = {
-        (
-            n['n.id'],
-            n['n.name'],
-            n['n.image'],
-            n['n.image_digest'],
-        )
-        for n in nodes
-    }
-    assert actual_nodes == expected_nodes
-
-    nodes = neo4j_session.run(
-        """
-        MATCH (:ECSTask)-[:HAS_CONTAINER]->(n:ECSContainer)
         RETURN count(n.id) AS c
         """,
     )


### PR DESCRIPTION
See https://github.com/lyft/cartography/issues/1126

This PR accomplishes the following: 
Updates the process to only import the actively used task definitions by parsing the tasks list for the taskDefinitionArn instead of ingesting all task definitions. This reduced time required to sync ECS with more than 50 clusters from nearly 2 hours to 1 minute. 
Creating a relationship between the task definition and the task that definition is used by
Updates the tests for importing task definitions