### PR TITLE
AWS SecretsManager: add `arn` field

### DIFF
--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -36,8 +36,9 @@ def load_secrets(
     UNWIND $Secrets as secret
         MERGE (s:SecretsManagerSecret{id: secret.ARN})
         ON CREATE SET s.firstseen = timestamp()
-        SET s.name = secret.Name, s.description = secret.Description, s.kms_key_id = secret.KmsKeyId,
-            s.rotation_enabled = secret.RotationEnabled, s.rotation_lambda_arn = secret.RotationLambdaARN,
+        SET s.name = secret.Name, s.arn = secret.ARN, s.description = secret.Description,
+            s.kms_key_id = secret.KmsKeyId, s.rotation_enabled = secret.RotationEnabled,
+            s.rotation_lambda_arn = secret.RotationLambdaARN,
             s.rotation_rules_automatically_after_days = secret.RotationRules.AutomaticallyAfterDays,
             s.last_rotated_date = secret.LastRotatedDate, s.last_changed_date = secret.LastChangedDate,
             s.last_accessed_date = secret.LastAccessedDate, s.deleted_date = secret.DeletedDate,


### PR DESCRIPTION
`SecretsManagerSecrets` should have an `arn` attribute. Currently the secret's ARNs are being used as the `SecretsManagerSecret.id`, but the `arn` key doesn't exist which causes issues when processing permission relationships.

This fixes an issue where a `SecretsManagerSecret` can not be specified as the target of an AWS permission relationship because `get_resource_arns` will return the empty list, because in the status quo a `SecretsManagerSecret` has no `arn`