### PR TITLE
#1316: EC2SubnetInstanceNodeProperties: s/subnet_id/subnetid/

### DIFF
--- a/cartography/models/aws/ec2/subnet_instance.py
+++ b/cartography/models/aws/ec2/subnet_instance.py
@@ -15,7 +15,7 @@ from cartography.models.core.relationships import TargetNodeMatcher
 class EC2SubnetInstanceNodeProperties(CartographyNodeProperties):
     # arn: PropertyRef = PropertyRef('Arn', extra_index=True) TODO use arn; issue #1024
     id: PropertyRef = PropertyRef('SubnetId')
-    subnet_id: PropertyRef = PropertyRef('SubnetId', extra_index=True)
+    subnetid: PropertyRef = PropertyRef('SubnetId', extra_index=True)
     region: PropertyRef = PropertyRef('Region', set_in_kwargs=True)
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_instances.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_instances.py
@@ -91,6 +91,11 @@ def test_sync_ec2_instances(mock_get_instances, neo4j_session):
         ('eni-87', 'SOME_SUBNET_1'),
     }
 
+    # #1316: Assert the fields of the subnet are as expected and that subnet_id does not exist
+    assert check_nodes(neo4j_session, 'EC2Subnet', ['id', 'subnetid', 'subnet_id']) == {
+        ('SOME_SUBNET_1', 'SOME_SUBNET_1', None),
+    }
+
     # Assert network interface to security group
     assert check_rels(
         neo4j_session,

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_subnets.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_subnets.py
@@ -1,6 +1,6 @@
 import cartography.intel.aws.ec2
 import tests.data.aws.ec2.subnets
-
+from tests.integration.util import check_nodes
 
 TEST_ACCOUNT_ID = '000000000000'
 TEST_REGION = 'eu-north-1'
@@ -16,21 +16,20 @@ def test_load_subnets(neo4j_session):
         TEST_ACCOUNT_ID,
         TEST_UPDATE_TAG,
     )
-
-    expected_nodes = {
-        "arn:aws:ec2:eu-north-1:000000000000:subnet/subnet-0773409557644dca4",
-        "arn:aws:ec2:eu-north-1:000000000000:subnet/subnet-020b2f3928f190ce8",
-        "arn:aws:ec2:eu-north-1:000000000000:subnet/subnet-0fa9c8fa7cb241479",
+    assert check_nodes(neo4j_session, 'EC2Subnet', ['subnetid', 'subnet_arn']) == {
+        (
+            'subnet-020b2f3928f190ce8',
+            'arn:aws:ec2:eu-north-1:000000000000:subnet/subnet-020b2f3928f190ce8',
+        ),
+        (
+            'subnet-0773409557644dca4',
+            'arn:aws:ec2:eu-north-1:000000000000:subnet/subnet-0773409557644dca4',
+        ),
+        (
+            'subnet-0fa9c8fa7cb241479',
+            'arn:aws:ec2:eu-north-1:000000000000:subnet/subnet-0fa9c8fa7cb241479',
+        ),
     }
-
-    nodes = neo4j_session.run(
-        """
-        MATCH (s:EC2Subnet) RETURN s.subnet_arn;
-        """,
-    )
-    actual_nodes = {n['s.subnet_arn'] for n in nodes}
-
-    assert actual_nodes == expected_nodes
 
 
 def test_load_subnet_relationships(neo4j_session):

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_subnets.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_subnets.py
@@ -16,6 +16,7 @@ def test_load_subnets(neo4j_session):
         TEST_ACCOUNT_ID,
         TEST_UPDATE_TAG,
     )
+    # Assert that we create EC2Subnet nodes and correctly include their subnetid field
     assert check_nodes(neo4j_session, 'EC2Subnet', ['subnetid', 'subnet_arn']) == {
         (
             'subnet-020b2f3928f190ce8',


### PR DESCRIPTION
Fixes #1316.

Fixes a typo where EC2 subnets as known by EC2 instances would have their id in `subnet_id` instead of `subnetid`. This would cause a missing relationship between the subnet and VPC because VPCs attach to subnets using `subnetid`; see https://github.com/lyft/cartography/blob/098d8ca5f4bb172944338dad9df797a36e23485a/cartography/intel/aws/ec2/subnets.py#L50-L51.

This PR is the same as #1318 but with tests; getting this fixed asap.

See https://lyftoss.slack.com/archives/CTZUQL0KX/p1718644518442939 for more context.