### PR TITLE
Fix docker-compose, Dockerfile, and container documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,25 @@ WORKDIR /srv/cartography
 
 ENV PATH=/venv/bin:$PATH
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.8-dev python3-pip python3-setuptools openssl libssl-dev gcc pkg-config libffi-dev libxml2-dev libxmlsec1-dev curl && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3.8-dev python3-pip python3-setuptools openssl libssl-dev gcc pkg-config libffi-dev libxml2-dev libxmlsec1-dev curl make && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Installs pip supported by python3.8
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3.8 get-pip.py
 
+# Create cartography user so that we can give it ownership of the directory later for unit&integ tests
+RUN groupadd cartography && \
+    useradd -s /bin/bash -d /home/cartography -m -g cartography cartography
+
 # Installs python dependencies
 COPY setup.py test-requirements.txt ./
 RUN pip install -e . && \
-    pip install -r test-requirements.txt
+    pip install -r test-requirements.txt && \
+    # Grant write access to the directory for unit and integration test coverage files
+    chmod -R a+w /srv/cartography
 
-# Install cartography
-COPY . /srv/cartography
+# Install cartography, setting the owner so that tests work
+COPY --chown=cartography:cartography . /srv/cartography
 
-RUN groupadd cartography && \
-    useradd -s /bin/bash -d /home/cartography -m -g cartography cartography
 USER cartography

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,9 @@ services:
         timeout: 10s
         retries: 10
   cartography:
-    image: ghcr.io/lyft/cartography
+    # As seen in docs, we build with `cd /path/to/cartography && docker build -t lyft/cartography .`
+    # and then run with `docker-compose up -d`.
+    image: lyft/cartography
     # EXAMPLE: Our ENTRYPOINT is cartography, running specific command to sync AWS
     # command: ["-v", "--neo4j-uri=bolt://neo4j:7687", "--aws-sync-all-profiles"]
     user: cartography
@@ -44,3 +46,6 @@ services:
       - neo4j
     volumes:
       - ~/.aws:/cartography/.aws/
+    environment:
+      # Point to the neo4j service defined in this docker-compose file.
+      - NEO4J_URL=bolt://cartography-neo4j-1:7687

--- a/docs/root/dev/testing-with-docker.md
+++ b/docs/root/dev/testing-with-docker.md
@@ -7,12 +7,12 @@ without needing to install Python and without needing to install Neo4j.
 ### Usage
 
 1. Build the cartography Dockerfile. This creates a Docker image with all the
-Python dependencies needed by cartography and installs cartography itself to 
+Python dependencies needed by cartography and installs cartography itself to
 the image.
 
     ```bash
     # Make sure you don't forget the '.' (represents current directory)
-    docker build -t lyft/cartography . 
+    docker build -t lyft/cartography .
     ```
 
 1. Start up the docker-compose dev environment

--- a/docs/root/dev/testing-with-docker.md
+++ b/docs/root/dev/testing-with-docker.md
@@ -1,8 +1,8 @@
 # Testing with docker
 
 ## Using the included docker-compose support
-docker-compose lets you run cartography unit and integration tests without
-needing to install Python and without needing to install Neo4j.
+docker-compose lets you run cartography (and its unit and integration tests)
+without needing to install Python and without needing to install Neo4j.
 
 ### Usage
 

--- a/docs/root/dev/testing-with-docker.md
+++ b/docs/root/dev/testing-with-docker.md
@@ -11,7 +11,7 @@ Python dependencies needed by cartography and installs cartography itself to
 the image.
 
     ```bash
-    # Make sure you don't forget the '.' (represent's current directory)
+    # Make sure you don't forget the '.' (represents current directory)
     docker build -t lyft/cartography . 
     ```
 

--- a/docs/root/dev/testing-with-docker.md
+++ b/docs/root/dev/testing-with-docker.md
@@ -1,14 +1,36 @@
 # Testing with docker
 
 ## Using the included docker-compose support
+docker-compose lets you run cartography unit and integration tests without
+needing to install Python and without needing to install Neo4j.
 
 ### Usage
 
-```bash
-docker build -t lyft/cartography
-docker-compose up -d
-docker-compose run cartography ...
-```
+1. Build the cartography Dockerfile. This creates a Docker image with all the
+Python dependencies needed by cartography and installs cartography itself to 
+the image.
+
+    ```bash
+    # Make sure you don't forget the '.' (represent's current directory)
+    docker build -t lyft/cartography . 
+    ```
+
+1. Start up the docker-compose dev environment
+
+    ```bash
+    docker-compose up -d
+    ```
+
+1. Run the tests
+    ```bash
+    docker-compose run cartography make test
+    # Alternatively replace `make test` with `make test_lint`,
+    # `make test_unit`, or `make test_integration`
+    ```
+
+Now when you make changes to the code, you can follow the steps above again to
+rebuild the container and re-run the automated tests. You can also run the full
+cartography sync by following the ["Notes"](#notes) section of this document.
 
 ### Configuration
 


### PR DESCRIPTION
Docker-compose fixes
- correctly points cartography container's NEO4J_URL at the Neo4j container instead of localhost. This was not working at all before.
- uses the cartography image built locally instead of the one in ghcr. Per testing-with-docker.md, this is the intended path.

Dockerfile fixes
- Updates Dockerfile permissions so that the main test user has permissions to write to the .coverage file for unit and integration tests.

Documentation fixes
- Updates docker instructions to clarify that the main dockerfile is meant for testing purposes.

