### PR TITLE
Fix index out of range for drift detection returning no results

### DIFF
--- a/cartography/driftdetect/get_states.py
+++ b/cartography/driftdetect/get_states.py
@@ -145,9 +145,10 @@ def get_state(session: neo4j.Session, state: State) -> None:
     logger.debug(f"Updating results for {state.name}")
 
     # The keys will be the same across all items in the returned list
-    state.properties = list(new_results[0].keys())
-    results = []
+    if len(new_results) > 0:
+        state.properties = list(new_results[0].keys())
 
+    results = []
     for record in new_results:
         values = []
         for field in record.values():

--- a/cartography/driftdetect/get_states.py
+++ b/cartography/driftdetect/get_states.py
@@ -145,8 +145,7 @@ def get_state(session: neo4j.Session, state: State) -> None:
     logger.debug(f"Updating results for {state.name}")
 
     # The keys will be the same across all items in the returned list
-    if len(new_results) > 0:
-        state.properties = list(new_results[0].keys())
+    state.properties = list(new_results[0].keys()) if len(new_results) > 0 else []
 
     results = []
     for record in new_results:


### PR DESCRIPTION
It's possible for neo4j sessions `read_transaction` in `get_state` to return an empty list in the drift detection module.

This PR ensures that there are entries before referencing index 0.
```
File "/code/venvs/venv/lib/python3.8/site-packages/cartography/driftdetect/get_states.py", line 123, in get_query_state
    get_state(session, state)
  File "/code/venvs/venv/lib/python3.8/site-packages/cartography/driftdetect/get_states.py", line 148, in get_state
    state.properties = list(new_results[0].keys())
IndexError: list index out of range
```