### PR TITLE
Fix #1198: handle github ratelimit

### DIFF
--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -23,7 +23,7 @@ GITHUB_ORG_REPOS_PAGINATED_GRAPHQL = """
         {
             url
             login
-            repositories(first: 100, after: $cursor){
+            repositories(first: 50, after: $cursor){
                 pageInfo{
                     endCursor
                     hasNextPage
@@ -59,7 +59,7 @@ GITHUB_ORG_REPOS_PAGINATED_GRAPHQL = """
                         login
                         __typename
                     }
-                    collaborators(affiliation: OUTSIDE, first: 100) {
+                    collaborators(affiliation: OUTSIDE, first: 50) {
                         edges {
                             permission
                         }

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -36,7 +36,6 @@ def handle_rate_limit_sleep(token: str) -> None:
     rate_limit_obj = response_json['resources']['graphql']
     remaining = rate_limit_obj['remaining']
     threshold = _GRAPHQL_RATE_LIMIT_REMAINING_THREASHOLD
-    print(remaining)
     if remaining > threshold:
         return
     reset_at = datetime.fromtimestamp(rate_limit_obj['reset'], tz=tz.utc)

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -145,6 +145,8 @@ def fetch_all(
     while has_next_page:
         exc: Any = None
         try:
+            # In the future, we may use also use the rateLimit object from the graphql response.
+            # But we still need at least one call to the REST endpoint in case the graphql remaining is already 0
             handle_rate_limit_sleep(token)
             resp = fetch_page(token, api_url, organization, query, cursor, **kwargs)
             retry = 0

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -17,7 +17,7 @@ import requests
 logger = logging.getLogger(__name__)
 # Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
 _TIMEOUT = (60, 60)
-_GRAPHQL_RATE_LIMIT_REMAINING_THREASHOLD = 500
+_GRAPHQL_RATE_LIMIT_REMAINING_THRESHOLD = 500
 
 
 class PaginatedGraphqlData(NamedTuple):
@@ -35,7 +35,7 @@ def handle_rate_limit_sleep(token: str) -> None:
     response_json = response.json()
     rate_limit_obj = response_json['resources']['graphql']
     remaining = rate_limit_obj['remaining']
-    threshold = _GRAPHQL_RATE_LIMIT_REMAINING_THREASHOLD
+    threshold = _GRAPHQL_RATE_LIMIT_REMAINING_THRESHOLD
     if remaining > threshold:
         return
     reset_at = datetime.fromtimestamp(rate_limit_obj['reset'], tz=tz.utc)

--- a/tests/data/github/rate_limit.py
+++ b/tests/data/github/rate_limit.py
@@ -5,35 +5,35 @@ RATE_LIMIT_RESPONSE_JSON = {
             "remaining": 60,
             "reset": 1696988282,
             "used": 0,
-            "resource": "core"
+            "resource": "core",
         },
         "graphql": {
             "limit": 0,
             "remaining": 0,
             "reset": 1696987997,
             "used": 0,
-            "resource": "graphql"
+            "resource": "graphql",
         },
         "integration_manifest": {
             "limit": 5000,
             "remaining": 5000,
             "reset": 1696988282,
             "used": 0,
-            "resource": "integration_manifest"
+            "resource": "integration_manifest",
         },
         "search": {
             "limit": 10,
             "remaining": 10,
             "reset": 1696984742,
             "used": 0,
-            "resource": "search"
-        }
+            "resource": "search",
+        },
     },
     "rate": {
         "limit": 60,
         "remaining": 60,
         "reset": 1696988282,
         "used": 0,
-        "resource": "core"
-    }
+        "resource": "core",
+    },
 }

