### PR TITLE
Update CVE intel module to use NVD CVE API v2.0

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -336,9 +336,9 @@ class CLI:
         parser.add_argument(
             '--nist-cve-url',
             type=str,
-            default='https://nvd.nist.gov/feeds/json/cve/1.1',
+            default='https://services.nvd.nist.gov/rest/json/cves/2.0/',
             help=(
-                'The base url for the NIST CVE data. Default = https://nvd.nist.gov/feeds/json/cve/1.1'
+                'The base url for the NIST CVE data. Default = https://services.nvd.nist.gov/rest/json/cves/2.0/'
             ),
         )
         parser.add_argument(
@@ -346,6 +346,14 @@ class CLI:
             action='store_true',
             help=(
                 'If set, CVE data will be synced from NIST.'
+            ),
+        )
+        parser.add_argument(
+            '--cve-api-key-env-var',
+            type=str,
+            default=None,
+            help=(
+                'If set, uses the provided NIST NVD API v2.0 key.'
             ),
         )
         parser.add_argument(
@@ -684,6 +692,13 @@ class CLI:
             config.semgrep_app_token = os.environ.get(config.semgrep_app_token_env_var)
         else:
             config.semgrep_app_token = None
+
+        # CVE feed config
+        if config.cve_api_key_env_var:
+            logger.debug(f"Reading NVD CVE API key environment variable {config.cve_api_key_env_var}")
+            config.cve_api_key = os.environ.get(config.cve_api_key_env_var)
+        else:
+            config.cve_api_key = None
 
         # Run cartography
         try:

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -146,6 +146,7 @@ class Config:
         pagerduty_request_timeout=None,
         nist_cve_url=None,
         cve_enabled=False,
+        cve_api_key=None,
         crowdstrike_client_id=None,
         crowdstrike_client_secret=None,
         crowdstrike_api_url=None,
@@ -198,6 +199,7 @@ class Config:
         self.pagerduty_request_timeout = pagerduty_request_timeout
         self.nist_cve_url = nist_cve_url
         self.cve_enabled = cve_enabled
+        self.cve_api_key = cve_api_key
         self.crowdstrike_client_id = crowdstrike_client_id
         self.crowdstrike_client_secret = crowdstrike_client_secret
         self.crowdstrike_api_url = crowdstrike_api_url

--- a/cartography/intel/cve/feed.py
+++ b/cartography/intel/cve/feed.py
@@ -1,16 +1,34 @@
-import gzip
-import json
 import logging
+import time
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from functools import reduce
 from typing import Any
+from typing import cast
 from typing import Dict
 from typing import List
+from typing import Optional
 
 import neo4j
 import requests
 
+from cartography.client.core.tx import load
+from cartography.client.core.tx import read_list_of_values_tx
+from cartography.client.core.tx import read_single_value_tx
+from cartography.models.cve.cve import CVESchema
+from cartography.models.cve.cve_feed import CVEFeedSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+
+MAX_RETRIES = 3
+REQUEST_TIMEOUT = 10
+CVE_FEED_ID = "NIST_NVD"
+BATCH_SIZE_DAYS = 120
+RESULTS_PER_PAGE = 2000
+DEFAULT_SLEEP_TIME = 3.0
+DELAYED_SLEEP_TIME = 6.0
 
 
 @timeit
@@ -20,75 +38,256 @@ def get_cve_sync_metadata(neo4j_session: neo4j.Session) -> List[int]:
     WHERE s.grouptype = "CVE" AND s.syncedtype = "year"
     RETURN s.groupid
     """
-    results = neo4j_session.run(get_cve_years_query)
-    years = []
-    for r in results:
-        years.append(int(r['s.groupid']))
+    results = read_list_of_values_tx(neo4j_session, get_cve_years_query)
+    years = [int(year) for year in results]
     return years
 
 
 @timeit
-def get_cves(nist_cve_url: str, cve_type: str) -> Dict[Any, Any]:
-    url = f"{nist_cve_url}/nvdcve-1.1-{cve_type}.json.gz"
-    with requests.get(url, stream=True) as res:
-        extracted = gzip.decompress(res.content)
-    return json.loads(extracted)
-
-
-def load_cves(neo4j_session: neo4j.Session, data: Dict[str, Any], update_tag: int) -> None:
+def get_last_modified_cve_date(neo4j_session: neo4j.Session) -> str:
+    query = """
+    MATCH (c:CVE) WHERE c.id STARTS WITH "CVE"
+    RETURN DISTINCT datetime(c.last_modified_date) AS last_modified
+    ORDER BY last_modified DESC
+    LIMIT 1
     """
-    Transform and load cve information
+    result = cast(neo4j.time.DateTime, read_single_value_tx(neo4j_session, query)).to_native()
+    return result.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _map_cve_dict(cve_dict: Dict[Any, Any], data: Dict[Any, Any]) -> None:
+    cve_dict["format"] = data["format"]
+    cve_dict["version"] = data["version"]
+    cve_dict["timestamp"] = data["timestamp"]
+    cve_dict["totalResults"] = data["totalResults"]
+    cve_dict["vulnerabilities"] = cve_dict.get("vulnerabilities", []) + data.get(
+        "vulnerabilities", [],
+    )
+    cve_dict["resultsPerPage"] = data["resultsPerPage"]
+    cve_dict["startIndex"] = data["startIndex"]
+
+
+def _call_cves_api(url: str, api_key: str, params: Dict[str, Any]) -> Dict[Any, Any]:
+    totalResults = 0
+    sleep_time = DEFAULT_SLEEP_TIME
+    retries = 0
+    params["startIndex"] = 0
+    params["resultsPerPage"] = RESULTS_PER_PAGE
+    headers = {}
+    headers["Content-Type"] = "application/json"
+    if api_key:
+        headers["apiKey"] = api_key
+    else:
+        sleep_time = DELAYED_SLEEP_TIME  # Sleep for 6 seconds between each request to avoid rate limiting
+        logger.warning(
+            f"No NIST NVD API key provided. Increasing sleep time to {sleep_time}.",
+        )
+    results: Dict[Any, Any] = dict()
+
+    while params["resultsPerPage"] > 0 or params["startIndex"] < totalResults:
+        try:
+            res = requests.get(
+                url, params=params, headers=headers, timeout=REQUEST_TIMEOUT,
+            )
+            res.raise_for_status()
+        except requests.exceptions.HTTPError:
+            logger.error(
+                f"Failed to get CVE data from NIST NVD API {res.status_code} : {res.text}",
+            )
+            retries += 1
+            if retries >= MAX_RETRIES:
+                raise
+            continue
+        data = res.json()
+        _map_cve_dict(results, data)
+        totalResults = data["totalResults"]
+        params["resultsPerPage"] = data["resultsPerPage"]
+        params["startIndex"] += data["resultsPerPage"]
+        retries = 0
+        time.sleep(sleep_time)
+    return results
+
+
+def get_cves_in_batches(
+    nist_cve_url: str,
+    start_date: datetime,
+    end_date: datetime,
+    date_param_names: Dict[str, str],
+    api_key: str,
+) -> Dict[Any, Any]:
+    cves: Dict[Any, Any] = dict()
+    current_start_date: datetime = start_date
+    current_end_date = end_date
+    total_days = (current_end_date - current_start_date).days
+    batch_size = timedelta(days=BATCH_SIZE_DAYS)
+    if total_days < 0:
+        raise ValueError(f"Start date {start_date} must be before end date {end_date}.")
+    if not date_param_names["start"] or not date_param_names["end"]:
+        raise ValueError("Date parameter names 'start' and 'end' must be provided.")
+    while current_start_date < end_date:
+        remaining = current_end_date - current_start_date
+        if remaining > batch_size:
+            current_end_date = current_start_date + batch_size
+        else:
+            current_end_date = (
+                end_date if remaining.days == 0 else current_start_date + remaining
+            )
+        params = {
+            date_param_names["start"]: current_start_date.strftime(
+                "%Y-%m-%dT%H:%M:%S",
+            ),
+            date_param_names["end"]: current_end_date.strftime("%Y-%m-%dT%H:%M:%S"),
+        }
+        logger.info(
+            f"Querying CVE data between {current_start_date} and {current_end_date}",
+        )
+        batch_cves = _call_cves_api(nist_cve_url, api_key, params)
+        _map_cve_dict(cves, batch_cves)
+        current_start_date = current_end_date
+        new_end_date = current_start_date + batch_size
+        if new_end_date > end_date:
+            new_end_date = end_date
+        current_end_date = new_end_date
+    return cves
+
+
+def get_modified_cves(
+    nist_cve_url: str, last_modified_date: str, api_key: str,
+) -> Dict[Any, Any]:
+    cves = dict()
+    end_date = datetime.now(tz=timezone.utc)
+    start_date = datetime.strptime(last_modified_date, "%Y-%m-%dT%H:%M:%S").replace(
+        tzinfo=timezone.utc,
+    )
+    date_param_names = {
+        "start": "lastModStartDate",
+        "end": "lastModEndDate",
+    }
+    cves = get_cves_in_batches(
+        nist_cve_url, start_date, end_date, date_param_names, api_key,
+    )
+    return cves
+
+
+def get_published_cves_per_year(
+    nist_cve_url: str, year: str, api_key: str,
+) -> Dict[Any, Any]:
+    cves = {}
+    start_of_year = datetime.strptime(f"{year}-01-01", "%Y-%m-%d")
+    next_year = int(year) + 1
+    end_of_next_year = datetime.strptime(f"{next_year}-01-01", "%Y-%m-%d")
+    date_param_names = {
+        "start": "pubStartDate",
+        "end": "pubEndDate",
+    }
+    cves = get_cves_in_batches(
+        nist_cve_url, start_of_year, end_of_next_year, date_param_names, api_key,
+    )
+    return cves
+
+
+def _get_primary_metric(metrics: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if metrics is None:
+        return metrics
+    metric = {}
+    for metric in metrics:
+        if metric["type"] == "Primary":
+            return metric
+    return metrics[0]
+
+
+def transform_cves(cve_json: Dict[Any, Any]) -> List[Dict[Any, Any]]:
     """
-    ingestion_cypher_query = """
-    UNWIND $cves AS cve
-        MERGE (c:CVE{id: cve.cve.CVE_data_meta.ID})
-        ON CREATE SET c.id = cve.cve.CVE_data_meta.ID,
-            c.firstseen = timestamp()
-        SET c.assigner = cve.cve.CVE_data_meta.ASSIGNER,
-            c.description_en = cve.cve.parsed_desc.en,
-            c.references = cve.cve.parsed_reference_urls,
-            c.problem_types = cve.cve.parsed_problem_types,
-            c.vector_string = cve.impact.baseMetricV3.cvssV3.vectorString,
-            c.attack_vector = cve.impact.baseMetricV3.cvssV3.attackVector,
-            c.attack_complexity = cve.impact.baseMetricV3.cvssV3.attackComplexity,
-            c.privileges_required = cve.impact.baseMetricV3.cvssV3.privilegesRequired,
-            c.user_interaction = cve.impact.baseMetricV3.cvssV3.userInteraction,
-            c.scope = cve.impact.baseMetricV3.cvssV3.scope,
-            c.confidentiality_impact = cve.impact.baseMetricV3.cvssV3.confidentialityImpact,
-            c.integrity_impact = cve.impact.baseMetricV3.cvssV3.integrityImpact,
-            c.availability_impact = cve.impact.baseMetricV3.cvssV3.availabilityImpact,
-            c.base_score = cve.impact.baseMetricV3.cvssV3.baseScore,
-            c.base_severity = cve.impact.baseMetricV3.cvssV3.baseSeverity,
-            c.exploitability_score = cve.impact.baseMetricV3.exploitabilityScore,
-            c.impact_score = cve.impact.baseMetricV3.impactScore,
-            c.published_date = cve.publishedDate,
-            c.last_modified_date = cve.lastModifiedDate,
-            c.lastupdated = $update_tag
-        WITH c, cve
-        MATCH (v:SpotlightVulnerability{id: cve.vuln_id})
-        MERGE (v)-[hc:HAS_CVE]->(c)
-        ON CREATE SET hc.firstseen = timestamp()
-        SET hc.lastupdated = $update_tag
+    Transform CVE data into a list of dictionaries with only the properties ingested.
+    Also, flattens any nested lists and properties to the main object.
     """
-    for cve in data["CVE_Items"]:
-        parsed_desc = {}
-        for desc in cve['cve']['description'].get('description_data', []):
-            parsed_desc[desc["lang"]] = (desc['value'])
-        cve["cve"]["parsed_desc"] = parsed_desc
+    cves = []
+    for data in cve_json["vulnerabilities"]:
+        try:
+            cve = data["cve"]
+            cve["descriptions_en"] = [
+                description["value"]
+                for description in cve.get("descriptions")
+                if description["lang"] == "en"
+            ]
+            cve["references_urls"] = [url["url"] for url in cve["references"]]
+            if cve.get("weaknesses"):
+                weakness_descriptions = [weakness["description"] for weakness in cve["weaknesses"]]
+                weakness_descriptions = reduce(
+                    lambda x, y: x + y, weakness_descriptions, [],
+                )
+                cve["weaknesses"] = [
+                    description["value"]
+                    for description in weakness_descriptions
+                    if description["lang"] == "en"
+                ]
+            cvss31_metrics = cve.get("metrics", {}).get("cvssMetricV31")
+            cvss31 = _get_primary_metric(cvss31_metrics)
+            if cvss31:
+                cvss31.update(cvss31["cvssData"])
+                cvss31.pop("cvssData")
+                cve["vectorString"] = cvss31["vectorString"]
+                cve["attackVector"] = cvss31["attackVector"]
+                cve["attackComplexity"] = cvss31["attackComplexity"]
+                cve["privilegesRequired"] = cvss31["privilegesRequired"]
+                cve["userInteraction"] = cvss31["userInteraction"]
+                cve["scope"] = cvss31["scope"]
+                cve["confidentialityImpact"] = cvss31["confidentialityImpact"]
+                cve["integrityImpact"] = cvss31["integrityImpact"]
+                cve["availabilityImpact"] = cvss31["availabilityImpact"]
+                cve["baseScore"] = cvss31["baseScore"]
+                cve["baseSeverity"] = cvss31["baseSeverity"]
+                cve["exploitabilityScore"] = cvss31["exploitabilityScore"]
+                cve["impactScore"] = cvss31["impactScore"]
+        except Exception:
+            logger.error("Failed to transform CVE data {data}")
+            raise
+        cves.append(cve)
+    return cves
 
-        parsed_reference_urls = []
-        for reference in cve['cve']['references'].get('reference_data', []):
-            parsed_reference_urls.append(reference['url'])
-        cve["cve"]["parsed_reference_urls"] = parsed_reference_urls
 
-        parsed_problem_types = []
-        for problemtype_data in cve['cve']['problemtype']['problemtype_data']:
-            for problemtype in problemtype_data["description"]:
-                parsed_problem_types.append(problemtype['value'])
-        cve["cve"]["parsed_problem_types"] = parsed_problem_types
+def transform_cve_feed(cve_json: Dict[Any, Any]) -> Dict[str, str]:
+    """
+    Extract version, timestamp, and lastupdated from the feed
+    """
+    feed = {
+        "FEED_ID": CVE_FEED_ID,
+        "format": cve_json["format"],
+        "version": cve_json["version"],
+        "timestamp": cve_json["timestamp"],
+    }
+    return feed
 
-    neo4j_session.run(
-        ingestion_cypher_query,
-        cves=data["CVE_Items"],
-        update_tag=update_tag,
+
+def load_cves(
+    neo4j_session: neo4j.Session,
+    data: List[Dict[str, Any]],
+    feed_id: str,
+    update_tag: int,
+) -> None:
+    """
+    Load CVE's information
+    """
+    logger.info(f"Loading {len(data)} CVEs into the graph.")
+    load(
+        neo4j_session,
+        CVESchema(),
+        data,
+        lastupdated=update_tag,
+        FEED_ID=feed_id,
+    )
+
+
+def load_cve_feed(
+    neo4j_session: neo4j.Session, data: List[Dict[str, Any]], update_tag: int,
+) -> None:
+    """
+    Load CVE feed information
+    """
+    logger.info(f"Loading CVE feed info {data} into the graph...")
+    load(
+        neo4j_session,
+        CVEFeedSchema(),
+        data,
+        lastupdated=update_tag,
     )

--- a/cartography/models/cve/cve.py
+++ b/cartography/models/cve/cve.py
@@ -1,4 +1,3 @@
-
 from dataclasses import dataclass
 
 from cartography.models.core.common import PropertyRef
@@ -10,6 +9,7 @@ from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
+
 
 @dataclass(frozen=True)
 class CVENodeProperties(CartographyNodeProperties):
@@ -36,9 +36,11 @@ class CVENodeProperties(CartographyNodeProperties):
     vuln_status: PropertyRef = PropertyRef('vulnStatus')
     lastupdated: PropertyRef = PropertyRef('lastupdated')
 
+
 @dataclass(frozen=True)
 class CVEtoCVEFeedRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
 
 @dataclass(frozen=True)
 # (:CVE)<-[:RESOURCE]-(:CVEFeed)
@@ -51,9 +53,11 @@ class CVEtoCVEFeedRelSchema(CartographyRelSchema):
     rel_label: str = "RESOURCE"
     properties: CVEtoCVEFeedRelProperties = CVEtoCVEFeedRelProperties()
 
+
 @dataclass(frozen=True)
 class CVEToSpotlightVulnerabilityRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
 
 @dataclass(frozen=True)
 # (:CVE)<-[:HAS_CVE]-(:SpotlightVulnerability)
@@ -65,6 +69,7 @@ class CVEToSpotlightVulnerabilityRel(CartographyRelSchema):
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_CVE"
     properties: CVEToSpotlightVulnerabilityRelProperties = CVEToSpotlightVulnerabilityRelProperties()
+
 
 @dataclass(frozen=True)
 class CVESchema(CartographyNodeSchema):

--- a/cartography/models/cve/cve.py
+++ b/cartography/models/cve/cve.py
@@ -1,0 +1,78 @@
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+@dataclass(frozen=True)
+class CVENodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('id')
+    assigner: PropertyRef = PropertyRef('sourceIdentifier')
+    description: PropertyRef = PropertyRef('descriptions_en')
+    references: PropertyRef = PropertyRef('references_urls')
+    problem_types: PropertyRef = PropertyRef('weaknesses')
+    vector_string: PropertyRef = PropertyRef('vectorString')
+    attack_vector: PropertyRef = PropertyRef('attackVector')
+    attack_complexity: PropertyRef = PropertyRef('attackComplexity')
+    privileges_required: PropertyRef = PropertyRef('privilegesRequired')
+    user_interaction: PropertyRef = PropertyRef('userInteraction')
+    scope: PropertyRef = PropertyRef('scope')
+    confidentiality_impact: PropertyRef = PropertyRef('confidentialityImpact')
+    integrity_impact: PropertyRef = PropertyRef('integrityImpact')
+    availability_impact: PropertyRef = PropertyRef('availabilityImpact')
+    base_score: PropertyRef = PropertyRef('baseScore')
+    base_severity: PropertyRef = PropertyRef('baseSeverity')
+    exploitability_score: PropertyRef = PropertyRef('exploitabilityScore')
+    impact_score: PropertyRef = PropertyRef('impactScore')
+    published_date: PropertyRef = PropertyRef('published')
+    last_modified_date: PropertyRef = PropertyRef('lastModified')
+    vuln_status: PropertyRef = PropertyRef('vulnStatus')
+    lastupdated: PropertyRef = PropertyRef('lastupdated')
+
+@dataclass(frozen=True)
+class CVEtoCVEFeedRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+@dataclass(frozen=True)
+# (:CVE)<-[:RESOURCE]-(:CVEFeed)
+class CVEtoCVEFeedRelSchema(CartographyRelSchema):
+    target_node_label: str = 'CVEFeed'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('FEED_ID', set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: CVEtoCVEFeedRelProperties = CVEtoCVEFeedRelProperties()
+
+@dataclass(frozen=True)
+class CVEToSpotlightVulnerabilityRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+@dataclass(frozen=True)
+# (:CVE)<-[:HAS_CVE]-(:SpotlightVulnerability)
+class CVEToSpotlightVulnerabilityRel(CartographyRelSchema):
+    target_node_label: str = 'SpotlightVulnerability'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('id')},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_CVE"
+    properties: CVEToSpotlightVulnerabilityRelProperties = CVEToSpotlightVulnerabilityRelProperties()
+
+@dataclass(frozen=True)
+class CVESchema(CartographyNodeSchema):
+    label: str = 'CVE'
+    properties: CVENodeProperties = CVENodeProperties()
+    sub_resource_relationship: CVEtoCVEFeedRelSchema = CVEtoCVEFeedRelSchema()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            CVEToSpotlightVulnerabilityRel(),
+        ],
+    )

