### PR TITLE
Semgrep SCA - add findings published date and fix status

### DIFF
--- a/cartography/models/semgrep/findings.py
+++ b/cartography/models/semgrep/findings.py
@@ -32,6 +32,8 @@ class SemgrepSCAFindingNodeProperties(CartographyNodeProperties):
     dependency_file: PropertyRef = PropertyRef('dependencyFileLocation_path', extra_index=True)
     dependency_file_url: PropertyRef = PropertyRef('dependencyFileLocation_url', extra_index=True)
     scan_time: PropertyRef = PropertyRef('openedAt')
+    published_time: PropertyRef = PropertyRef('announcedAt')
+    fix_status: PropertyRef = PropertyRef('fixStatus')
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
The triage information from response https://semgrep.dev/api/docs#/SupplyChainService/SupplyChainService_ListVulns2 contains either "NEW", "CLOSED" or "IGNORED" status. This field can be used to determine if a finding has been fixed or not.
Also, adding the "announcedAt" date to get the CVE/GHSA published date information.