### PR TITLE
fix OktaUserFactor cleanup okta_import_cleanup.json

### DIFF
--- a/cartography/data/jobs/cleanup/okta_import_cleanup.json
+++ b/cartography/data/jobs/cleanup/okta_import_cleanup.json
@@ -1,7 +1,7 @@
 {
   "statements": [
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaUser)-[:FACTOR]->(n:OktaUserFactor) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaUser)-[:FACTOR]->(n:OktaUserFactor) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale OktaUserFactor nodes"


### PR DESCRIPTION
This cleanup job for OktaUserFactor uses the same label `n` twice, once for OktaUser and again for OktaUserFactor in the same query.

Neo4j will not error, but the query does not return anything, so cleanups will not happen.

```
MATCH (:OktaOrganization)-[:RESOURCE]->(n:OktaUser)-[:FACTOR]->(n:OktaUserFactor) return n
```

This PR fixes it to just `(n:OktaUserFactor)`