### PR TITLE
Fix #1140: Ensure AWS cleanup jobs are account specific

### DIFF
--- a/cartography/data/jobs/cleanup/aws_import_ec2_key_pairs_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_ec2_key_pairs_cleanup.json
@@ -1,18 +1,20 @@
 {
-  "statements": [{
-    "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(n:EC2KeyPair) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:EC2Instance)<-[r:SSH_LOGIN_TO]-(:EC2KeyPair) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:AWSAccount{id: $AWS_ID})-[r:RESOURCE]->(:EC2KeyPair) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
-    "iterative": true,
-    "iterationsize": 100
-  }],
+  "statements": [
+    {
+      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(n:EC2KeyPair) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(:EC2Instance)<-[r:SSH_LOGIN_TO]-(:EC2KeyPair) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[r:RESOURCE]->(:EC2KeyPair) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100
+    }
+  ],
   "name": "cleanup EC2KeyPair"
 }

--- a/cartography/data/jobs/cleanup/aws_import_elastic_ip_addresses_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_elastic_ip_addresses_cleanup.json
@@ -11,12 +11,12 @@
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:ElasticIpAddress)<-[r:ELASTIC_IP_ADDRESS]-(:EC2Instance) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "query": "MATCH (:ElasticIpAddress)<-[r:ELASTIC_IP_ADDRESS]-(:EC2Instance)<-[:RESOURCE]-(:AWSAccount{id: $AWS_ID}) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:ElasticIpAddress)<-[r:ELASTIC_IP_ADDRESS]-(:NetworkInterface) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "query": "MATCH (:ElasticIpAddress)<-[r:ELASTIC_IP_ADDRESS]-(:NetworkInterface)<-[:RESOURCE]-(:AWSAccount{id: $AWS_ID}) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }

--- a/cartography/data/jobs/cleanup/aws_import_sqs_queues_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_sqs_queues_cleanup.json
@@ -6,7 +6,7 @@
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:SQSQueue)-[r:HAS_DEADLETTER_QUEUE]->(:SQSQueue) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(:SQSQueue)-[r:HAS_DEADLETTER_QUEUE]->(:SQSQueue) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Cleanup HAS_DEADLETTER_QUEUE for queues that no longer have a deadletter queue."

--- a/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_tags_cleanup.json
@@ -61,7 +61,7 @@
             "iterationsize": 100
         },
         {
-            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RedshiftCluster) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+            "query": "MATCH (n:AWSTag)<-[:TAGGED]-(:RedshiftCluster)<-[:RESOURCE]-(:AWSAccount{id: $AWS_ID}) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
             "iterative": true,
             "iterationsize": 100
         },

--- a/cartography/data/jobs/cleanup/aws_import_vpc_peering_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_vpc_peering_cleanup.json
@@ -1,43 +1,45 @@
 {
-  "statements": [{
-    "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(:AWSVpc)<-[:ACCEPTER_VPC]-(n:AWSPeeringConnection) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(:AWSVpc)<-[:REQUESTER_VPC]-(n:AWSPeeringConnection) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (n:AWSCidrBlock)<-[:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:AWSCidrBlock)<-[r:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (n:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true}) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:AWSVpc)<-[r:RESOURCE]-(:AWSAccount{foreign: true}) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:AWSVpc)-[r:VPC_PEERING]-(:AWSVpc) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (n:AWSAccount{foreign: true}) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
-    "iterative": true,
-    "iterationsize": 100
-  }],
+  "statements": [
+    {
+      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(:AWSVpc)<-[:ACCEPTER_VPC]-(n:AWSPeeringConnection) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(:AWSVpc)<-[:REQUESTER_VPC]-(n:AWSPeeringConnection) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (n:AWSCidrBlock)<-[:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true, id: $AWS_ID}) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:AWSCidrBlock)<-[r:BLOCK_ASSOCIATION]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true, id: $AWS_ID}) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (n:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true, id: $AWS_ID}) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:AWSVpc)<-[r:RESOURCE]-(:AWSAccount{foreign: true, id: $AWS_ID}) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (:AWSVpc)-[r:VPC_PEERING]-(:AWSVpc)<-[:RESOURCE]-(:AWSAccount{foreign: true, id: $AWS_ID}) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100
+    },
+    {
+      "query": "MATCH (n:AWSAccount{foreign: true, id: $AWS_ID}) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100
+    }
+  ],
   "name": "cleanup AWS VPC information"
 }


### PR DESCRIPTION
made AWS cleanup jobs account specific
Issue 
**All cleanup jobs need to be account specific**
#1140 