### PR TITLE
fix: looks like a typo - network interfaces with attached elb wont lo…

### DIFF
--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -54,7 +54,7 @@ def transform_network_interface_data(data_list: List[Dict[str, Any]], region: st
         elb_v2_id = None
         elb_match = re.match(r'^ELB (?:net|app)/([^\/]+)\/(.*)', network_interface.get('Description', ''))
         if elb_match:
-            elb_v1_id = f'{elb_match[1]}-{elb_match[2]}.elb.{region}.amazonaws.com',
+            elb_v1_id = f'{elb_match[1]}-{elb_match[2]}.elb.{region}.amazonaws.com'
         else:
             elb_match = re.match(r'^ELB (.*)', network_interface.get('Description', ''))
             if elb_match:


### PR DESCRIPTION
When gathering network interfaces that have an attached ELB, neo4j ingestion fails due to this typo which turns the elbv1 variable into a tuple instead of a string.

reopening PR to fix CLA check