### PR TITLE
duo: add proxy config

### DIFF
--- a/cartography/intel/duo/__init__.py
+++ b/cartography/intel/duo/__init__.py
@@ -30,6 +30,7 @@ def get_client(config: Config) -> duo_client.Admin:
         skey=config.duo_api_secret,
         host=config.duo_api_hostname,
     )
+    # Duo's library does not automatically respect the HTTP_PROXY env variable
     proxy_url = os.environ.get('HTTP_PROXY')
     if proxy_url:
         proxy_config = urlparse(proxy_url)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.79.1'
+__version__ = '0.79.1.dev1'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.79.1.dev1'
+__version__ = '0.79.2.dev1'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.79.2.dev1'
+__version__ = '0.79.2'
 
 
 setup(


### PR DESCRIPTION
Add the ability to set the duo client's proxy configuration from the standard `HTTP_PROXY` environment variable, if set.