--- a/tests/data/github/rate_limit.py
+++ b/tests/data/github/rate_limit.py
@@ -1,0 +1,39 @@
+RATE_LIMIT_RESPONSE_JSON = {
+    "resources": {
+        "core": {
+            "limit": 60,
+            "remaining": 60,
+            "reset": 1696988282,
+            "used": 0,
+            "resource": "core"
+        },
+        "graphql": {
+            "limit": 0,
+            "remaining": 0,
+            "reset": 1696987997,
+            "used": 0,
+            "resource": "graphql"
+        },
+        "integration_manifest": {
+            "limit": 5000,
+            "remaining": 5000,
+            "reset": 1696988282,
+            "used": 0,
+            "resource": "integration_manifest"
+        },
+        "search": {
+            "limit": 10,
+            "remaining": 10,
+            "reset": 1696984742,
+            "used": 0,
+            "resource": "search"
+        }
+    },
+    "rate": {
+        "limit": 60,
+        "remaining": 60,
+        "reset": 1696988282,
+        "used": 0,
+        "resource": "core"
+    }
+}

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 from requests.exceptions import HTTPError
 
-from cartography.intel.github.util import _GRAPHQL_RATE_LIMIT_REMAINING_THREASHOLD
+from cartography.intel.github.util import _GRAPHQL_RATE_LIMIT_REMAINING_THRESHOLD
 from cartography.intel.github.util import fetch_all
 from cartography.intel.github.util import handle_rate_limit_sleep
 from tests.data.github.rate_limit import RATE_LIMIT_RESPONSE_JSON
