### PR TITLE
Fix #1284: bump sphinx version to 5.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==4.3.0
+sphinx==5.0.0
 sphinx-material==0.0.35
 m2r2==0.3.2


### PR DESCRIPTION
Failing run: https://github.com/lyft/cartography/actions/runs/8012473952/job/21887802009

Bumping to 5.0.0 should fix this error:
```
+ sphinx-build -j auto --keep-going -b html generated/rst generated/docs
Running Sphinx v4.3.0
loading translations [en]... done

Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
Error: Process completed with exit code 2.
```
