### PR TITLE
Handle flaky CI failures in integration tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,3 +69,8 @@ ignore_errors = true
 
 [coverage:report]
 fail_under = 30
+
+[tool:pytest]
+addopts = --cov-config=setup.cfg --no-cov-on-fail --cov-report=term-missing:skip-covered --strict-markers
+markers =
+  flaky: mark test as flaky

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,8 @@ pre-commit
 pytest>=6.2.4
 pytest-mock
 pytest-cov==2.10.0
+# To avoid flaky integration tests
+pytest-rerunfailures
 
 types-PyYAML
 types-requests<2.31.0.7

--- a/tests/integration/test_util.py
+++ b/tests/integration/test_util.py
@@ -4,6 +4,7 @@ from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
 
+@pytest.mark.flaky(reruns=5)
 def test_check_rels(neo4j_session):
     # Arrange
     neo4j_session.run(


### PR DESCRIPTION
See https://github.com/neo4j/neo4j/issues/13404 for context.

The neo4j 4.x container in our CI occasionally fails integration tests because we create indexes quickly without giving the database enough time for those actions to settle (roughly speaking).

This PR uses pytest-rerunfailures to retry flaky tests so that we don't need to manually re-run them.

Credit to @heryxpc for figuring this out.