### PR TITLE
Add support for Okta group->AWS SSO role rel

### DIFF
--- a/cartography/intel/okta/__init__.py
+++ b/cartography/intel/okta/__init__.py
@@ -68,7 +68,7 @@ def start_okta_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     applications.sync_okta_applications(neo4j_session, config.okta_org_id, config.update_tag, config.okta_api_key)
     factors.sync_users_factors(neo4j_session, config.okta_org_id, config.update_tag, config.okta_api_key, state)
     origins.sync_trusted_origins(neo4j_session, config.okta_org_id, config.update_tag, config.okta_api_key)
-    awssaml.sync_okta_aws_saml(neo4j_session, config.okta_saml_role_regex, config.update_tag)
+    awssaml.sync_okta_aws_saml(neo4j_session, config.okta_saml_role_regex, config.update_tag, config.okta_org_id)
 
     # need creds with permission
     # soft fail as some won't be able to get such high priv token

--- a/cartography/intel/okta/awssaml.py
+++ b/cartography/intel/okta/awssaml.py
@@ -7,6 +7,8 @@ from typing import Optional
 
 import neo4j
 
+from cartography.client.core.tx import read_list_of_values_tx
+from cartography.client.core.tx import read_single_value_tx
 from cartography.util import timeit
 
 
@@ -17,17 +19,24 @@ def _parse_regex(regex_string: str) -> str:
     return regex_string.replace("{{accountid}}", "P<accountid>").replace("{{role}}", "P<role>").strip()
 
 
-@timeit
-def transform_okta_group_to_aws_role(group_id: str, group_name: str, mapping_regex: str) -> Optional[Dict]:
+def _get_account_and_role_name(okta_group_name: str, mapping_regex: str) -> tuple[str, str] | None:
     regex = _parse_regex(mapping_regex)
-    matches = re.search(regex, group_name)
+    matches = re.search(regex, okta_group_name)
     if matches:
-        accountid = matches.group("accountid")
-        role = matches.group("role")
+        account_id = matches.group("accountid")
+        role_slug = matches.group("role")
+        return account_id, role_slug
+    return None
+
+
+def transform_okta_group_to_aws_role(group_id: str, group_name: str, mapping_regex: str) -> Optional[Dict]:
+    account_and_role = _get_account_and_role_name(group_name, mapping_regex)
+    if account_and_role:
+        accountid = account_and_role[0]
+        role = account_and_role[1]
         role_arn = f"arn:aws:iam::{accountid}:role/{role}"
         return {"groupid": group_id, "role": role_arn}
-    else:
-        return None
+    return None
 
 
 @timeit
