### PR TITLE
github: resaise exceptions

### DIFF
--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -114,22 +114,26 @@ def fetch_all(
     retry = 0
 
     while has_next_page:
+        exc: Any = None
         try:
             resp = fetch_page(token, api_url, organization, query, cursor, **kwargs)
             retry = 0
-        except requests.exceptions.Timeout:
+        except requests.exceptions.Timeout as err:
             retry += 1
-        except requests.exceptions.HTTPError:
+            exc = err
+        except requests.exceptions.HTTPError as err:
             retry += 1
-        except requests.exceptions.ChunkedEncodingError:
+            exc = err
+        except requests.exceptions.ChunkedEncodingError as err:
             retry += 1
+            exc = err
 
         if retry >= retries:
             logger.error(
                 f"GitHub: Could not retrieve page of resource `{resource_type}` due to HTTP error.",
                 exc_info=True,
             )
-            raise
+            raise exc
         elif retry > 0:
             time.sleep(1 * retry)
             continue

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -1,0 +1,24 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+from requests.exceptions import HTTPError
+
+from cartography.intel.github.util import fetch_all
+
+
+@patch('cartography.intel.github.util.fetch_page')
+def test_fetch_all_handles_retries(mock_fetch_page: Mock) -> None:
+    '''
+    Ensures that fetch_all re-reaises the same exceptions when exceeding retry limit
+    '''
+    # Arrange
+    exception = HTTPError
+    mock_fetch_page.side_effect = exception('my-error')
+    retries = 3
+    # Act
+    with pytest.raises(exception) as excinfo:
+        fetch_all('my-token', 'my-api_url', 'my-org', 'my-query', 'my-resource', retries=retries)
+    # Assert
+    mock_fetch_page.call_count == retries
+    assert 'my-error' in str(excinfo.value)


### PR DESCRIPTION
Fix a bug where the exception after github retries was lost. Before we would just see:

```
...
RuntimeError: No active exception to reraise
```

But now the original exception is properly re-eaised.

### Testing

Added a unit test