### PR TITLE
Add UnauthorizedOperation to skippable AWS errors

### DIFF
--- a/cartography/util.py
+++ b/cartography/util.py
@@ -238,6 +238,7 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
         'AccessDeniedException',
         'AuthFailure',
         'InvalidClientTokenId',
+        'UnauthorizedOperation',
         'UnrecognizedClientException',
         'InternalServerErrorException',
     ]


### PR DESCRIPTION
See https://github.com/lyft/cartography/issues/1252.