### PR TITLE
fix: GSuite data only populated on match

### DIFF
--- a/cartography/intel/gsuite/api.py
+++ b/cartography/intel/gsuite/api.py
@@ -130,6 +130,14 @@ def load_gsuite_groups(neo4j_session: neo4j.Session, groups: List[Dict], gsuite_
         UNWIND $GroupData as group
         MERGE (g:GSuiteGroup{id: group.id})
         ON CREATE SET
+        g.group_id = group.id,
+        g.admin_created = group.adminCreated,
+        g.description = group.description,
+        g.direct_members_count = group.directMembersCount,
+        g.email = group.email,
+        g.etag = group.etag,
+        g.kind = group.kind,
+        g.name = group.name,
         g.firstseen = $UpdateTag
         ON MATCH SET
         g.group_id = group.id,
@@ -152,6 +160,31 @@ def load_gsuite_users(neo4j_session: neo4j.Session, users: List[Dict], gsuite_up
         UNWIND $UserData as user
         MERGE (u:GSuiteUser{id: user.id})
         ON CREATE SET
+        u.user_id = user.id,
+        u.agreed_to_terms = user.agreedToTerms,
+        u.archived = user.archived,
+        u.change_password_at_next_login = user.changePasswordAtNextLogin,
+        u.creation_time = user.creationTime,
+        u.customer_id = user.customerId,
+        u.etag = user.etag,
+        u.include_in_global_address_list = user.includeInGlobalAddressList,
+        u.ip_whitelisted = user.ipWhitelisted,
+        u.is_admin = user.isAdmin,
+        u.is_delegated_admin =  user.isDelegatedAdmin,
+        u.is_enforced_in_2_sv = user.isEnforcedIn2Sv,
+        u.is_enrolled_in_2_sv = user.isEnrolledIn2Sv,
+        u.is_mailbox_setup = user.isMailboxSetup,
+        u.kind = user.kind,
+        u.last_login_time = user.lastLoginTime,
+        u.name = user.name.fullName,
+        u.family_name = user.name.familyName,
+        u.given_name = user.name.givenName,
+        u.org_unit_path = user.orgUnitPath,
+        u.primary_email = user.primaryEmail,
+        u.email = user.primaryEmail,
+        u.suspended = user.suspended,
+        u.thumbnail_photo_etag = user.thumbnailPhotoEtag,
+        u.thumbnail_photo_url = user.thumbnailPhotoUrl,
         u.firstseen = $UpdateTag
         ON MATCH SET
         u.user_id = user.id,

--- a/cartography/intel/gsuite/api.py
+++ b/cartography/intel/gsuite/api.py
@@ -130,17 +130,9 @@ def load_gsuite_groups(neo4j_session: neo4j.Session, groups: List[Dict], gsuite_
         UNWIND $GroupData as group
         MERGE (g:GSuiteGroup{id: group.id})
         ON CREATE SET
-        g.group_id = group.id,
-        g.admin_created = group.adminCreated,
-        g.description = group.description,
-        g.direct_members_count = group.directMembersCount,
-        g.email = group.email,
-        g.etag = group.etag,
-        g.kind = group.kind,
-        g.name = group.name,
-        g.firstseen = $UpdateTag
-        ON MATCH SET
-        g.group_id = group.id,
+        g.firstseen = $UpdateTag,
+        g.group_id = group.id
+        SET
         g.admin_created = group.adminCreated,
         g.description = group.description,
         g.direct_members_count = group.directMembersCount,
@@ -161,33 +153,8 @@ def load_gsuite_users(neo4j_session: neo4j.Session, users: List[Dict], gsuite_up
         MERGE (u:GSuiteUser{id: user.id})
         ON CREATE SET
         u.user_id = user.id,
-        u.agreed_to_terms = user.agreedToTerms,
-        u.archived = user.archived,
-        u.change_password_at_next_login = user.changePasswordAtNextLogin,
-        u.creation_time = user.creationTime,
-        u.customer_id = user.customerId,
-        u.etag = user.etag,
-        u.include_in_global_address_list = user.includeInGlobalAddressList,
-        u.ip_whitelisted = user.ipWhitelisted,
-        u.is_admin = user.isAdmin,
-        u.is_delegated_admin =  user.isDelegatedAdmin,
-        u.is_enforced_in_2_sv = user.isEnforcedIn2Sv,
-        u.is_enrolled_in_2_sv = user.isEnrolledIn2Sv,
-        u.is_mailbox_setup = user.isMailboxSetup,
-        u.kind = user.kind,
-        u.last_login_time = user.lastLoginTime,
-        u.name = user.name.fullName,
-        u.family_name = user.name.familyName,
-        u.given_name = user.name.givenName,
-        u.org_unit_path = user.orgUnitPath,
-        u.primary_email = user.primaryEmail,
-        u.email = user.primaryEmail,
-        u.suspended = user.suspended,
-        u.thumbnail_photo_etag = user.thumbnailPhotoEtag,
-        u.thumbnail_photo_url = user.thumbnailPhotoUrl,
         u.firstseen = $UpdateTag
-        ON MATCH SET
-        u.user_id = user.id,
+        SET
         u.agreed_to_terms = user.agreedToTerms,
         u.archived = user.archived,
         u.change_password_at_next_login = user.changePasswordAtNextLogin,
@@ -226,7 +193,7 @@ def load_gsuite_members(neo4j_session: neo4j.Session, group: Dict, members: List
         MERGE (user)-[r:MEMBER_GSUITE_GROUP]->(group)
         ON CREATE SET
         r.firstseen = $UpdateTag
-        ON MATCH SET
+        SET
         r.lastupdated = $UpdateTag
     """
     neo4j_session.run(
@@ -241,7 +208,7 @@ def load_gsuite_members(neo4j_session: neo4j.Session, group: Dict, members: List
         MERGE (group_1)-[r:MEMBER_GSUITE_GROUP]->(group_2)
         ON CREATE SET
         r.firstseen = $UpdateTag
-        ON MATCH SET
+        SET
         r.lastupdated = $UpdateTag
     """
     neo4j_session.run(membership_qry, MemberData=members, GroupID=group.get("id"), UpdateTag=gsuite_update_tag)

--- a/tests/unit/cartography/intel/aws/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/aws/test_permission_relationships.py
@@ -36,7 +36,7 @@ def test_not_action_statement():
         "action": [
             "*",
         ],
-        "notaction":[
+        "notaction": [
             "S3:GetObject",
         ],
         "resource": [
@@ -209,7 +209,7 @@ def test_non_matching_notresource():
             "action": [
                 "s3:Get*",
             ],
-            "resource":["*"],
+            "resource": ["*"],
             "notresource": [
                 "arn:aws:s3:::nottest",
             ],
@@ -417,7 +417,7 @@ def test_single_comma():
             "action": [
                 "s3:?et*",
             ],
-            "resource":["arn:aws:s3:::testbucke?"],
+            "resource": ["arn:aws:s3:::testbucke?"],
             "effect": "Allow",
         },
     ]
@@ -432,7 +432,7 @@ def test_multiple_comma():
             "action": [
                 "s3:?et*",
             ],
-            "resource":["arn:aws:s3:::????bucket"],
+            "resource": ["arn:aws:s3:::????bucket"],
             "effect": "Allow",
         },
     ]

--- a/tests/unit/cartography/intel/gsuite/test_api.py
+++ b/tests/unit/cartography/intel/gsuite/test_api.py
@@ -107,6 +107,14 @@ def test_load_gsuite_groups():
         UNWIND $GroupData as group
         MERGE (g:GSuiteGroup{id: group.id})
         ON CREATE SET
+        g.group_id = group.id,
+        g.admin_created = group.adminCreated,
+        g.description = group.description,
+        g.direct_members_count = group.directMembersCount,
+        g.email = group.email,
+        g.etag = group.etag,
+        g.kind = group.kind,
+        g.name = group.name,
         g.firstseen = $UpdateTag
         ON MATCH SET
         g.group_id = group.id,
@@ -135,6 +143,31 @@ def test_load_gsuite_users():
         UNWIND $UserData as user
         MERGE (u:GSuiteUser{id: user.id})
         ON CREATE SET
+        u.user_id = user.id,
+        u.agreed_to_terms = user.agreedToTerms,
+        u.archived = user.archived,
+        u.change_password_at_next_login = user.changePasswordAtNextLogin,
+        u.creation_time = user.creationTime,
+        u.customer_id = user.customerId,
+        u.etag = user.etag,
+        u.include_in_global_address_list = user.includeInGlobalAddressList,
+        u.ip_whitelisted = user.ipWhitelisted,
+        u.is_admin = user.isAdmin,
+        u.is_delegated_admin =  user.isDelegatedAdmin,
+        u.is_enforced_in_2_sv = user.isEnforcedIn2Sv,
+        u.is_enrolled_in_2_sv = user.isEnrolledIn2Sv,
+        u.is_mailbox_setup = user.isMailboxSetup,
+        u.kind = user.kind,
+        u.last_login_time = user.lastLoginTime,
+        u.name = user.name.fullName,
+        u.family_name = user.name.familyName,
+        u.given_name = user.name.givenName,
+        u.org_unit_path = user.orgUnitPath,
+        u.primary_email = user.primaryEmail,
+        u.email = user.primaryEmail,
+        u.suspended = user.suspended,
+        u.thumbnail_photo_etag = user.thumbnailPhotoEtag,
+        u.thumbnail_photo_url = user.thumbnailPhotoUrl,
         u.firstseen = $UpdateTag
         ON MATCH SET
         u.user_id = user.id,

--- a/tests/unit/cartography/intel/gsuite/test_api.py
+++ b/tests/unit/cartography/intel/gsuite/test_api.py
@@ -107,9 +107,9 @@ def test_load_gsuite_groups():
         UNWIND $GroupData as group
         MERGE (g:GSuiteGroup{id: group.id})
         ON CREATE SET
-        g.firstseen = $UpdateTag
+        g.firstseen = $UpdateTag,
+        g.group_id = group.id
         SET
-        g.group_id = group.id,
         g.admin_created = group.adminCreated,
         g.description = group.description,
         g.direct_members_count = group.directMembersCount,
@@ -135,9 +135,9 @@ def test_load_gsuite_users():
         UNWIND $UserData as user
         MERGE (u:GSuiteUser{id: user.id})
         ON CREATE SET
-        u.firstseen = $UpdateTag
+        u.firstseen = $UpdateTag,
+        u.user_id = user.id
         SET
-        u.user_id = user.id,
         u.agreed_to_terms = user.agreedToTerms,
         u.archived = user.archived,
         u.change_password_at_next_login = user.changePasswordAtNextLogin,

--- a/tests/unit/cartography/intel/gsuite/test_api.py
+++ b/tests/unit/cartography/intel/gsuite/test_api.py
@@ -135,8 +135,8 @@ def test_load_gsuite_users():
         UNWIND $UserData as user
         MERGE (u:GSuiteUser{id: user.id})
         ON CREATE SET
-        u.firstseen = $UpdateTag,
-        u.user_id = user.id
+        u.user_id = user.id,
+        u.firstseen = $UpdateTag
         SET
         u.agreed_to_terms = user.agreedToTerms,
         u.archived = user.archived,

--- a/tests/unit/cartography/intel/gsuite/test_api.py
+++ b/tests/unit/cartography/intel/gsuite/test_api.py
@@ -107,16 +107,8 @@ def test_load_gsuite_groups():
         UNWIND $GroupData as group
         MERGE (g:GSuiteGroup{id: group.id})
         ON CREATE SET
-        g.group_id = group.id,
-        g.admin_created = group.adminCreated,
-        g.description = group.description,
-        g.direct_members_count = group.directMembersCount,
-        g.email = group.email,
-        g.etag = group.etag,
-        g.kind = group.kind,
-        g.name = group.name,
         g.firstseen = $UpdateTag
-        ON MATCH SET
+        SET
         g.group_id = group.id,
         g.admin_created = group.adminCreated,
         g.description = group.description,
@@ -143,33 +135,8 @@ def test_load_gsuite_users():
         UNWIND $UserData as user
         MERGE (u:GSuiteUser{id: user.id})
         ON CREATE SET
-        u.user_id = user.id,
-        u.agreed_to_terms = user.agreedToTerms,
-        u.archived = user.archived,
-        u.change_password_at_next_login = user.changePasswordAtNextLogin,
-        u.creation_time = user.creationTime,
-        u.customer_id = user.customerId,
-        u.etag = user.etag,
-        u.include_in_global_address_list = user.includeInGlobalAddressList,
-        u.ip_whitelisted = user.ipWhitelisted,
-        u.is_admin = user.isAdmin,
-        u.is_delegated_admin =  user.isDelegatedAdmin,
-        u.is_enforced_in_2_sv = user.isEnforcedIn2Sv,
-        u.is_enrolled_in_2_sv = user.isEnrolledIn2Sv,
-        u.is_mailbox_setup = user.isMailboxSetup,
-        u.kind = user.kind,
-        u.last_login_time = user.lastLoginTime,
-        u.name = user.name.fullName,
-        u.family_name = user.name.familyName,
-        u.given_name = user.name.givenName,
-        u.org_unit_path = user.orgUnitPath,
-        u.primary_email = user.primaryEmail,
-        u.email = user.primaryEmail,
-        u.suspended = user.suspended,
-        u.thumbnail_photo_etag = user.thumbnailPhotoEtag,
-        u.thumbnail_photo_url = user.thumbnailPhotoUrl,
         u.firstseen = $UpdateTag
-        ON MATCH SET
+        SET
         u.user_id = user.id,
         u.agreed_to_terms = user.agreedToTerms,
         u.archived = user.archived,


### PR DESCRIPTION
On Gsuite Intel, User and Group properties are only populated on existing node (ON MATCH).
On first run only ID is populated.

This PR fix this issue.