### PR TITLE
Fix ghpages python version string

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       # https://docs.github.com/en/actions/guides/building-and-testing-python#caching-dependencies
       # ^-- How to set up caching for pip on Ubuntu
       - name: Cache pip

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -35,7 +35,7 @@ jobs:
             --publish 7474:7474 \
             --publish 7473:7473 \
             --publish 7687:7687 \
-            neo4j:4.4.30-community
+            neo4j:4.4-community
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -35,7 +35,7 @@ jobs:
             --publish 7474:7474 \
             --publish 7473:7473 \
             --publish 7687:7687 \
-            neo4j:4.4.29-community
+            neo4j:4.4.30-community
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -35,7 +35,7 @@ jobs:
             --publish 7474:7474 \
             --publish 7473:7473 \
             --publish 7687:7687 \
-            neo4j:4.4-community
+            neo4j:4.4.29-community
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.90.0rc1'
+__version__ = '0.90.0rc2'
 
 
 setup(


### PR DESCRIPTION
Similar issue as this: https://github.com/actions/setup-python/issues/401#issuecomment-1848265537

`3.10` gets interpreted as `3.1` when I want it to be `"3.10"`.