--- a/cartography/models/cve/cve_feed.py
+++ b/cartography/models/cve/cve_feed.py
@@ -4,6 +4,7 @@ from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
 
+
 @dataclass(frozen=True)
 class CVEFeedNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef('FEED_ID')
@@ -11,6 +12,7 @@ class CVEFeedNodeProperties(CartographyNodeProperties):
     format: PropertyRef = PropertyRef('format')
     version: PropertyRef = PropertyRef('version')
     timestamp: PropertyRef = PropertyRef('timestamp')
+
 
 @dataclass(frozen=True)
 class CVEFeedSchema(CartographyNodeSchema):

--- a/cartography/models/cve/cve_feed.py
+++ b/cartography/models/cve/cve_feed.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+
+@dataclass(frozen=True)
+class CVEFeedNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('FEED_ID')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+    format: PropertyRef = PropertyRef('format')
+    version: PropertyRef = PropertyRef('version')
+    timestamp: PropertyRef = PropertyRef('timestamp')
+
+@dataclass(frozen=True)
+class CVEFeedSchema(CartographyNodeSchema):
+    label: str = 'CVEFeed'
+    properties: CVEFeedNodeProperties = CVEFeedNodeProperties()

--- a/tests/data/cve/feed.py
+++ b/tests/data/cve/feed.py
@@ -1,177 +1,508 @@
-GET_CVE_SYNC_METADATA = {
-    "CVE_data_type": "CVE",
-    "CVE_data_format": "MITRE",
-    "CVE_data_version": "4.0",
-    "CVE_data_numberOfCVEs": "6769",
-    "CVE_data_timestamp": "2022-02-23T08:01Z",
-    "CVE_Items": [{
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-1999-0001",
-                "ASSIGNER": "cve@mitre.org",
-            },
-            "problemtype": {
-                "problemtype_data": [{
-                    "description": [{
+# flake8: noqa
+GET_CVE_API_DATA = {
+    "resultsPerPage": 5,
+    "startIndex": 0,
+    "totalResults": 80,
+    "format": "NVD_CVE",
+    "version": "2.0",
+    "timestamp": "2024-01-10T19:30:07.520",
+    "vulnerabilities": [
+        {
+            "cve": {
+                "id": "CVE-2023-41782",
+                "sourceIdentifier": "psirt@zte.com.cn",
+                "published": "2024-01-05T02:15:07.147",
+                "lastModified": "2024-01-05T11:54:11.040",
+                "vulnStatus": "Undergoing Analysis",
+                "descriptions": [
+                    {
                         "lang": "en",
-                        "value": "CWE-20",
-                    }],
-                }],
-            },
-            "references": {
-                "reference_data": [
+                        "value": "\nThere is a DLL hijacking vulnerability in ZTE ZXCLOUD iRAI, an attacker could place a fake DLL file in a specific directory and successfully exploit this vulnerability to execute malicious code.\n\n",
+                    },
                     {
-                        "url": "http://www.openbsd.org/errata23.html#tcpfix",
-                        "name": "http://www.openbsd.org/errata23.html#tcpfix",
-                        "refsource": "CONFIRM",
-                        "tags": [],
-                    }, {
-                        "url": "http://www.osvdb.org/5707",
-                        "name": "5707",
-                        "refsource": "OSVDB",
-                        "tags": [],
+                        "lang": "es",
+                        "value": "Existe una vulnerabilidad de secuestro de DLL en ZTE ZXCLOUD iRAI. Un atacante podría colocar un archivo DLL falso en un directorio específico y explotar con éxito esta vulnerabilidad para ejecutar código malicioso.",
                     },
                 ],
-            },
-            "description": {
-                "description_data": [{
-                    "lang": "en",
-                    "value": (
-                        "ip_input.c in BSD-derived TCP/IP implementations allows remote "
-                        "attackers to cause a denial of service (crash or hang) via "
-                        "crafted packets."
-                    ),
-                }],
-            },
-        },
-        "configurations": {
-            "CVE_data_version": "4.0",
-            "nodes": [{
-                "operator": "OR",
-                "children": [],
-                "cpe_match": [
-                    {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:1.0:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:1.1.5.1:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.1.7:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.2:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.2.8:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:openbsd:openbsd:2.3:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:bsdi:bsd_os:3.1:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.2.3:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.2.4:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.2.5:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.2.6:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.0:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.0.5:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.1.5:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.1.6:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.2.2:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.0.1:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:1.1:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:1.2:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.1.6.1:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:2.1.7.1:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:freebsd:freebsd:3.0:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    }, {
-                        "vulnerable": True,
-                        "cpe23Uri": "cpe:2.3:o:openbsd:openbsd:2.4:*:*:*:*:*:*:*",
-                        "cpe_name": [],
-                    },
-                ],
-            }],
-        },
-        "impact": {
-            "baseMetricV2": {
-                "cvssV2": {
-                    "version": "2.0",
-                    "vectorString": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
-                    "accessVector": "NETWORK",
-                    "accessComplexity": "LOW",
-                    "authentication": "NONE",
-                    "confidentialityImpact": "NONE",
-                    "integrityImpact": "NONE",
-                    "availabilityImpact": "PARTIAL",
-                    "baseScore": 5.0,
+                "metrics": {
+                    "cvssMetricV31": [
+                        {
+                            "source": "psirt@zte.com.cn",
+                            "type": "Secondary",
+                            "cvssData": {
+                                "version": "3.1",
+                                "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:L/I:N/A:L",
+                                "attackVector": "LOCAL",
+                                "attackComplexity": "LOW",
+                                "privilegesRequired": "LOW",
+                                "userInteraction": "REQUIRED",
+                                "scope": "UNCHANGED",
+                                "confidentialityImpact": "LOW",
+                                "integrityImpact": "NONE",
+                                "availabilityImpact": "LOW",
+                                "baseScore": 3.9,
+                                "baseSeverity": "LOW",
+                            },
+                            "exploitabilityScore": 1.3,
+                            "impactScore": 2.5,
+                        },
+                    ],
                 },
-                "severity": "MEDIUM",
-                "exploitabilityScore": 10.0,
-                "impactScore": 2.9,
-                "obtainAllPrivilege": False,
-                "obtainUserPrivilege": False,
-                "obtainOtherPrivilege": False,
-                "userInteractionRequired": False,
+                "weaknesses": [
+                    {
+                        "source": "psirt@zte.com.cn",
+                        "type": "Secondary",
+                        "description": [
+                            {
+                                "lang": "en",
+                                "value": "CWE-20",
+                            },
+                        ],
+                    },
+                ],
+                "references": [
+                    {
+                        "url": "https://support.zte.com.cn/support/news/LoopholeInfoDetail.aspx?newsId=1032984",
+                        "source": "psirt@zte.com.cn",
+                    },
+                ],
             },
         },
-        "publishedDate": "1999-12-30T05:00Z",
-        "lastModifiedDate": "2010-12-16T05:00Z",
-    }],
+        {
+            "cve": {
+                "id": "CVE-2023-6493",
+                "sourceIdentifier": "security@wordfence.com",
+                "published": "2024-01-05T02:15:07.740",
+                "lastModified": "2024-01-10T15:10:40.807",
+                "vulnStatus": "Analyzed",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "The Depicter Slider – Responsive Image Slider, Video Slider & Post Slider plugin for WordPress is vulnerable to Cross-Site Request Forgery in all versions up to, and including, 2.0.6. This is due to missing or incorrect nonce validation on the 'save' function. This makes it possible for unauthenticated attackers to modify the plugin's settings via a forged request granted they can trick a site administrator into performing an action such as clicking on a link. CVE-2023-51491 appears to be a duplicate of this issue.",
+                    },
+                    {
+                        "lang": "es",
+                        "value": "El complemento The Depicter Slider – Responsive Image Slider, Video Slider &amp; Post Slider para WordPress es vulnerable a Cross-Site Request Forgery en todas las versiones hasta la 2.0.6 incluida. Esto se debe a una validación nonce faltante o incorrecta en la función \"save\". Esto hace posible que atacantes no autenticados modifiquen la configuración del complemento mediante una solicitud falsificada, siempre que puedan engañar al administrador del sitio para que realice una acción como hacer clic en un enlace. CVE-2023-51491 parece ser un duplicado de este problema.",
+                    },
+                ],
+                "metrics": {
+                    "cvssMetricV31": [
+                        {
+                            "source": "nvd@nist.gov",
+                            "type": "Primary",
+                            "cvssData": {
+                                "version": "3.1",
+                                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+                                "attackVector": "NETWORK",
+                                "attackComplexity": "LOW",
+                                "privilegesRequired": "NONE",
+                                "userInteraction": "REQUIRED",
+                                "scope": "UNCHANGED",
+                                "confidentialityImpact": "NONE",
+                                "integrityImpact": "LOW",
+                                "availabilityImpact": "NONE",
+                                "baseScore": 4.3,
+                                "baseSeverity": "MEDIUM",
+                            },
+                            "exploitabilityScore": 2.8,
+                            "impactScore": 1.4,
+                        },
+                        {
+                            "source": "security@wordfence.com",
+                            "type": "Secondary",
+                            "cvssData": {
+                                "version": "3.1",
+                                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+                                "attackVector": "NETWORK",
+                                "attackComplexity": "LOW",
+                                "privilegesRequired": "NONE",
+                                "userInteraction": "REQUIRED",
+                                "scope": "UNCHANGED",
+                                "confidentialityImpact": "NONE",
+                                "integrityImpact": "LOW",
+                                "availabilityImpact": "NONE",
+                                "baseScore": 4.3,
+                                "baseSeverity": "MEDIUM",
+                            },
+                            "exploitabilityScore": 2.8,
+                            "impactScore": 1.4,
+                        },
+                    ],
+                },
+                "weaknesses": [
+                    {
+                        "source": "nvd@nist.gov",
+                        "type": "Primary",
+                        "description": [
+                            {
+                                "lang": "en",
+                                "value": "CWE-352",
+                            },
+                        ],
+                    },
+                ],
+                "configurations": [
+                    {
+                        "nodes": [
+                            {
+                                "operator": "OR",
+                                "negate": False,
+                                "cpeMatch": [
+                                    {
+                                        "vulnerable": True,
+                                        "criteria": "cpe:2.3:a:averta:depicter_slider:*:*:*:*:*:wordpress:*:*",
+                                        "versionEndIncluding": "2.0.6",
+                                        "matchCriteriaId": "7EC2E784-7E22-4632-BA4C-4B931749BD15",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "references": [
+                    {
+                        "url": "https://plugins.trac.wordpress.org/changeset/3013596/depicter/trunk/app/src/WordPress/Settings/Settings.php",
+                        "source": "security@wordfence.com",
+                        "tags": [
+                            "Patch",
+                        ],
+                    },
+                    {
+                        "url": "https://www.wordfence.com/threat-intel/vulnerabilities/id/c9c907ea-3ab4-4674-8945-ade4f6ff2679?source=cve",
+                        "source": "security@wordfence.com",
+                        "tags": [
+                            "Third Party Advisory",
+                        ],
+                    },
+                ],
+            },
+        },
+        {
+            "cve": {
+                "id": "CVE-2024-22075",
+                "sourceIdentifier": "cve@mitre.org",
+                "published": "2024-01-05T03:15:08.537",
+                "lastModified": "2024-01-10T15:06:42.563",
+                "vulnStatus": "Analyzed",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "Firefly III (aka firefly-iii) before 6.1.1 allows webhooks HTML Injection.",
+                    },
+                    {
+                        "lang": "es",
+                        "value": "Firefly III (aka firefly-iii) anterior a 6.1.1 permite la inyección HTML de webhooks.",
+                    },
+                ],
+                "metrics": {
+                    "cvssMetricV31": [
+                        {
+                            "source": "nvd@nist.gov",
+                            "type": "Primary",
+                            "cvssData": {
+                                "version": "3.1",
+                                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+                                "attackVector": "NETWORK",
+                                "attackComplexity": "LOW",
+                                "privilegesRequired": "NONE",
+                                "userInteraction": "REQUIRED",
+                                "scope": "CHANGED",
+                                "confidentialityImpact": "LOW",
+                                "integrityImpact": "LOW",
+                                "availabilityImpact": "NONE",
+                                "baseScore": 6.1,
+                                "baseSeverity": "MEDIUM",
+                            },
+                            "exploitabilityScore": 2.8,
+                            "impactScore": 2.7,
+                        },
+                    ],
+                },
+                "weaknesses": [
+                    {
+                        "source": "nvd@nist.gov",
+                        "type": "Primary",
+                        "description": [
+                            {
+                                "lang": "en",
+                                "value": "CWE-79",
+                            },
+                        ],
+                    },
+                    {
+                        "source": "nvd@nist.gov",
+                        "type": "Primary",
+                        "description": [
+                            {
+                                "lang": "en",
+                                "value": "CWE-80",
+                            },
+                        ],
+                    },
+                ],
+                "configurations": [
+                    {
+                        "nodes": [
+                            {
+                                "operator": "OR",
+                                "negate": False,
+                                "cpeMatch": [
+                                    {
+                                        "vulnerable": True,
+                                        "criteria": "cpe:2.3:a:firefly-iii:firefly_iii:*:*:*:*:*:*:*:*",
+                                        "versionEndExcluding": "6.1.1",
+                                        "matchCriteriaId": "A6454D7F-5388-4519-AE45-11A8BD704D1E",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "references": [
+                    {
+                        "url": "https://github.com/firefly-iii/firefly-iii/releases/tag/v6.1.1",
+                        "source": "cve@mitre.org",
+                        "tags": [
+                            "Release Notes",
+                        ],
+                    },
+                ],
+            },
+        },
+        {
+            "cve": {
+                "id": "CVE-2023-52323",
+                "sourceIdentifier": "cve@mitre.org",
+                "published": "2024-01-05T04:15:07.763",
+                "lastModified": "2024-01-05T11:54:11.040",
+                "vulnStatus": "Undergoing Analysis",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "PyCryptodome and pycryptodomex before 3.19.1 allow side-channel leakage for OAEP decryption, exploitable for a Manger attack.",
+                    },
+                    {
+                        "lang": "es",
+                        "value": "PyCryptodome y pycryptodomex anteriores a 3.19.1 permiten la fuga de canal lateral para el descifrado OAEP, explotable para un ataque Manger.",
+                    },
+                ],
+                "metrics": {},
+                "references": [
+                    {
+                        "url": "https://github.com/Legrandin/pycryptodome/blob/master/Changelog.rst",
+                        "source": "cve@mitre.org",
+                    },
+                    {
+                        "url": "https://pypi.org/project/pycryptodomex/#history",
+                        "source": "cve@mitre.org",
+                    },
+                ],
+            },
+        },
+        {
+            "cve": {
+                "id": "CVE-2024-22086",
+                "sourceIdentifier": "cve@mitre.org",
+                "published": "2024-01-05T04:15:07.833",
+                "lastModified": "2024-01-05T11:54:11.040",
+                "vulnStatus": "Undergoing Analysis",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "handle_request in http.c in cherry through 4b877df has an sscanf stack-based buffer overflow via a long URI, leading to remote code execution.",
+                    },
+                    {
+                        "lang": "es",
+                        "value": "handle_request en http.c en cherry hasta 4b877df tiene un desbordamiento de búfer en la región stack de la memoria sscanf a través de un URI largo, lo que lleva a la ejecución remota de código.",
+                    },
+                ],
+                "metrics": {},
+                "references": [
+                    {
+                        "url": "https://github.com/hayyp/cherry/issues/1",
+                        "source": "cve@mitre.org",
+                    },
+                ],
+            },
+        },
+    ],
+}
+
+GET_CVE_API_DATA_BATCH_2 = {
+    "resultsPerPage": 5,
+    "startIndex": 5,
+    "totalResults": 80,
+    "format": "NVD_CVE",
+    "version": "2.0",
+    "timestamp": "2024-01-10T19:42:01.957",
+    "vulnerabilities": [
+        {
+            "cve": {
+                "id": "CVE-2024-22086",
+                "sourceIdentifier": "cve@mitre.org",
+                "published": "2024-01-05T04:15:07.833",
+                "lastModified": "2024-01-05T11:54:11.040",
+                "vulnStatus": "Undergoing Analysis",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "handle_request in http.c in cherry through 4b877df has an sscanf stack-based buffer overflow via a long URI, leading to remote code execution.",
+                    },
+                    {
+                        "lang": "es",
+                        "value": "handle_request en http.c en cherry hasta 4b877df tiene un desbordamiento de búfer en la región stack de la memoria sscanf a través de un URI largo, lo que lleva a la ejecución remota de código.",
+                    },
+                ],
+                "metrics": {},
+                "references": [
+                    {
+                        "url": "https://github.com/hayyp/cherry/issues/1",
+                        "source": "cve@mitre.org",
+                    },
+                ],
+            },
+        },
+        {
+            "cve": {
+                "id": "CVE-2024-22087",
+                "sourceIdentifier": "cve@mitre.org",
+                "published": "2024-01-05T04:15:07.880",
+                "lastModified": "2024-01-05T11:54:11.040",
+                "vulnStatus": "Undergoing Analysis",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "route in main.c in Pico HTTP Server in C through f3b69a6 has an sprintf stack-based buffer overflow via a long URI, leading to remote code execution.",
+                    },
+                    {
+                        "lang": "es",
+                        "value": "La ruta en main.c en Pico HTTP Server en C hasta f3b69a6 tiene un desbordamiento de búfer en la región stack de la memoria sprintf a través de un URI largo, lo que lleva a la ejecución remota de código.",
+                    },
+                ],
+                "metrics": {},
+                "references": [
+                    {
+                        "url": "https://github.com/foxweb/pico/issues/31",
+                        "source": "cve@mitre.org",
+                    },
+                ],
+            },
+        },
+        {
+            "cve": {
+                "id": "CVE-2024-22088",
+                "sourceIdentifier": "cve@mitre.org",
+                "published": "2024-01-05T04:15:07.930",
+                "lastModified": "2024-01-05T11:54:11.040",
+                "vulnStatus": "Undergoing Analysis",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "Lotos WebServer through 0.1.1 (commit 3eb36cc) has a use-after-free in buffer_avail() at buffer.h via a long URI, because realloc is mishandled.",
+                    },
+                    {
+                        "lang": "es",
+                        "value": "Lotos WebServer hasta 0.1.1 (commit 3eb36cc) tiene un use after free en buffer_avail() en buffer.h a través de un URI largo, porque la realloc no se maneja correctamente.",
+                    },
+                ],
+                "metrics": {},
+                "references": [
+                    {
+                        "url": "https://github.com/chendotjs/lotos/issues/7",
+                        "source": "cve@mitre.org",
+                    },
+                ],
+            },
+        },
+        {
+            "cve": {
+                "id": "CVE-2023-51277",
+                "sourceIdentifier": "cve@mitre.org",
+                "published": "2024-01-05T05:15:08.793",
+                "lastModified": "2024-01-05T11:54:11.040",
+                "vulnStatus": "Undergoing Analysis",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "nbviewer-app (aka Jupyter Notebook Viewer) before 0.1.6 has the get-task-allow entitlement for release builds.",
+                    },
+                    {
+                        "lang": "es",
+                        "value": "nbviewer-app (aka Jupyter Notebook Viewer) anterior a 0.1.6 tiene el derecho get-task-allow para las versiones de lanzamiento.",
+                    },
+                ],
+                "metrics": {},
+                "references": [
+                    {
+                        "url": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087731",
+                        "source": "cve@mitre.org",
+                    },
+                    {
+                        "url": "https://github.com/tuxu/nbviewer-app/commit/dc1e4ddf64c78e13175a39b076fa0646fc62e581",
+                        "source": "cve@mitre.org",
+                    },
+                    {
+                        "url": "https://github.com/tuxu/nbviewer-app/compare/0.1.5...0.1.6",
+                        "source": "cve@mitre.org",
+                    },
+                    {
+                        "url": "https://www.youtube.com/watch?v=c0nawqA_bdI",
+                        "source": "cve@mitre.org",
+                    },
+                ],
+            },
+        },
+        {
+            "cve": {
+                "id": "CVE-2020-13878",
+                "sourceIdentifier": "cve@mitre.org",
+                "published": "2024-01-05T08:15:41.840",
+                "lastModified": "2024-01-05T11:54:11.040",
+                "vulnStatus": "Undergoing Analysis",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "IrfanView B3D PlugIns before version 4.56 has a B3d.dll!+27ef heap-based out-of-bounds write.",
+                    },
+                    {
+                        "lang": "es",
+                        "value": "IrfanView B3D PlugIns anteriores a la versión 4.56 tienen una escritura fuera de los límites basada en montón B3d.dll!+27ef.",
+                    },
+                ],
+                "metrics": {},
+                "references": [
+                    {
+                        "url": "https://gist.github.com/oicu0619/2b0eb7dd447aca8f4ab398a99f47488b",
+                        "source": "cve@mitre.org",
+                    },
+                ],
+            },
+        },
+        {
+            "cve": {
+                "id": "CVE-2020-13879",
+                "sourceIdentifier": "cve@mitre.org",
+                "published": "2024-01-05T08:15:42.663",
+                "lastModified": "2024-01-05T11:54:11.040",
+                "vulnStatus": "Undergoing Analysis",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "IrfanView B3D PlugIns before version 4.56 has a B3d.dll!+214f heap-based out-of-bounds write.",
+                    },
+                    {
+                        "lang": "es",
+                        "value": "rfanView B3D PlugIns anteriores a la versión 4.56 tienen una escritura fuera de los límites basada en montón B3d.dll!+214f.",
+                    },
+                ],
+                "metrics": {},
+                "references": [
+                    {
+                        "url": "https://gist.github.com/oicu0619/878b8c37f238f4de5ff543973ef083f5",
+                        "source": "cve@mitre.org",
+                    },
+                ],
+            },
+        },
+    ],
 }

