### PR TITLE
LoadBalancerV2 target groups: include port and protocol to EC2Instance

### DIFF
--- a/cartography/intel/aws/ec2/load_balancer_v2s.py
+++ b/cartography/intel/aws/ec2/load_balancer_v2s.py
@@ -159,6 +159,7 @@ def load_load_balancer_v2_target_groups(
     MERGE (elbv2)-[r:EXPOSE]->(instance)
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag
+        r.port = $PORT, r.protocol = $PROTOCOL
     WITH instance
     MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
     MERGE (aa)-[r:RESOURCE]->(instance)
@@ -177,6 +178,8 @@ def load_load_balancer_v2_target_groups(
                 ID=load_balancer_id,
                 INSTANCE_ID=instance,
                 AWS_ACCOUNT_ID=current_aws_account_id,
+                PORT=target_group.get('Port'),
+                PROTOCOL=target_group.get('Protocol'),
                 update_tag=update_tag,
             )
 

--- a/cartography/intel/aws/ec2/load_balancer_v2s.py
+++ b/cartography/intel/aws/ec2/load_balancer_v2s.py
@@ -157,8 +157,9 @@ def load_load_balancer_v2_target_groups(
     ingest_instances = """
     MATCH (elbv2:LoadBalancerV2{id: $ID}), (instance:EC2Instance{instanceid: $INSTANCE_ID})
     MERGE (elbv2)-[r:EXPOSE]->(instance)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = $update_tag
+    ON CREATE SET r.firstseen = timestamp(),
+                  r.target_group_arn = $TARGET_GROUP_ARN
+    SET r.lastupdated = $update_tag,
         r.port = $PORT, r.protocol = $PROTOCOL
     WITH instance
     MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
@@ -178,6 +179,7 @@ def load_load_balancer_v2_target_groups(
                 ID=load_balancer_id,
                 INSTANCE_ID=instance,
                 AWS_ACCOUNT_ID=current_aws_account_id,
+                TARGET_GROUP_ARN=target_group.get('TargetGroupArn'),
                 PORT=target_group.get('Port'),
                 PROTOCOL=target_group.get('Protocol'),
                 update_tag=update_tag,

--- a/cartography/intel/aws/ec2/load_balancer_v2s.py
+++ b/cartography/intel/aws/ec2/load_balancer_v2s.py
@@ -157,10 +157,10 @@ def load_load_balancer_v2_target_groups(
     ingest_instances = """
     MATCH (elbv2:LoadBalancerV2{id: $ID}), (instance:EC2Instance{instanceid: $INSTANCE_ID})
     MERGE (elbv2)-[r:EXPOSE]->(instance)
-    ON CREATE SET r.firstseen = timestamp(),
-                  r.target_group_arn = $TARGET_GROUP_ARN
+    ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $update_tag,
-        r.port = $PORT, r.protocol = $PROTOCOL
+        r.port = $PORT, r.protocol = $PROTOCOL,
+        r.target_group_arn = $TARGET_GROUP_ARN
     WITH instance
     MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
     MERGE (aa)-[r:RESOURCE]->(instance)

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1706,6 +1706,7 @@ Represents an Elastic Load Balancer V2 ([Application Load Balancer](https://docs
         ```
         (LoadBalancerV2)-[EXPOSE]->(EC2Instance)
         ```
+`EXPOSE` relationshiohip also holds the protocol, port and TargetGroupArn the load balancer points to.
 
 - LoadBalancerV2's can be part of EC2SecurityGroups but only if their `type` = "application". NLBs don't have SGs.
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.87.0'
+__version__ = '0.88.0rc1'
 
 
 setup(


### PR DESCRIPTION
AWS api exposes a port and protocol per TargetGroup (see https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_TargetGroup.html)

Using those values to identify which EC2 instances are exposed by which protocols and ports based on LoadBalancer configuration.
