### PR TITLE
ec2: optional PrivateDnsName

### DIFF
--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -69,7 +69,7 @@ def transform_network_interface_data(data_list: List[Dict[str, Any]], region: st
                 'InstanceId': network_interface.get('Attachment', {}).get('InstanceId'),
                 'InterfaceType': network_interface['InterfaceType'],
                 'MacAddress': network_interface['MacAddress'],
-                'PrivateDnsName': network_interface['PrivateDnsName'],
+                'PrivateDnsName': network_interface.get('PrivateDnsName'),
                 'PrivateIpAddress': network_interface['PrivateIpAddress'],
                 'PublicIp': network_interface.get('Association', {}).get('PublicIp'),
                 'RequesterId': network_interface.get('RequesterId'),


### PR DESCRIPTION
In describe-netowrk-interfaces, PrivateDnsName is sometimes optional, like in  describe-instances' version of the object
https://github.com/lyft/cartography/blob/1831f76bfb86f57614f1572d6a465292b509a243/cartography/intel/aws/ec2/instances.py#L130


error
```
  File "<redacted>/lib/python3.8/site-packages/cartography/intel/aws/ec2/network_interfaces.py", line 72, in transform_network_interface_data
    'PrivateDnsName': network_interface['PrivateDnsName'],
KeyError: 'PrivateDnsName'
```