--- a/tests/integration/cartography/intel/cve/test_feed.py
+++ b/tests/integration/cartography/intel/cve/test_feed.py
@@ -1,36 +1,122 @@
-import cartography.intel.cve.feed
-import tests.data.cve.feed
+from cartography.intel.cve import feed
+from tests.data.cve.feed import GET_CVE_API_DATA
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
+NIST_CVE_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0/"
+API_KEY = "nvd_api_key"
 
 
-def test_load_cves(neo4j_session):
-    cve_data = tests.data.cve.feed.GET_CVE_SYNC_METADATA
-    cartography.intel.cve.feed.load_cves(neo4j_session, cve_data, TEST_UPDATE_TAG)
-
-    expected_nodes = {
-        (
-            "CVE-1999-0001",
-            tuple(["CWE-20"]),
-            tuple(["http://www.openbsd.org/errata23.html#tcpfix", "http://www.osvdb.org/5707"]),
-            (
-                "ip_input.c in BSD-derived TCP/IP implementations allows remote attackers to cause a "
-                "denial of service (crash or hang) via crafted packets."
-            ),
-        ),
-    }
-    nodes = neo4j_session.run(
+def _create_spotlight_nodes(neo4j_session):
+    neo4j_session.run(
         """
-        MATCH (n:CVE) RETURN n.id, n.problem_types, n.references, n.description_en
+        MERGE (v:SpotlightVulnerability{id: $spotlight_id})
+        ON CREATE SET v.firstseen = timestamp()
         """,
+        spotlight_id="CVE-2023-41782",
     )
-    actual_nodes = {
-        (
-            n['n.id'],
-            tuple(n['n.problem_types']),
-            tuple(n['n.references']),
-            n['n.description_en'],
-        )
-        for n in nodes
+
+
+def _create_sync_metadata(neo4j_session):
+    neo4j_session.run(
+        """
+        MERGE (s:SyncMetadata{id: $id})
+        ON CREATE SET s.firstseen = timestamp(),
+            s.grouptype = $grouptype,
+            s.syncedtype = "year",
+            s.groupid = $groupid
+        """,
+        id="CVE_2023",
+        grouptype="CVE",
+        groupid="2023",
+    )
+
+
+def _create_cve_nodes(neo4j_session):
+    neo4j_session.run(
+        """
+        MERGE (c:CVE{id: $cve_id})
+        ON CREATE SET c.firstseen = timestamp(),
+        c.lastupdated = $update_tag,
+        c.published_date = $published_date,
+        c.last_modified_date = $last_modified_date
+        MERGE(feed:CVEFeed{id: $feed_id})-[:RESOURCE]->(c)
+        """,
+        cve_id="CVE-2023-9999",
+        update_tag=TEST_UPDATE_TAG,
+        published_date="2023-01-10T19:30:07.000",
+        last_modified_date="2023-01-10T19:30:07.000",
+        feed_id=feed.CVE_FEED_ID,
+    )
+
+
+def test_get_cve_sync_metadata(neo4j_session):
+    # Arrange
+    _create_sync_metadata(neo4j_session)
+
+    # Act
+    sync_metadata = feed.get_cve_sync_metadata(neo4j_session)
+
+    # Assert
+    assert sync_metadata == [2023]
+
+
+def test_get_last_modified_cve_date(neo4j_session):
+    # Arrange
+    _create_cve_nodes(neo4j_session)
+
+    # Act
+    last_modified_date = feed.get_last_modified_cve_date(neo4j_session)
+
+    # Assert
+    assert last_modified_date == "2023-01-10T19:30:07"
+
+
+def test_sync(neo4j_session):
+    # Arrange
+    _create_spotlight_nodes(neo4j_session)
+    _create_cve_nodes(neo4j_session)
+    expected_feed = {(
+        feed.CVE_FEED_ID,
+        "NVD_CVE",
+        "2.0",
+        GET_CVE_API_DATA["timestamp"],
+    )}
+    expected_cves = {
+        (cve["cve"]["id"], cve["cve"]["published"], cve["cve"]["lastModified"])
+        for cve in GET_CVE_API_DATA.get("vulnerabilities")
     }
-    assert actual_nodes == expected_nodes
+    expected_cves.add(("CVE-2023-9999", "2023-01-10T19:30:07.000", "2023-01-10T19:30:07.000"))
+    expected_feed_cve_rels = {(feed.CVE_FEED_ID, cve_id[0]) for cve_id in expected_cves}
+    # Act
+    cves = GET_CVE_API_DATA
+    feed_metadata = feed.transform_cve_feed(cves)
+    feed.load_cve_feed(neo4j_session, [feed_metadata], TEST_UPDATE_TAG)
+    published_cves = feed.transform_cves(cves)
+    feed.load_cves(
+        neo4j_session, published_cves, feed_metadata["FEED_ID"], TEST_UPDATE_TAG,
+    )
+
+    # Assert
+    assert check_nodes(
+        neo4j_session, "CVEFeed", ["id", "format", "version", "timestamp"],
+    ) == expected_feed
+
+    assert (
+        check_nodes(
+            neo4j_session, "CVE", ["id", "published_date", "last_modified_date"],
+        ) ==
+        expected_cves
+    )
+
+    assert (
+        check_rels(neo4j_session, "CVEFeed", "id", "CVE", "id", "RESOURCE") ==
+        expected_feed_cve_rels
+    )
+
+    assert check_rels(
+        neo4j_session, "SpotlightVulnerability", "id", "CVE", "id", "HAS_CVE",
+    ) == {
+        ("CVE-2023-41782", "CVE-2023-41782"),
+    }

--- a/tests/unit/cartography/intel/cve/test_feed.py
+++ b/tests/unit/cartography/intel/cve/test_feed.py
@@ -1,0 +1,224 @@
+import requests
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, patch
+from cartography.intel.cve.feed import (
+    _call_cves_api,
+    _map_cve_dict,
+    get_cves_in_batches,
+    get_modified_cves,
+    get_published_cves_per_year,
+)
+
+from tests.data.cve.feed import GET_CVE_API_DATA, GET_CVE_API_DATA_BATCH_2
+
+NIST_CVE_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0/"
+API_KEY = "nvd_api_key"
+
+
+@patch("cartography.intel.cve.feed.DEFAULT_SLEEP_TIME", 0)
+@patch("cartography.intel.cve.feed.requests.get")
+def test_call_cves_api(mock_get: Mock):
+    # Arrange
+    mock_response_1 = Mock()
+    mock_response_1.status_code = 200
+    mock_response_1.json.return_value = {
+        "resultsPerPage": 2000,
+        "startIndex": 0,
+        "totalResults": 4000,
+        "format": "NVD_CVE",
+        "version": "2.0",
+        "timestamp": "2024-01-10T19:30:07.520",
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "CVE-2024-001",
+                }
+            },
+            {
+                "cve": {
+                    "id": "CVE-2024-002",
+                }
+            },
+            {
+                "cve": {
+                    "id": "CVE-2024-003",
+                }
+            },
+        ],
+    }
+    mock_response_2 = Mock()
+    mock_response_2.status_code = 200
+    mock_response_2.json.return_value = {
+        "resultsPerPage": 2000,
+        "startIndex": 2000,
+        "totalResults": 4000,
+        "format": "NVD_CVE",
+        "version": "2.0",
+        "timestamp": "2024-01-10T19:30:07.520",
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "CVE-2024-004",
+                }
+            },
+            {
+                "cve": {
+                    "id": "CVE-2024-005",
+                }
+            },
+            {
+                "cve": {
+                    "id": "CVE-2024-006",
+                }
+            },
+        ],
+    }
+    mock_response_3 = Mock()
+    mock_response_3.status_code = 200
+    mock_response_3.json.return_value = {
+        "resultsPerPage": 0,
+        "startIndex": 4000,
+        "totalResults": 4000,
+        "format": "NVD_CVE",
+        "version": "2.0",
+        "timestamp": "2024-01-10T19:30:07.520",
+        "vulnerabilities": []
+    }
+
+    mock_get.side_effect = [mock_response_1, mock_response_2, mock_response_3]
+    params = {"start": "2024-01-10T00:00:00Z", "end": "2024-01-10T23:59:59Z"}
+    expected_result = {
+        "resultsPerPage": 0,
+        "startIndex": 4000,
+        "totalResults": 4000,
+        "format": "NVD_CVE",
+        "version": "2.0",
+        "timestamp": "2024-01-10T19:30:07.520",
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "CVE-2024-001",
+                }
+            },
+            {
+                "cve": {
+                    "id": "CVE-2024-002",
+                }
+            },
+            {
+                "cve": {
+                    "id": "CVE-2024-003",
+                }
+            },
+            {
+                "cve": {
+                    "id": "CVE-2024-004",
+                }
+            },
+            {
+                "cve": {
+                    "id": "CVE-2024-005",
+                }
+            },
+            {
+                "cve": {
+                    "id": "CVE-2024-006",
+                }
+            },
+        ],
+    }
+
+    # Act
+    result = _call_cves_api(NIST_CVE_URL, API_KEY, params)
+
+    # Assert
+    assert mock_get.call_count == 3
+    assert result == expected_result
+
+
+@patch("cartography.intel.cve.feed.DEFAULT_SLEEP_TIME", 0)
+@patch("cartography.intel.cve.feed.requests.get")
+def test_call_cves_api_with_error(mock_get: Mock):
+    # Arrange
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_response.message = "Data error"
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        response=mock_response
+    )
+    mock_get.return_value = mock_response
+    params = {"start": "2024-01-10T00:00:00Z", "end": "2024-01-10T23:59:59Z"}
+
+    # Act
+    try:
+        _call_cves_api(NIST_CVE_URL, API_KEY, params)
+    except requests.exceptions.HTTPError as err:
+        assert err.response.message == "Data error"
+    assert mock_get.call_count == 3
+
+
+@patch("cartography.intel.cve.feed._call_cves_api")
+def test_get_cves_in_batches(mock_call_cves_api: Mock):
+    """
+    Ensure that we get the correct number of CVEs in batches of 120 days
+    """
+    # Arrange
+    mock_call_cves_api.side_effect = [
+        GET_CVE_API_DATA,
+        GET_CVE_API_DATA_BATCH_2,
+    ]
+    start_date = datetime.strptime("2024-01-01T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+    end_date = datetime.strptime("2024-05-01T00:00:00Z", "%Y-%m-%dT%H:%M:%SZ")
+    date_param_names = {
+        "start": "startDate",
+        "end": "endDate",
+    }
+    excepted_cves = GET_CVE_API_DATA.copy()
+    _map_cve_dict(excepted_cves, GET_CVE_API_DATA_BATCH_2)
+    # Act
+    cves = get_cves_in_batches(
+        NIST_CVE_URL, start_date, end_date, date_param_names, API_KEY
+    )
+    # Assert
+    assert mock_call_cves_api.call_count == 2
+    assert cves == excepted_cves
+
+
+@patch("cartography.intel.cve.feed._call_cves_api")
+def test_get_modified_cves(mock_call_cves_api: Mock):
+    # Arrange
+    mock_call_cves_api.side_effect = [GET_CVE_API_DATA]
+    last_modified_date = datetime.now(tz=timezone.utc) + timedelta(days=-1)
+    last_modified_date_iso8601 = last_modified_date.strftime("%Y-%m-%dT%H:%M:%S")
+    current_date_iso8601 = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    expected_params = {
+        "lastModStartDate": last_modified_date_iso8601,
+        "lastModEndDate": current_date_iso8601,
+    }
+    # Act
+    cves = get_modified_cves(NIST_CVE_URL, last_modified_date_iso8601, API_KEY)
+    # Assert
+    mock_call_cves_api.assert_called_once_with(NIST_CVE_URL, API_KEY, expected_params)
+    assert cves == GET_CVE_API_DATA
+
+
+@patch("cartography.intel.cve.feed._call_cves_api")
+def test_get_published_cves_per_year(mock_call_cves_api: Mock):
+    # Arrange
+    no_cves = {
+        "resultsPerPage": 0,
+        "startIndex": 4000,
+        "totalResults": 4000,
+        "format": "NVD_CVE",
+        "version": "2.0",
+        "timestamp": "2024-01-10T19:30:07.520",
+        "vulnerabilities": []
+    }
+    expected_cves = GET_CVE_API_DATA.copy()
+    _map_cve_dict(expected_cves, no_cves)
+    mock_call_cves_api.side_effect = [GET_CVE_API_DATA, no_cves, no_cves, no_cves]
+    # Act
+    cves = get_published_cves_per_year(NIST_CVE_URL, "2024", API_KEY)
+    # Assert
+    mock_call_cves_api.call_count == 4
+    assert cves == expected_cves

--- a/tests/unit/cartography/intel/cve/test_feed.py
+++ b/tests/unit/cartography/intel/cve/test_feed.py
@@ -1,15 +1,18 @@
-import requests
-from datetime import datetime, timedelta, timezone
-from unittest.mock import Mock, patch
-from cartography.intel.cve.feed import (
-    _call_cves_api,
-    _map_cve_dict,
-    get_cves_in_batches,
-    get_modified_cves,
-    get_published_cves_per_year,
-)
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest.mock import Mock
+from unittest.mock import patch
 
-from tests.data.cve.feed import GET_CVE_API_DATA, GET_CVE_API_DATA_BATCH_2
+import requests
+
+from cartography.intel.cve.feed import _call_cves_api
+from cartography.intel.cve.feed import _map_cve_dict
+from cartography.intel.cve.feed import get_cves_in_batches
+from cartography.intel.cve.feed import get_modified_cves
+from cartography.intel.cve.feed import get_published_cves_per_year
+from tests.data.cve.feed import GET_CVE_API_DATA
+from tests.data.cve.feed import GET_CVE_API_DATA_BATCH_2
 
 NIST_CVE_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0/"
 API_KEY = "nvd_api_key"
@@ -32,17 +35,17 @@ def test_call_cves_api(mock_get: Mock):
             {
                 "cve": {
                     "id": "CVE-2024-001",
-                }
+                },
             },
             {
                 "cve": {
                     "id": "CVE-2024-002",
-                }
+                },
             },
             {
                 "cve": {
                     "id": "CVE-2024-003",
-                }
+                },
             },
         ],
     }