@@ -45,6 +54,7 @@ def query_for_okta_to_aws_role_mapping(neo4j_session: neo4j.Session, mapping_reg
 
     for res in results:
         has_results = True
+        # input: okta group id, okta group name. output: aws role arn.
         mapping = transform_okta_group_to_aws_role(res["group.id"], res["group.name"], mapping_regex)
         if mapping:
             group_to_role_mapping.append(mapping)
@@ -107,6 +117,74 @@ def _load_human_can_assume_role(neo4j_session: neo4j.Session, okta_update_tag: i
     )
 
 
+def get_awssso_okta_groups(neo4j_session: neo4j.Session) -> list[str]:
+    """
+    Return list of all Okta group ids tied to the Okta Application named "amazon_aws_sso".
+    """
+    query = """
+    MATCH (g:OktaGroup)--(a:OktaApplication{name:"amazon_aws_sso"})
+    RETURN g.id
+    """
+    return neo4j_session.read_transaction(read_list_of_values_tx, query)
+
+
+def get_aws_sso_role_arn(okta_group_name: str, mapping_regex: str, neo4j_session: neo4j.Session) -> str | None:
+    account_and_role = _get_account_and_role_name(okta_group_name, mapping_regex)
+    if not account_and_role:
+        return None
+    account_id = account_and_role[0]
+    role_name = account_and_role[1]
+
+    # The associated SSO role will have a 'AWSReservedSSO' prefix and a hashed suffix -- we remove those.
+    query = """
+    MATCH (:AWSAccount{id:$account_id})-[:RESOURCE]->(role:AWSRole{path:"/aws-reserved/sso.amazonaws.com/"})
+    WHERE SPLIT(role.name, '_')[1..-1][0] = $role_slug
+    RETURN role.arn AS role_arn
+    """
+    return neo4j_session.read_transaction(read_single_value_tx, query, account_id=account_id, role_slug=role_name)
+
+
+def query_for_okta_to_awssso_role_mapping(neo4j_session: neo4j.Session, mapping_regex: str) -> list[dict[str, str]]:
+    """
+    Inputs:
+    - neo4j session
+    - the okta group to aws role mapping regex as defined in cartography.config
+    Output:
+    - a list of dicts with keys `groupid` and `role_arn`
+    """
+    result = []
+    okta_groups = get_awssso_okta_groups(neo4j_session)
+    for group_id in okta_groups:
+        role_name = get_aws_sso_role_arn(group_id, mapping_regex, neo4j_session)
+        if role_name:
+            result.append({'groupid': group_id, 'role_arn': role_name})
+    return result
+
+
+def _load_awssso_tx(tx: neo4j.Transaction, group_to_role: list[dict[str, str]], okta_update_tag: int) -> None:
+    ingest_statement = """
+    UNWIND $GROUP_TO_ROLE as app_data
+        MATCH (role:AWSRole{arn: app_data.role_arn})
+        MATCH (group:OktaGroup{id: app_data.groupid})
+        MERGE (role)<-[r:ALLOWED_BY]-(group)
+        ON CREATE SET r.firstseen = timestamp()
+        SET r.lastupdated = $okta_update_tag
+    """
+    tx.run(
+        ingest_statement,
+        GROUP_TO_ROLE=group_to_role,
+        okta_update_tag=okta_update_tag,
+    )
+
+
+def _load_okta_group_to_awssso_roles(
+        neo4j_session: neo4j.Session,
+        group_to_role: list[dict[str, str]],
+        okta_update_tag: int,
+) -> None:
+    neo4j_session.write_transaction(_load_awssso_tx, group_to_role, okta_update_tag)
+
+
 @timeit
 def sync_okta_aws_saml(neo4j_session: neo4j.Session, mapping_regex: str, okta_update_tag: int) -> None:
     """
@@ -127,3 +205,6 @@ def sync_okta_aws_saml(neo4j_session: neo4j.Session, mapping_regex: str, okta_up
     group_to_role_mapping = query_for_okta_to_aws_role_mapping(neo4j_session, mapping_regex)
     _load_okta_group_to_aws_roles(neo4j_session, group_to_role_mapping, okta_update_tag)
     _load_human_can_assume_role(neo4j_session, okta_update_tag)
+
+    group_to_ssorole_mapping = query_for_okta_to_awssso_role_mapping(neo4j_session, mapping_regex)
+    _load_okta_group_to_awssso_roles(neo4j_session, group_to_ssorole_mapping, okta_update_tag)

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -555,6 +555,12 @@ Representation of an AWS [IAM Role](https://docs.aws.amazon.com/IAM/latest/APIRe
     (AWSRole)-[TRUSTS_AWS_PRINCIPAL]->(AWSPrincipal)
     ```
 
+- Members of an Okta group can assume associated AWS roles if Okta SAML is configured with AWS.
+
+    ```
+    (AWSRole)-[ALLOWED_BY]->(OktaGroup)
+    ```
+
 - AWS Roles are defined in AWS Accounts.
 
     ```

--- a/docs/root/modules/okta/schema.md
+++ b/docs/root/modules/okta/schema.md
@@ -130,6 +130,10 @@ Representation of an [Okta Group](https://developer.okta.com/docs/reference/api/
      ```
     (OktaGroup)-[MEMBER_OF_OKTA_ROLE]->(OktaAdministrationRole)
     ```
+- Members of an Okta group can assume associated AWS roles if Okta SAML is configured with AWS.
+    ```
+    (AWSRole)-[ALLOWED_BY]->(OktaGroup)
+    ```
 
 ### OktaApplication
 

--- a/tests/integration/cartography/intel/okta/test_awssaml.py
+++ b/tests/integration/cartography/intel/okta/test_awssaml.py
@@ -1,0 +1,123 @@
+from cartography.intel.okta.awssaml import _load_okta_group_to_awssso_roles
+from cartography.intel.okta.awssaml import get_awssso_okta_groups
+from cartography.intel.okta.awssaml import get_awssso_role_arn
+from cartography.intel.okta.awssaml import GroupRole
+from cartography.intel.okta.awssaml import OktaGroup
+from tests.integration.util import check_rels
+
+
+TEST_UPDATE_TAG = 000000
+TEST_ORG_ID = 'ORG_ID'
+DEFAULT_REGEX = r"^aws\#\S+\#(?{{role}}[\w\-]+)\#(?{{accountid}}\d+)$"
+
+
+def test_get_awssso_okta_groups(neo4j_session):
+    # Arrange
+    _ensure_okta_test_data(neo4j_session)
+
+    # Act
+    groups = get_awssso_okta_groups(neo4j_session, TEST_ORG_ID)
+
+    # Assert that the data objects are created correctly
+    assert sorted(groups) == [
+        OktaGroup(group_id='0oaxm1', group_name='AWS_1234_myrole1'),
+        OktaGroup(group_id='0oaxm2', group_name='AWS_1234_myrole2'),
+        OktaGroup(group_id='0oaxm3', group_name='AWS_1234_myrole3'),
+    ]
+
+
+def _ensure_okta_test_data(neo4j_session):
+    test_groups = [
+        ('AWS_1234_myrole1', '0oaxm1'),
+        ('AWS_1234_myrole2', '0oaxm2'),
+        ('AWS_1234_myrole3', '0oaxm3'),
+    ]
+    for group in test_groups:
+        neo4j_session.run(
+            '''
+            MERGE (o:OktaOrganization{id: $ORG_ID})
+            MERGE (o)-[:RESOURCE]-> (g:OktaGroup{name: $GROUP_NAME, id: $GROUP_ID, lastupdated: $UPDATE_TAG})
+            MERGE (o)-[:RESOURCE]->(a:OktaApplication{name:"amazon_aws_sso"})
+            MERGE (a)<-[:APPLICATION]-(g)
+            ''',
+            ORG_ID=TEST_ORG_ID,
+            GROUP_NAME=group[0],
+            GROUP_ID=group[1],
+            UPDATE_TAG=TEST_UPDATE_TAG,
+        )
+
+
+def test_get_awssso_role_arn(neo4j_session):
+    # Arrange
+    _ensure_aws_test_data(neo4j_session)
+
+    # Act and assert
+    assert get_awssso_role_arn(
+        '1234',
+        'myrole1',
+        neo4j_session,
+    ) == 'arn:aws:iam:1234:role/AWSReservedSSO_myrole1_abcdef'
+
+    # Act and assert that we grab the role in the other account correctly
+    assert get_awssso_role_arn(
+        '2345',
+        'myrole1',
+        neo4j_session,
+    ) == 'arn:aws:iam:2345:role/AWSReservedSSO_myrole1_abcdef'
+
+    # Act and assert the None case
+    assert get_awssso_role_arn('1234', 'myrole4', neo4j_session) is None
+
+
+def _ensure_aws_test_data(neo4j_session):
+    # Arrange
+    test_sso_roles = [
+        ('AWSReservedSSO_myrole1_abcdef', 'arn:aws:iam:1234:role/AWSReservedSSO_myrole1_abcdef', '1234'),
+        ('AWSReservedSSO_myrole2_bcdefa', 'arn:aws:iam:1234:role/AWSReservedSSO_myrole2_bcdefa', '1234'),
+        ('AWSReservedSSO_myrole3_cdefab', 'arn:aws:iam:1234:role/AWSReservedSSO_myrole3_cdefab', '1234'),
+        # Add one that has same role name but is in a different account. Expect this to not be returned.
+        ('AWSReservedSSO_myrole1_abcdef', 'arn:aws:iam:2345:role/AWSReservedSSO_myrole1_abcdef', '2345'),
+    ]
+    for role in test_sso_roles:
+        neo4j_session.run(
+            '''
+            MERGE (o:AWSAccount{id: $account_id})
+            MERGE (o)-[:RESOURCE]->
+                  (r1:AWSRole{name: $role_name, id: $arn, arn: $arn, path: $path, lastupdated: $update_tag})
+            ''',
+            role_name=role[0],
+            arn=role[1],
+            id=role[1],
+            account_id=role[2],
+            path='/aws-reserved/sso.amazonaws.com/',
+            update_tag=TEST_UPDATE_TAG,
+        )
+
+
+def test_load_okta_group_to_awssso_roles(neo4j_session):
+    # Arrange
+    _ensure_aws_test_data(neo4j_session)
+    _ensure_okta_test_data(neo4j_session)
+    group_roles = [
+        GroupRole(okta_group_id='0oaxm1', aws_role_arn='arn:aws:iam:1234:role/AWSReservedSSO_myrole1_abcdef'),
+        GroupRole(okta_group_id='0oaxm2', aws_role_arn='arn:aws:iam:1234:role/AWSReservedSSO_myrole2_bcdefa'),
+        GroupRole(okta_group_id='0oaxm3', aws_role_arn='arn:aws:iam:1234:role/AWSReservedSSO_myrole3_cdefab'),
+    ]
+
+    # Act
+    _load_okta_group_to_awssso_roles(neo4j_session, group_roles, TEST_UPDATE_TAG)
+
+    # Assert
+    assert check_rels(
+        neo4j_session,
+        'AWSRole',
+        'id',
+        'OktaGroup',
+        'name',
+        'ALLOWED_BY',
+        False,
+    ) == {
+        ('arn:aws:iam:1234:role/AWSReservedSSO_myrole1_abcdef', 'AWS_1234_myrole1'),
+        ('arn:aws:iam:1234:role/AWSReservedSSO_myrole2_bcdefa', 'AWS_1234_myrole2'),
+        ('arn:aws:iam:1234:role/AWSReservedSSO_myrole3_cdefab', 'AWS_1234_myrole3'),
+    }

--- a/tests/unit/cartography/intel/okta/test_awssaml.py
+++ b/tests/unit/cartography/intel/okta/test_awssaml.py
@@ -1,12 +1,25 @@
+from typing import Optional
+from unittest import mock
+from unittest.mock import MagicMock
+
+import cartography.intel.okta.awssaml
+from cartography.intel.okta.awssaml import _parse_okta_group_name
+from cartography.intel.okta.awssaml import AccountRole
+from cartography.intel.okta.awssaml import GroupRole
+from cartography.intel.okta.awssaml import OktaGroup
+from cartography.intel.okta.awssaml import query_for_okta_to_awssso_role_mapping
 from cartography.intel.okta.awssaml import transform_okta_group_to_aws_role
+
+
+SAMPLE_OKTA_GROUP_IDS = ['00g9oh2', '00g9oh3', '00g9oh4']
+DEFAULT_REGEX = r"AWS_(?{{accountid}}\d+)_(?{{role}}[a-zA-Z0-9+=,.@\-_]+)"
 
 
 def test_saml_with_default_regex():
     group_name = "aws#northamerica-production#Tier1_Support#828416469395"
     group_id = "groupid"
-    default_regex = r"^aws\#\S+\#(?{{role}}[\w\-]+)\#(?{{accountid}}\d+)$"
 
-    result = transform_okta_group_to_aws_role(group_id, group_name, default_regex)
+    result = transform_okta_group_to_aws_role(group_id, group_name, DEFAULT_REGEX)
 
     assert result
     assert result["groupid"] == group_id
@@ -23,3 +36,44 @@ def test_saml_with_custom_regex():
     assert result
     assert result["groupid"] == group_id
     assert result["role"] == "arn:aws:iam::123456789123:role/developer"
+
+
+def test_parse_okta_group_name() -> None:
+    group_name = 'AWS_1234_myrole1'
+
+    # Act
+    account_role: Optional[AccountRole] = _parse_okta_group_name(group_name, DEFAULT_REGEX)
+
+    # Assert
+    assert account_role is not None
+    assert account_role.role_name == 'myrole1'
+    assert account_role.account_id == '1234'
+
+
+@mock.patch.object(
+    cartography.intel.okta.awssaml,
+    'get_awssso_role_arn',
+    side_effect=[
+        'arn:aws:iam:1234:role/AWSReservedSSO_myrole1_abcdef',
+        'arn:aws:iam:1234:role/AWSReservedSSO_myrole2_bcdefa',
+        'arn:aws:iam:1234:role/AWSReservedSSO_myrole3_cdefab',
+    ],
+)
+def test_query_for_okta_to_awssso_role_mapping(mock_get_awssso_role_arn: MagicMock) -> None:
+    # Arrange
+    neo4j_session = mock.MagicMock()
+    okta_groups = [
+        OktaGroup(group_id='0oaxm1', group_name='AWS_1234_myrole1'),
+        OktaGroup(group_id='0oaxm2', group_name='AWS_1234_myrole2'),
+        OktaGroup(group_id='0oaxm3', group_name='AWS_1234_myrole3'),
+    ]
+
+    # Act
+    result = query_for_okta_to_awssso_role_mapping(neo4j_session, okta_groups, DEFAULT_REGEX)
+
+    # Assert
+    assert result == [
+        GroupRole(okta_group_id='0oaxm1', aws_role_arn='arn:aws:iam:1234:role/AWSReservedSSO_myrole1_abcdef'),
+        GroupRole(okta_group_id='0oaxm2', aws_role_arn='arn:aws:iam:1234:role/AWSReservedSSO_myrole2_bcdefa'),
+        GroupRole(okta_group_id='0oaxm3', aws_role_arn='arn:aws:iam:1234:role/AWSReservedSSO_myrole3_cdefab'),
+    ]


### PR DESCRIPTION
AWS SSO role names are weird because they look like `AWSReservedSSO_myrolename_<somehash>`. This caused our awssaml module to not draw links from Okta groups to these SSO roles correctly. This PR updates the module with the correct string comparisons to do this.

Screenshot showing that this works:
![Screenshot 2024-06-03 at 1 49 03 PM](https://github.com/lyft/cartography/assets/46503781/82ef7971-36f3-4f07-ac9c-7d0f856489e2)