@@ -59,12 +59,12 @@ def test_handle_rate_limit_sleep(
 
     # above threoshold
     resp_0 = deepcopy(RATE_LIMIT_RESPONSE_JSON)
-    resp_0['resources']['graphql']['remaining'] = _GRAPHQL_RATE_LIMIT_REMAINING_THREASHOLD + 1
+    resp_0['resources']['graphql']['remaining'] = _GRAPHQL_RATE_LIMIT_REMAINING_THRESHOLD + 1
     resp_0['resources']['graphql']['reset'] = reset
 
     # below threhold
     resp_1 = deepcopy(RATE_LIMIT_RESPONSE_JSON)
-    resp_1['resources']['graphql']['remaining'] = _GRAPHQL_RATE_LIMIT_REMAINING_THREASHOLD - 1
+    resp_1['resources']['graphql']['remaining'] = _GRAPHQL_RATE_LIMIT_REMAINING_THRESHOLD - 1
     resp_1['resources']['graphql']['reset'] = reset
 
     mock_requests_get.side_effect = [

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -1,14 +1,26 @@
+import typing
+from copy import deepcopy
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone as tz
 from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
 from requests.exceptions import HTTPError
 
+from cartography.intel.github.util import _GRAPHQL_RATE_LIMIT_REMAINING_THREASHOLD
 from cartography.intel.github.util import fetch_all
+from cartography.intel.github.util import handle_rate_limit_sleep
+from tests.data.github.rate_limit import RATE_LIMIT_RESPONSE_JSON
 
 
+@patch('cartography.intel.github.util.handle_rate_limit_sleep')
 @patch('cartography.intel.github.util.fetch_page')
-def test_fetch_all_handles_retries(mock_fetch_page: Mock) -> None:
+def test_fetch_all_handles_retries(
+    mock_fetch_page: Mock,
+    mock_handle_rate_limit_sleep: Mock,
+) -> None:
     '''
     Ensures that fetch_all re-reaises the same exceptions when exceeding retry limit
     '''
@@ -20,5 +32,59 @@ def test_fetch_all_handles_retries(mock_fetch_page: Mock) -> None:
     with pytest.raises(exception) as excinfo:
         fetch_all('my-token', 'my-api_url', 'my-org', 'my-query', 'my-resource', retries=retries)
     # Assert
-    mock_fetch_page.call_count == retries
+    assert mock_handle_rate_limit_sleep.call_count == retries
+    assert mock_fetch_page.call_count == retries
     assert 'my-error' in str(excinfo.value)
+
+
+@typing.no_type_check
+@patch('cartography.intel.github.util.time.sleep')
+@patch('cartography.intel.github.util.datetime')
+@patch('cartography.intel.github.util.requests.get')
+def test_handle_rate_limit_sleep(
+    mock_requests_get: Mock,
+    mock_datetime: Mock,
+    mock_sleep: Mock,
+) -> None:
+    '''
+    Ensure we sleep to avoid the rate limit
+    '''
+    # Arrange
+    mock_datetime.fromtimestamp = datetime.fromtimestamp
+    now = datetime(year=2040, month=1, day=1, hour=19, minute=0, second=0, tzinfo=tz.utc)
+    mock_datetime.now = Mock(return_value=now)
+    reset = (now + timedelta(minutes=47)).timestamp()
+    # sleep for one extra minute for safety
+    expected_sleep_seconds = timedelta(minutes=48).seconds
+
+    # above threoshold
+    resp_0 = deepcopy(RATE_LIMIT_RESPONSE_JSON)
+    resp_0['resources']['graphql']['remaining'] = _GRAPHQL_RATE_LIMIT_REMAINING_THREASHOLD + 1
+    resp_0['resources']['graphql']['reset'] = reset
+
+    # below threhold
+    resp_1 = deepcopy(RATE_LIMIT_RESPONSE_JSON)
+    resp_1['resources']['graphql']['remaining'] = _GRAPHQL_RATE_LIMIT_REMAINING_THREASHOLD - 1
+    resp_1['resources']['graphql']['reset'] = reset
+
+    mock_requests_get.side_effect = [
+        Mock(json=Mock(return_value=resp_0)),
+        Mock(json=Mock(return_value=resp_1)),
+    ]
+
+    # Act
+    handle_rate_limit_sleep('my-token')
+    # Assert
+    mock_datetime.now.assert_not_called()
+    mock_sleep.assert_not_called()
+
+    # reset mocks
+    mock_datetime.reset_mock()
+    mock_sleep.reset_mock()
+
+    # Act
+    # mock_requests_get.return_value = Mock(json=Mock(return_value=resp_1))
+    handle_rate_limit_sleep('my-token')
+    # Assert
+    mock_datetime.now.assert_called_once_with(tz.utc)
+    mock_sleep.assert_called_once_with(expected_sleep_seconds)

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -57,12 +57,12 @@ def test_handle_rate_limit_sleep(
     # sleep for one extra minute for safety
     expected_sleep_seconds = timedelta(minutes=48).seconds
 
-    # above threoshold
+    # above threshold
     resp_0 = deepcopy(RATE_LIMIT_RESPONSE_JSON)
     resp_0['resources']['graphql']['remaining'] = _GRAPHQL_RATE_LIMIT_REMAINING_THRESHOLD + 1
     resp_0['resources']['graphql']['reset'] = reset
 
-    # below threhold
+    # below threshold
     resp_1 = deepcopy(RATE_LIMIT_RESPONSE_JSON)
     resp_1['resources']['graphql']['remaining'] = _GRAPHQL_RATE_LIMIT_REMAINING_THRESHOLD - 1
     resp_1['resources']['graphql']['reset'] = reset
@@ -83,7 +83,6 @@ def test_handle_rate_limit_sleep(
     mock_sleep.reset_mock()
 
     # Act
-    # mock_requests_get.return_value = Mock(json=Mock(return_value=resp_1))
     handle_rate_limit_sleep('my-token')
     # Assert
     mock_datetime.now.assert_called_once_with(tz.utc)


### PR DESCRIPTION
Github has a requests-per-hour ratelimit that resets per hour.

### Changes

- when the `remaining` is lower than a threshold of `500`, delays github graphql requests until the `reset` time.
- changes the retry mode from constant to exponential backoff
- change the page size of the repos query to `50` from `100`. The github API would very frequently timeout, but is much better now.

### Testing

- added unit tests
- manual testing