@@ -59,17 +62,17 @@ def test_call_cves_api(mock_get: Mock):
             {
                 "cve": {
                     "id": "CVE-2024-004",
-                }
+                },
             },
             {
                 "cve": {
                     "id": "CVE-2024-005",
-                }
+                },
             },
             {
                 "cve": {
                     "id": "CVE-2024-006",
-                }
+                },
             },
         ],
     }
@@ -82,7 +85,7 @@ def test_call_cves_api(mock_get: Mock):
         "format": "NVD_CVE",
         "version": "2.0",
         "timestamp": "2024-01-10T19:30:07.520",
-        "vulnerabilities": []
+        "vulnerabilities": [],
     }
 
     mock_get.side_effect = [mock_response_1, mock_response_2, mock_response_3]
@@ -98,32 +101,32 @@ def test_call_cves_api(mock_get: Mock):
             {
                 "cve": {
                     "id": "CVE-2024-001",
-                }
+                },
             },
             {
                 "cve": {
                     "id": "CVE-2024-002",
-                }
+                },
             },
             {
                 "cve": {
                     "id": "CVE-2024-003",
-                }
+                },
             },
             {
                 "cve": {
                     "id": "CVE-2024-004",
-                }
+                },
             },
             {
                 "cve": {
                     "id": "CVE-2024-005",
-                }
+                },
             },
             {
                 "cve": {
                     "id": "CVE-2024-006",
-                }
+                },
             },
         ],
     }
