### PR TITLE
Only run aws analysis jobs if dependent syncs finished

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import traceback
-from typing import Any, Set
+from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
@@ -17,8 +17,8 @@ from cartography.config import Config
 from cartography.intel.aws.util.common import parse_and_validate_aws_requested_syncs
 from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
-from cartography.util import run_analysis_job
 from cartography.util import run_analysis_and_ensure_deps
+from cartography.util import run_analysis_job
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -212,13 +212,13 @@ def _perform_aws_analysis(
         common_job_parameters: Dict[str, Any],
 ) -> None:
     requested_syncs_as_set = set(requested_syncs)
+
     ec2_asset_exposure_requirements = {
         'ec2:instance',
         'ec2:security_group',
         'ec2:load_balancer',
         'ec2:load_balancer_v2',
     }
-
     run_analysis_and_ensure_deps(
         'aws_ec2_asset_exposure.json',
         ec2_asset_exposure_requirements,

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import traceback
-from typing import Any
+from typing import Any, Set
 from typing import Dict
 from typing import Iterable
 from typing import List
@@ -18,8 +18,10 @@ from cartography.intel.aws.util.common import parse_and_validate_aws_requested_s
 from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_analysis_job
+from cartography.util import run_analysis_and_ensure_deps
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
+
 
 stat_handler = get_stats_client(__name__)
 logger = logging.getLogger(__name__)
@@ -204,6 +206,53 @@ def _sync_multiple_accounts(
 
 
 @timeit
+def _perform_aws_analysis(
+        requested_syncs: List[str],
+        neo4j_session: neo4j.Session,
+        common_job_parameters: Dict[str, Any],
+) -> None:
+    requested_syncs_as_set = set(requested_syncs)
+    ec2_asset_exposure_requirements = {
+        'ec2:instance',
+        'ec2:security_group',
+        'ec2:load_balancer',
+        'ec2:load_balancer_v2',
+    }
+
+    run_analysis_and_ensure_deps(
+        'aws_ec2_asset_exposure.json',
+        ec2_asset_exposure_requirements,
+        requested_syncs_as_set,
+        common_job_parameters,
+        neo4j_session,
+    )
+
+    run_analysis_and_ensure_deps(
+        'aws_ec2_keypair_analysis.json',
+        {'ec2:keypair'},
+        requested_syncs_as_set,
+        common_job_parameters,
+        neo4j_session,
+    )
+
+    run_analysis_and_ensure_deps(
+        'aws_eks_asset_exposure.json',
+        {'eks'},
+        requested_syncs_as_set,
+        common_job_parameters,
+        neo4j_session,
+    )
+
+    run_analysis_and_ensure_deps(
+        'aws_foreign_accounts.json',
+        set(),  # This job has no requirements
+        requested_syncs_as_set,
+        common_job_parameters,
+        neo4j_session,
+    )
+
+
+@timeit
 def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,
@@ -256,26 +305,4 @@ def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     )
 
     if sync_successful:
-        run_analysis_job(
-            'aws_ec2_asset_exposure.json',
-            neo4j_session,
-            common_job_parameters,
-        )
-
-        run_analysis_job(
-            'aws_ec2_keypair_analysis.json',
-            neo4j_session,
-            common_job_parameters,
-        )
-
-        run_analysis_job(
-            'aws_eks_asset_exposure.json',
-            neo4j_session,
-            common_job_parameters,
-        )
-
-        run_analysis_job(
-            'aws_foreign_accounts.json',
-            neo4j_session,
-            common_job_parameters,
-        )
+        _perform_aws_analysis(requested_syncs, neo4j_session, common_job_parameters)

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -3,7 +3,7 @@ import re
 import sys
 from functools import wraps
 from string import Template
-from typing import Any, Set
+from typing import Any
 from typing import BinaryIO
 from typing import Callable
 from typing import cast
@@ -11,6 +11,7 @@ from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Optional
+from typing import Set
 from typing import TypeVar
 from typing import Union
 
@@ -74,7 +75,7 @@ def run_analysis_and_ensure_deps(
     if not resource_dependencies.issubset(requested_syncs):
         logger.warning(
             f"Did not run {analysis_job_name} because it needs {resource_dependencies} to be included in the"
-            f"as a requested sync. You specified: {requested_syncs}. Please check your CLI args/cartography config."
+            f"as a requested sync. You specified: {requested_syncs}. Please check your CLI args/cartography config.",
         )
         return
 

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -73,9 +73,10 @@ def run_analysis_and_ensure_deps(
     :param neo4j_session: The neo4j session object.
     """
     if not resource_dependencies.issubset(requested_syncs):
-        logger.warning(
+        logger.info(
             f"Did not run {analysis_job_name} because it needs {resource_dependencies} to be included in the"
-            f"as a requested sync. You specified: {requested_syncs}. Please check your CLI args/cartography config.",
+            f"as a requested sync. You specified: {requested_syncs}. If you want this job to run, please change your "
+            f"CLI args/cartography config so that all required resources are included.",
         )
         return
 

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -74,7 +74,7 @@ def run_analysis_and_ensure_deps(
     """
     if not resource_dependencies.issubset(requested_syncs):
         logger.info(
-            f"Did not run {analysis_job_name} because it needs {resource_dependencies} to be included in the"
+            f"Did not run {analysis_job_name} because it needs {resource_dependencies} to be included "
             f"as a requested sync. You specified: {requested_syncs}. If you want this job to run, please change your "
             f"CLI args/cartography config so that all required resources are included.",
         )

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -145,7 +145,7 @@ def test_run_analysis_and_ensure_deps_no_requirements(mock_run_analysis_job: moc
     # Act
     run_analysis_and_ensure_deps(
         'aws_foreign_accounts.json',
-        set(),  # This job has no requirements
+        {'iam'},
         requested_syncs,
         common_job_parameters,
         neo4j_session,

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -9,8 +10,6 @@ from cartography import util
 from cartography.util import aws_handle_regions
 from cartography.util import batch
 from cartography.util import run_analysis_and_ensure_deps
-
-from unittest import mock
 
 
 def test_run_analysis_job_default_package(mocker):
@@ -97,6 +96,7 @@ def test_batch(mocker):
     # Also check for empty input
     assert batch([], 3) == []
 
+
 @mock.patch.object(cartography.util, 'run_analysis_job', return_value=None)
 def test_run_analysis_and_ensure_deps(mock_run_analysis_job: mock.MagicMock):
     # Arrange
@@ -107,7 +107,7 @@ def test_run_analysis_and_ensure_deps(mock_run_analysis_job: mock.MagicMock):
     requested_syncs = {
         'ec2:instance',
         'iam',
-        'resourcegroupstaggingapi'
+        'resourcegroupstaggingapi',
     }
 
     # Act
@@ -139,7 +139,7 @@ def test_run_analysis_and_ensure_deps_no_requirements(mock_run_analysis_job: moc
     requested_syncs = {
         'ec2:instance',
         'iam',
-        'resourcegroupstaggingapi'
+        'resourcegroupstaggingapi',
     }
 
     # Act

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -4,9 +4,13 @@ from unittest.mock import patch
 import botocore
 import pytest
 
+import cartography.util
 from cartography import util
 from cartography.util import aws_handle_regions
 from cartography.util import batch
+from cartography.util import run_analysis_and_ensure_deps
+
+from unittest import mock
 
 
 def test_run_analysis_job_default_package(mocker):
@@ -92,3 +96,64 @@ def test_batch(mocker):
     assert actual == expected
     # Also check for empty input
     assert batch([], 3) == []
+
+@mock.patch.object(cartography.util, 'run_analysis_job', return_value=None)
+def test_run_analysis_and_ensure_deps(mock_run_analysis_job: mock.MagicMock):
+    # Arrange
+    neo4j_session = mock.MagicMock()
+    common_job_parameters = mock.MagicMock()
+
+    # This arg doesn't matter for this test
+    requested_syncs = {
+        'ec2:instance',
+        'iam',
+        'resourcegroupstaggingapi'
+    }
+
+    # Act
+    ec2_asset_exposure_requirements = {
+        'ec2:instance',
+        'ec2:security_group',
+        'ec2:load_balancer',
+        'ec2:load_balancer_v2',
+    }
+    run_analysis_and_ensure_deps(
+        'aws_ec2_asset_exposure.json',
+        ec2_asset_exposure_requirements,
+        requested_syncs,
+        common_job_parameters,
+        neo4j_session,
+    )
+
+    # Assert that the analysis job was not called because the requested sync reqs aren't met
+    mock_run_analysis_job.assert_not_called()
+
+
+@mock.patch.object(cartography.util, 'run_analysis_job', return_value=None)
+def test_run_analysis_and_ensure_deps_no_requirements(mock_run_analysis_job: mock.MagicMock):
+    # Arrange
+    neo4j_session = mock.MagicMock()
+    common_job_parameters = mock.MagicMock()
+
+    # This arg doesn't matter for this test
+    requested_syncs = {
+        'ec2:instance',
+        'iam',
+        'resourcegroupstaggingapi'
+    }
+
+    # Act
+    run_analysis_and_ensure_deps(
+        'aws_foreign_accounts.json',
+        set(),  # This job has no requirements
+        requested_syncs,
+        common_job_parameters,
+        neo4j_session,
+    )
+
+    # Assert
+    mock_run_analysis_job.assert_called_once_with(
+        'aws_foreign_accounts.json',
+        neo4j_session,
+        common_job_parameters,
+    )


### PR DESCRIPTION
AWS analysis jobs now declare what sync resources must have succeeded before they are allowed to run. This ensures that we don't run analysis on partial or incorrect graph data.