### PR TITLE
Fixes #1161 optional Instance.PrivateDnsName

### DIFF
--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -127,7 +127,7 @@ def transform_ec2_instances(reservations: List[Dict[str, Any]], region: str, cur
                         'Status': network_interface['Status'],
                         'MacAddress': network_interface['MacAddress'],
                         'Description': network_interface['Description'],
-                        'PrivateDnsName': network_interface['PrivateDnsName'],
+                        'PrivateDnsName': network_interface.get('PrivateDnsName'),
                         'PrivateIpAddress': network_interface['PrivateIpAddress'],
                         'InstanceId': instance_id,
                         'SubnetId': subnet_id,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.79.0rc1'
+__version__ = '0.79.0rc2'
 
 
 setup(


### PR DESCRIPTION
Fixes #1161 Because the PrivateDnsName property is optional sometimes.