@@ -144,7 +147,7 @@ def test_call_cves_api_with_error(mock_get: Mock):
     mock_response.status_code = 404
     mock_response.message = "Data error"
     mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
-        response=mock_response
+        response=mock_response,
     )
     mock_get.return_value = mock_response
     params = {"start": "2024-01-10T00:00:00Z", "end": "2024-01-10T23:59:59Z"}
@@ -177,7 +180,7 @@ def test_get_cves_in_batches(mock_call_cves_api: Mock):
     _map_cve_dict(excepted_cves, GET_CVE_API_DATA_BATCH_2)
     # Act
     cves = get_cves_in_batches(
-        NIST_CVE_URL, start_date, end_date, date_param_names, API_KEY
+        NIST_CVE_URL, start_date, end_date, date_param_names, API_KEY,
     )
     # Assert
     assert mock_call_cves_api.call_count == 2
@@ -212,7 +215,7 @@ def test_get_published_cves_per_year(mock_call_cves_api: Mock):
         "format": "NVD_CVE",
         "version": "2.0",
         "timestamp": "2024-01-10T19:30:07.520",
-        "vulnerabilities": []
+        "vulnerabilities": [],
     }
     expected_cves = GET_CVE_API_DATA.copy()
     _map_cve_dict(expected_cves, no_cves)

--- a/tests/unit/cartography/intel/cve/test_feed.py
+++ b/tests/unit/cartography/intel/cve/test_feed.py
@@ -156,7 +156,7 @@ def test_call_cves_api_with_error(mock_get: Mock):
     try:
         _call_cves_api(NIST_CVE_URL, API_KEY, params)
     except requests.exceptions.HTTPError as err:
-        assert err.response.message == "Data error"
+        assert err.response == mock_response
     assert mock_get.call_count == 3
 
 


### PR DESCRIPTION
Issue https://github.com/lyft/cartography/issues/1275

Update the CVE intel module to the new [API 2.0 for vulnerabilities](https://nvd.nist.gov/developers/vulnerabilities).

Followed the [API 2.0 workflow](https://nvd.nist.gov/developers/api-workflows), but kept the year sync for compatibility with previous module version. Added as well delay among API calls to keep among [rate limits established](https://nvd.nist.gov/developers/start-here#divRateLimits).

Finally, switched to the Cartography ORM [model](https://github.com/lyft/cartography/tree/master/cartography/models/core) adding a new `CVEFeed` node representing the `:RESOURCE` parent of all `CVE` nodes.

