### PR TITLE
Fixes #1133: AWS: IAM: Roles: merge roles by principal first

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -309,11 +309,15 @@ def load_roles(
     neo4j_session: neo4j.Session, roles: List[Dict], current_aws_account_id: str, aws_update_tag: int,
 ) -> None:
     ingest_role = """
-    MERGE (rnode:AWSRole{arn: $Arn})
-    ON CREATE SET rnode:AWSPrincipal, rnode.roleid = $RoleId, rnode.firstseen = timestamp(),
-    rnode.createdate = $CreateDate
-    ON MATCH SET rnode.name = $RoleName, rnode.path = $Path
-    SET rnode.lastupdated = $aws_update_tag
+    MERGE (rnode:AWSPrincipal{arn: $Arn})
+    ON CREATE SET rnode.firstseen = timestamp()
+    SET
+        rnode:AWSRole,
+        rnode.roleid = $RoleId,
+        rnode.createdate = $CreateDate,
+        rnode.name = $RoleName,
+        rnode.path = $Path,
+        rnode.lastupdated = $aws_update_tag
     WITH rnode
     MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
     MERGE (aa)-[r:RESOURCE]->(rnode)


### PR DESCRIPTION
Fixes #1133 

This PR:

- When merging AWSRoles, first merges as an AWSPrincipal and then adds the AWSRole label.
- Modifies a test to verify the fix.