### PR TITLE
Update Semgrep intel module to use the /findings API endpoint

### DIFF
--- a/cartography/data/jobs/scoped_analysis/semgrep_sca_risk_analysis.json
+++ b/cartography/data/jobs/scoped_analysis/semgrep_sca_risk_analysis.json
@@ -13,47 +13,47 @@
         },
         {
             "__comment__": "not possible to identify if reachable && version specifier is the only flag of the vulnerability (likelihood = rare) && severity in [low, medium, high] -> Risk = Info",
-            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'UNKNOWN_EXPOSURE', reachability_check:'VERSION_SPECIFIER', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity IN ['LOW', 'MEDIUM', 'HIGH'] SET s.reachability_risk = 'INFO' return COUNT(*) as TotalCompleted",
+            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'UNREACHABLE', reachability_check:'NO REACHABILITY ANALYSIS', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity IN ['LOW', 'MEDIUM', 'HIGH'] SET s.reachability_risk = 'INFO' return COUNT(*) as TotalCompleted",
             "iterative": false
         },
         {
             "__comment__": "not possible to identify if reachable && version specifier is the only flag of the vulnerability (likelihood = rare) && severity = critical -> Risk = Low",
-            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'UNKNOWN_EXPOSURE', reachability_check:'VERSION_SPECIFIER', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity = 'CRITICAL' SET s.reachability_risk = 'LOW' return COUNT(*) as TotalCompleted",
+            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'UNREACHABLE', reachability_check:'NO REACHABILITY ANALYSIS', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity = 'CRITICAL' SET s.reachability_risk = 'LOW' return COUNT(*) as TotalCompleted",
             "iterative": false
         },
         {
-            "__comment__": "manual review required to confirm && version specifier is the only flag of the vulnerability (likelihood = possible) && severity in [low, medium] -> Risk = Low",
-            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'MANUAL_REVIEW_REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity IN ['LOW', 'MEDIUM'] SET s.reachability_risk = 'LOW' return COUNT(*) as TotalCompleted",
+            "__comment__": "manual review required to confirm exploitation when conditions met && identified version is vulnerable (likelihood = possible) && severity in [low, medium] -> Risk = Low",
+            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'CONDITIONALLY REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity IN ['LOW', 'MEDIUM'] SET s.reachability_risk = 'LOW' return COUNT(*) as TotalCompleted",
             "iterative": false
         },
         {
-            "__comment__": "manual review required to confirm && version specifier is the only flag of the vulnerability (likelihood = possible) && severity = high -> Risk = Medium",
-            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'MANUAL_REVIEW_REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity = 'HIGH' SET s.reachability_risk = 'MEDIUM' return COUNT(*) as TotalCompleted",
+            "__comment__": "manual review required to confirm exploitation when conditions met && identified version is vulnerable (likelihood = possible) && severity = high -> Risk = Medium",
+            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'CONDITIONALLY REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity = 'HIGH' SET s.reachability_risk = 'MEDIUM' return COUNT(*) as TotalCompleted",
             "iterative": false
         },
         {
-            "__comment__": "manual review required to confirm && version specifier is the only flag of the vulnerability (likelihood = possible) &&  severity = critical -> Risk = High",
-            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'MANUAL_REVIEW_REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity = 'CRITICAL' SET s.reachability_risk = 'HIGH' return COUNT(*) as TotalCompleted",
+            "__comment__": "manual review required to confirm exploitation when conditions met && identified version is vulnerable (likelihood = possible) &&  severity = critical -> Risk = High",
+            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'CONDITIONALLY REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity = 'CRITICAL' SET s.reachability_risk = 'HIGH' return COUNT(*) as TotalCompleted",
             "iterative": false
         },
         {
             "__comment__": "adding the vulnerable version flags it reachable (likelihood = likely) && severity in [low, medium] -> Risk = Low",
-            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'ALWAYS_REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity IN ['LOW','MEDIUM'] SET s.reachability_risk = 'LOW' return COUNT(*) as TotalCompleted",
+            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'ALWAYS REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity IN ['LOW','MEDIUM'] SET s.reachability_risk = 'LOW' return COUNT(*) as TotalCompleted",
             "iterative": false
         },
         {
-            "__comment__": "adding the vulnerable version flags it reachable (likelihood = likely) && severity = high -> Risk = Low",
-            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'ALWAYS_REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity = 'HIGH' SET s.reachability_risk = 'MEDIUM' return COUNT(*) as TotalCompleted",
+            "__comment__": "adding the vulnerable version flags it reachable (likelihood = likely) && severity = high -> Risk = Medium",
+            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'ALWAYS REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity = 'HIGH' SET s.reachability_risk = 'MEDIUM' return COUNT(*) as TotalCompleted",
             "iterative": false
         },
         {
             "__comment__": "adding the vulnerable version flags it reachable (special case for critical, if something is so critical that needs to be fixed, likelihood = likely)) && severity = critical -> Risk = Critical",
-            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'ALWAYS_REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity = 'CRITICAL' SET s.reachability_risk = 'CRITICAL' return COUNT(*) as TotalCompleted",
+            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'ALWAYS REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) WHERE s.severity = 'CRITICAL' SET s.reachability_risk = 'CRITICAL' return COUNT(*) as TotalCompleted",
             "iterative": false
         },
         {
             "__comment__": "if reachability analysis confirmed that is rechable (likelihood = certain) -> Risk = Severity",
-            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'REACHABILITY', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) SET s.reachability_risk = s.severity return COUNT(*) as TotalCompleted",
+            "query": "MATCH (g:GitHubRepository{archived:false})<-[:FOUND_IN]-(s:SemgrepSCAFinding{reachability:'REACHABLE', reachability_check:'REACHABLE', lastupdated:$UPDATE_TAG})<-[:RESOURCE]-(:SemgrepDeployment{id:$DEPLOYMENT_ID}) SET s.reachability_risk = s.severity return COUNT(*) as TotalCompleted",
             "iterative": false
         },
         {

--- a/cartography/intel/semgrep/findings.py
+++ b/cartography/intel/semgrep/findings.py
@@ -198,7 +198,7 @@ def transform_sca_vulns(raw_vulns: List[Dict[str, Any]]) -> Tuple[List[Dict[str,
                 usage_dict["url"] = url
                 usages.append(usage_dict)
             vulns.append(sca_vuln)
-        except Exception as e:
+        except KeyError as e:
             logger.warning(f"Error transforming Semgrep SCA vuln {vuln}: {e}")
             continue
     return vulns, usages

--- a/cartography/intel/semgrep/findings.py
+++ b/cartography/intel/semgrep/findings.py
@@ -3,10 +3,11 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Tuple
-from urllib.error import HTTPError
 
 import neo4j
 import requests
+from requests.exceptions import HTTPError
+from requests.exceptions import ReadTimeout
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
@@ -20,6 +21,7 @@ from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 stat_handler = get_stats_client(__name__)
+_PAGE_SIZE = 500
 _TIMEOUT = (60, 60)
 _MAX_RETRIES = 3
 
@@ -48,58 +50,89 @@ def get_deployment(semgrep_app_token: str) -> Dict[str, Any]:
 
 
 @timeit
-def get_sca_vulns(semgrep_app_token: str, deployment_id: str) -> List[Dict[str, Any]]:
+def get_sca_vulns(semgrep_app_token: str, deployment_slug: str) -> List[Dict[str, Any]]:
     """
     Gets the SCA vulns associated with the passed Semgrep App token and deployment id.
     param: semgrep_app_token: The Semgrep App token to use for authentication.
-    param: deployment_id: The Semgrep deployment id to use for retrieving SCA vulns.
+    param: deployment_slug: The Semgrep deployment slug to use for retrieving SCA vulns.
     """
     all_vulns = []
-    sca_url = f"https://semgrep.dev/api/v1/deployments/{deployment_id}/ssc-vulns"
+    sca_url = f"https://semgrep.dev/api/v1/deployments/{deployment_slug}/findings"
     has_more = True
-    cursor: Dict[str, str] = {}
-    page = 1
+    page = 0
     retries = 0
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {semgrep_app_token}",
     }
 
-    request_data = {
-        "deploymentId": deployment_id,
-        "pageSize": 100,
-        "exposure": ["UNREACHABLE", "REACHABLE", "UNKNOWN_EXPOSURE"],
-        "refs": ["_default"],
+    request_data: dict[str, Any] = {
+        "page": page,
+        "page_size": _PAGE_SIZE,
+        "issue_type": "sca",
+        "exposures": "reachable,always_reachable,conditionally_reachable,unreachable,unknown",
+        "ref": "_default",
+        "dedup": "true",
     }
-
+    logger.info(f"Retrieving Semgrep SCA vulns for deployment '{deployment_slug}'.")
     while has_more:
 
-        if cursor:
-            request_data.update({
-                "cursor": {
-                    "vulnOffset": cursor["vulnOffset"],
-                    "issueOffset": cursor["issueOffset"],
-                },
-            })
         try:
-            response = requests.post(sca_url, json=request_data, headers=headers, timeout=_TIMEOUT)
+            response = requests.get(sca_url, params=request_data, headers=headers, timeout=_TIMEOUT)
             response.raise_for_status()
             data = response.json()
-        except HTTPError as e:
+        except (ReadTimeout, HTTPError) as e:
             logger.warning(f"Failed to retrieve Semgrep SCA vulns for page {page}. Retrying...")
             retries += 1
             if retries >= _MAX_RETRIES:
                 raise e
             continue
-        vulns = data["vulns"]
-        cursor = data.get("cursor")
-        has_more = data.get("hasMore", False)
+        vulns = data["findings"]
+        has_more = len(vulns) > 0
         if page % 10 == 0:
-            logger.info(f"Processed {page} pages of Semgrep SCA vulnerabilities so far.")
+            logger.info(f"Processed page {page} of Semgrep SCA vulnerabilities.")
         all_vulns.extend(vulns)
         retries = 0
+        page += 1
+        request_data["page"] = page
 
+    logger.info(f"Retrieved {len(all_vulns)} Semgrep SCA vulns in {page} pages.")
     return all_vulns
+
+
+def _get_vuln_class(vuln: Dict) -> str:
+    vulnerability_classes = vuln["rule"].get("vulnerability_classes", [])
+    if vulnerability_classes:
+        return vulnerability_classes[0]
+    return "Other"
+
+
+def _determine_exposure(vuln: Dict[str, Any]) -> str | None:
+    # See Semgrep reachability types:
+    # https://semgrep.dev/docs/semgrep-supply-chain/overview#types-of-semgrep-supply-chain-findings
+    reachability_types = {
+        "NO REACHABILITY ANALYSIS": 2,
+        "UNREACHABLE": 2,
+        "REACHABLE": 0,
+        "ALWAYS REACHABLE": 0,
+        "CONDITIONALLY REACHABLE": 1,
+    }
+    reachable_flag = vuln["reachability"]
+    if reachable_flag and reachable_flag.upper() in reachability_types:
+        reach_score = reachability_types[reachable_flag.upper()]
+        if reach_score < reachability_types["UNREACHABLE"]:
+            return "REACHABLE"
+        else:
+            return "UNREACHABLE"
+    return None
+
+
+def _build_vuln_url(vuln: str) -> str | None:
+    if 'CVE' in vuln:
+        return f"https://nvd.nist.gov/vuln/detail/{vuln}"
+    if 'GHSA' in vuln:
+        return f"https://github.com/advisories/{vuln}"
+    return None
 
 
 def transform_sca_vulns(raw_vulns: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, str]]]:
@@ -110,48 +143,64 @@ def transform_sca_vulns(raw_vulns: List[Dict[str, Any]]) -> Tuple[List[Dict[str,
     vulns = []
     usages = []
     for vuln in raw_vulns:
-        sca_vuln: Dict[str, Any] = {}
-        # Mandatory fields
-        sca_vuln["id"] = vuln["groupKey"]
-        sca_vuln["repositoryName"] = vuln["repositoryName"]
-        sca_vuln["ruleId"] = vuln["advisory"]["ruleId"]
-        sca_vuln["title"] = vuln["advisory"]["title"]
-        sca_vuln["description"] = vuln["advisory"]["description"]
-        sca_vuln["ecosystem"] = vuln["advisory"]["ecosystem"]
-        sca_vuln["severity"] = vuln["advisory"]["severity"]
-        sca_vuln["reachability"] = vuln["advisory"]["reachability"]
-        sca_vuln["reachableIf"] = vuln["advisory"]["reachableIf"]
-        sca_vuln["exposureType"] = vuln["exposureType"]
-        dependency = f"{vuln['matchedDependency']['name']}|{vuln['matchedDependency']['versionSpecifier']}"
-        sca_vuln["matchedDependency"] = dependency
-        sca_vuln["dependencyFileLocation_path"] = vuln["dependencyFileLocation"]["path"]
-        sca_vuln["dependencyFileLocation_url"] = vuln["dependencyFileLocation"]["url"]
-        # Optional fields
-        sca_vuln["transitivity"] = vuln.get("transitivity", None)
-        cves = vuln.get("advisory", {}).get("references", {}).get("cveIds")
-        if len(cves) > 0:
-            # Take the first CVE
-            sca_vuln["cveId"] = vuln["advisory"]["references"]["cveIds"][0]
-        if vuln.get('closestSafeDependency'):
-            dep_fix = f"{vuln['closestSafeDependency']['name']}|{vuln['closestSafeDependency']['versionSpecifier']}"
-            sca_vuln["closestSafeDependency"] = dep_fix
-        if vuln["advisory"].get("references", {}).get("urls", []):
-            sca_vuln["ref_urls"] = vuln["advisory"].get("references", {}).get("urls", [])
-        sca_vuln["openedAt"] = vuln.get("openedAt", None)
-        sca_vuln["announcedAt"] = vuln.get("announcedAt", None)
-        sca_vuln["fixStatus"] = vuln["triage"]["status"]
-        for usage in vuln.get("usages", []):
-            usage_dict = {}
-            usage_dict["SCA_ID"] = sca_vuln["id"]
-            usage_dict["findingId"] = usage["findingId"]
-            usage_dict["path"] = usage["location"]["path"]
-            usage_dict["startLine"] = usage["location"]["startLine"]
-            usage_dict["startCol"] = usage["location"]["startCol"]
-            usage_dict["endLine"] = usage["location"]["endLine"]
-            usage_dict["endCol"] = usage["location"]["endCol"]
-            usage_dict["url"] = usage["location"]["url"]
-            usages.append(usage_dict)
-        vulns.append(sca_vuln)
+        try:
+            sca_vuln: Dict[str, Any] = {}
+            # Mandatory fields
+            repository_name = vuln["repository"]["name"]
+            rule_id = vuln["rule"]["name"]
+            vulnerability_class = _get_vuln_class(vuln)
+            package = vuln['found_dependency']['package']
+            sca_vuln["id"] = vuln["id"]
+            sca_vuln["repositoryName"] = repository_name
+            sca_vuln["branch"] = vuln["ref"]
+            sca_vuln["ruleId"] = rule_id
+            sca_vuln["title"] = package + ":" + vulnerability_class
+            sca_vuln["description"] = vuln["rule"]["message"]
+            sca_vuln["ecosystem"] = vuln["found_dependency"]["ecosystem"]
+            sca_vuln["severity"] = vuln["severity"].upper()
+            sca_vuln["reachability"] = vuln["reachability"].upper()  # Check done to determine rechabilitity
+            sca_vuln["reachableIf"] = vuln["reachable_condition"].upper() if vuln["reachable_condition"] else None
+            sca_vuln["exposureType"] = _determine_exposure(vuln)  # Determintes if reachable or unreachable
+            dependency = f"{package}|{vuln['found_dependency']['version']}"
+            sca_vuln["matchedDependency"] = dependency
+            dep_url = vuln["found_dependency"]["lockfile_line_url"]
+            if dep_url:  # Lock file can be null, need to set
+                dep_file = dep_url.split("/")[-1].split("#")[0]
+                sca_vuln["dependencyFileLocation_path"] = dep_file
+                sca_vuln["dependencyFileLocation_url"] = dep_url
+            else:
+                if sca_vuln.get("location"):
+                    sca_vuln["dependencyFileLocation_path"] = sca_vuln["location"]["file_path"]
+            sca_vuln["transitivity"] = vuln["found_dependency"]["transitivity"].upper()
+            if vuln.get("vulnerability_identifier"):
+                vuln_id = vuln["vulnerability_identifier"].upper()
+                sca_vuln["cveId"] = vuln_id
+                sca_vuln["ref_urls"] = [_build_vuln_url(vuln_id)]
+            if vuln.get('fix_recommendations') and len(vuln['fix_recommendations']) > 0:
+                fix = vuln['fix_recommendations'][0]
+                dep_fix = f"{fix['package']}|{fix['version']}"
+                sca_vuln["closestSafeDependency"] = dep_fix
+            sca_vuln["openedAt"] = vuln["created_at"]
+            sca_vuln["fixStatus"] = vuln["status"]
+            sca_vuln["triageStatus"] = vuln["triage_state"]
+            sca_vuln["confidence"] = vuln["confidence"]
+            usage = vuln.get("usage")
+            if usage:
+                usage_dict = {}
+                url = usage["location"]["url"]
+                usage_dict["SCA_ID"] = sca_vuln["id"]
+                usage_dict["findingId"] = hash(url.split("github.com/")[-1])
+                usage_dict["path"] = usage["location"]["path"]
+                usage_dict["startLine"] = usage["location"]["start_line"]
+                usage_dict["startCol"] = usage["location"]["start_col"]
+                usage_dict["endLine"] = usage["location"]["end_line"]
+                usage_dict["endCol"] = usage["location"]["end_col"]
+                usage_dict["url"] = url
+                usages.append(usage_dict)
+            vulns.append(sca_vuln)
+        except Exception as e:
+            logger.warning(f"Error transforming Semgrep SCA vuln {vuln}: {e}")
+            continue
     return vulns, usages
 
 
@@ -228,9 +277,10 @@ def sync(
     logger.info("Running Semgrep SCA findings sync job.")
     semgrep_deployment = get_deployment(semgrep_app_token)
     deployment_id = semgrep_deployment["id"]
+    deployment_slug = semgrep_deployment["slug"]
     load_semgrep_deployment(neo4j_sesion, semgrep_deployment, update_tag)
     common_job_parameters["DEPLOYMENT_ID"] = deployment_id
-    raw_vulns = get_sca_vulns(semgrep_app_token, deployment_id)
+    raw_vulns = get_sca_vulns(semgrep_app_token, deployment_slug)
     vulns, usages = transform_sca_vulns(raw_vulns)
     load_semgrep_sca_vulns(neo4j_sesion, vulns, deployment_id, update_tag)
     load_semgrep_sca_usages(neo4j_sesion, usages, deployment_id, update_tag)

--- a/cartography/models/semgrep/findings.py
+++ b/cartography/models/semgrep/findings.py
@@ -17,6 +17,7 @@ class SemgrepSCAFindingNodeProperties(CartographyNodeProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
     rule_id: PropertyRef = PropertyRef('ruleId', extra_index=True)
     repository: PropertyRef = PropertyRef('repositoryName', extra_index=True)
+    branch: PropertyRef = PropertyRef('branch')
     summary: PropertyRef = PropertyRef('title', extra_index=True)
     description: PropertyRef = PropertyRef('description')
     package_manager: PropertyRef = PropertyRef('ecosystem')
@@ -32,8 +33,9 @@ class SemgrepSCAFindingNodeProperties(CartographyNodeProperties):
     dependency_file: PropertyRef = PropertyRef('dependencyFileLocation_path', extra_index=True)
     dependency_file_url: PropertyRef = PropertyRef('dependencyFileLocation_url', extra_index=True)
     scan_time: PropertyRef = PropertyRef('openedAt')
-    published_time: PropertyRef = PropertyRef('announcedAt')
     fix_status: PropertyRef = PropertyRef('fixStatus')
+    triage_status: PropertyRef = PropertyRef('triageStatus')
+    confidence: PropertyRef = PropertyRef('confidence')
 
 
 @dataclass(frozen=True)

--- a/docs/root/modules/semgrep/schema.md
+++ b/docs/root/modules/semgrep/schema.md
@@ -39,9 +39,10 @@ Represents a [Semgre Supply Chain](https://semgrep.dev/docs/semgrep-supply-chain
 |-------|--------------|
 | firstseen | Timestamp of when a sync job first discovered this node  |
 | lastupdated | Timestamp of the last time the node was updated |
-| **id** | A composed id based using the repository path and the rule that triggered the finding |
+| **id** | Unique id of the finding taken from Semgrep API |
 | **rule_id** | The rule that triggered the finding |
 | **repository** | The repository path where the finding was discovered |
+| **branch** | The branch where the finding was discovered |
 | summary | A short title summarizing of the finding |
 | description | Description of the vulnerability. |
 | package_manager | The ecosystem of the dependency where the finding was discovered (e.g. pypi, npm, maven) |
@@ -58,8 +59,9 @@ Represents a [Semgre Supply Chain](https://semgrep.dev/docs/semgrep-supply-chain
 | dependency_file | Path of the file where the finding was discovered (e.g. lock.json, requirements.txt) |
 | dependency_file_url | URL of the file where the finding was discovered |
 | scan_time | Date and time when the finding was discovered in UTC |
-| published_time | Date and time when the finding reference (CVE or GHSA) was published in UTC |
-| fix_status | Whether the finding is fixed or not based on triage (e.g. UNKNOWN_STATUS, NEW, IN_PROGRESS, IGNORED, CLOSED) |
+| fix_status | Whether the finding is fixed or not based on triage (e.g. open, fixed, ignored) |
+| triage_status | Whether the finding is triaged or not (e.g. untriaged, ignored, reopened) |
+| confidence | Confidence of the finding based on Semgrep analysis (e.g. high, medium, low) |
 
 
 #### Relationships

--- a/tests/data/semgrep/sca.py
+++ b/tests/data/semgrep/sca.py
@@ -19,7 +19,7 @@ SCA_RESPONSE = {
                 "name": "org/repository",
                 "url": "https: //github.com/org/repository",
             },
-            "line_of_code_url": "https: //github.com/org/repository/blob/71bbed12f950de8335006d7f91112263d8504f1b/src/packages/components/AccountsTable/constants.tsx#L274", # noqa E501
+            "line_of_code_url": "https: //github.com/org/repository/blob/71bbed12f950de8335006d7f91112263d8504f1b/src/packages/components/AccountsTable/constants.tsx#L274",  # noqa E501
             "first_seen_scan_id": 30469982,
             "state": "unresolved",
             "triage_state": "untriaged",
@@ -73,7 +73,7 @@ SCA_RESPONSE = {
                     "start_col": 37,
                     "end_line": 274,
                     "end_col": 62,
-                    "url": "https: //github.com/org/repository/blob/commit_id/src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx#L274", # noqa E501
+                    "url": "https: //github.com/org/repository/blob/commit_id/src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx#L274",  # noqa E501
                 },
                 "external_ticket": None,
             },
@@ -92,6 +92,6 @@ USAGES = [
         "start_col": 37,
         "end_line": 274,
         "end_col": 62,
-        "url": "https: //github.com/org/repository/blob/commit_id/src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx#L274", # noqa E501
+        "url": "https: //github.com/org/repository/blob/commit_id/src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx#L274",  # noqa E501
     },
 ]

--- a/tests/data/semgrep/sca.py
+++ b/tests/data/semgrep/sca.py
@@ -1,120 +1,97 @@
 DEPLOYMENTS = {
     "id": "123456",
-    "name": "YourOrg",
-    "slug": "yourorg",
+    "name": "Org",
+    "slug": "org",
 }
+VULN_ID = 73537136
+USAGE_ID = hash(
+    "org/repository/blob/commit_id/src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx#L274",
+)
 
 SCA_RESPONSE = {
-    "vulns": [
+    "findings": [
         {
-            "title": "Reachable vuln",
-            "advisory": {
-                "ruleId": "ssc-92af1d99-4fb3-4d4e-a9f4-d57572cd6590",
-                "title": "Reachable vuln",
-                "description": "description",
-                "ecosystem": "go",
-                "severity": "HIGH",
-                "references": {
-                    "cveIds": ["CVE-2023-37897"],
-                    "cweIds": ["CWE-617: Reachable Assertion"],
-                    "owaspIds": ["A06:2021 - Vulnerable and Outdated Components"],
-                    "urls": [
-                        "https://github.com/advisories//GHSA-9436-3gmp-4f53",
-                        "https://nvd.nist.gov/vuln/detail/CVE-2023-37897",
-                    ],
-                },
-                "announcedAt": "2023-07-19T21:15:08Z",
-                "ruleText": '{\n  "id": "ssc-92af1d99-4fb3-4d4e-a9f4-d57572cd6590",\n  "languages": [\n    "python",\n    "java",\n    "ruby"\n  ],\n  "message": "message ",\n }',  # noqa E501
-                "reachability": "MANUAL_REVIEW_REACHABLE",
-                "vulnerableDependencies": [
-                    {"name": "grav", "versionSpecifier": "<  1.7.42.1"},
+            "id": VULN_ID,
+            "ref": "main",
+            "syntactic_id": "91f6bebf5c374b3db9ae6b0afeb8ba4f",
+            "match_based_id": "cf89274a455b0f7dae15d218af143cf317fb9886d12f3dcbe0e37cad02d0d29411cecb9a2c3fedc9e973dee5e4dc0b4aeffed2fb666c459a0dadaaa78f420acc_e",
+            "repository": {
+                "name": "org/repository",
+                "url": "https: //github.com/org/repository",
+            },
+            "line_of_code_url": "https: //github.com/org/repository/blob/71bbed12f950de8335006d7f91112263d8504f1b/src/packages/components/AccountsTable/constants.tsx#L274",
+            "first_seen_scan_id": 30469982,
+            "state": "unresolved",
+            "triage_state": "untriaged",
+            "status": "open",
+            "confidence": "high",
+            "created_at": "2024-07-11T20:46:25.269650Z",
+            "relevant_since": "2024-07-11T20:46:25.268845Z",
+            "rule_name": "ssc-1e99e462-0fc5-4109-ad52-d2b5a7048232",
+            "rule_message": "description",
+            "location": {
+                "file_path": "src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx",
+                "line": 274,
+                "column": 37,
+                "end_line": 274,
+                "end_column": 62,
+            },
+            "triaged_at": None,
+            "triage_comment": None,
+            "triage_reason": None,
+            "state_updated_at": None,
+            "categories": ["security"],
+            "rule": {
+                "name": "ssc-1e99e462-0fc5-4109-ad52-d2b5a7048232",
+                "message": "description",
+                "confidence": "high",
+                "category": "security",
+                "subcategories": [],
+                "vulnerability_classes": ["Denial-of-Service (DoS)"],
+                "cwe_names": [
+                    "CWE-1333: Inefficient Regular Expression Complexity",
+                    "CWE-400: Uncontrolled Resource Consumption",
                 ],
-                "safeDependencies": [
-                    {"name": "grav", "versionSpecifier": "1.7.42.2"},
-                ],
-                "reachableIf": "a non-administrator, user account that has Admin panel access and Create/Update page permissions",  # noqa E501
+                "owasp_names": ["A06: 2021 - Vulnerable and Outdated Components"],
             },
-            "exposureType": "REACHABLE",
-            "repositoryId": "123456",
-            "matchedDependency": {"name": "grav", "versionSpecifier": "1.7.42.0"},
-            "dependencyFileLocation": {
-                "path": "go.mod",
-                "startLine": "111",
-                "url": "https://github.com/yourorg/yourrepo/blame/71bbed12f950de8335006d7f91112263d8504f1b/go.mod#L111",
-                "startCol": "0",
-                "endLine": "0",
-                "endCol": "0",
+            "severity": "high",
+            "vulnerability_identifier": "CVE-2022-31129",
+            "reachability": "reachable",
+            "reachable_condition": None,
+            "found_dependency": {
+                "package": "moment",
+                "version": "2.29.2",
+                "ecosystem": "npm",
+                "transitivity": "direct",
+                "lockfile_line_url": "https: //github.com/org/repository/blob/commit_id/package-lock.json#L14373",
             },
-            "usages": [
-                {
-                    "findingId": "20128504",
-                    "location": {
-                        "path": "src/packages/directory/file1.go",
-                        "startLine": "24",
-                        "startCol": "57",
-                        "endLine": "24",
-                        "endCol": "78",
-                        "url": "https://github.com/yourorg/yourrepo/blame/6fdee8f2727f4506cfbbe553e23b895e27956588/src/packages/directory/file1.go.ts#L24",  # noqa E501
-                        "committedAt": "1970-01-01T00:00:00Z",
-                    },
+            "fix_recommendations": [{"package": "moment", "version": "2.29.4"}],
+            "usage": {
+                "location": {
+                    "path": "src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx",
+                    "start_line": 274,
+                    "start_col": 37,
+                    "end_line": 274,
+                    "end_col": 62,
+                    "url": "https: //github.com/org/repository/blob/commit_id/src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx#L274",
                 },
-                {
-                    "findingId": "20128505",
-                    "location": {
-                        "path": "src/packages/directory/file2.go",
-                        "startLine": "24",
-                        "startCol": "37",
-                        "endLine": "24",
-                        "endCol": "54",
-                        "url": "https://github.com/yourorg/yourrepo/blame/6fdee8f2727f4506cfbbe553e23b895e27956588/src/packages/directory/file2.go.ts#L24",  # noqa E501
-                        "committedAt": "1970-01-01T00:00:00Z",
-                    },
-                },
-            ],
-            "triage": {
-                "status": "NEW",
-                "dismissReason": "UNKNOWN_REASON",
-                "issueUrl": "",
-                "prUrl": "",
+                "external_ticket": None,
             },
-            "groupKey": "132465::::ssc-92af1d99-4fb3-4d4e-a9f4-d57572cd6590::reachable",
-            "closestSafeDependency": {"name": "grav", "versionSpecifier": "1.7.42.2"},
-            "repositoryName": "yourorg/yourrepo",
-            "openedAt": "2023-07-19T12:51:53Z",
-            "firstTriagedAt": "1970-01-01T00:00:00Z",
-            "transitivity": "DIRECT",
-            "subdirectory": "",
-            "packageManager": "no_package_manager",
         },
     ],
-    "hasMore": True,
-    "cursor": {
-        "vulnOffset": "1",
-        "issueOffset": "19311309",
-    },
 }
 
-RAW_VULNS = SCA_RESPONSE["vulns"]
-VULN_ID = "yourorg/yourrepo|ssc-92af1d99-4fb3-4d4e-a9f4-d57572cd6590"
+RAW_VULNS = SCA_RESPONSE["findings"]
+
 USAGES = [
-                {
-                    "SCA_ID": VULN_ID,
-                    "findingId": "20128504",
-                    "path": "src/packages/directory/file1.go",
-                    "startLine": "24",
-                    "startCol": "57",
-                    "endLine": "24",
-                    "endCol": "78",
-                    "url": "https://github.com/yourorg/yourrepo/blame/6fdee8f2727f4506cfbbe553e23b895e27956588/src/packages/directory/file1.go.ts#L24",  # noqa E501
-                },
-                {
-                    "SCA_ID": VULN_ID,
-                    "findingId": "20128505",
-                    "path": "src/packages/directory/file2.go",
-                    "startLine": "24",
-                    "startCol": "37",
-                    "endLine": "24",
-                    "endCol": "54",
-                    "url": "https://github.com/yourorg/yourrepo/blame/6fdee8f2727f4506cfbbe553e23b895e27956588/src/packages/directory/file2.go.ts#L24",  # noqa E501
-                },
+    {
+        "SCA_ID": VULN_ID,
+        "findingId": USAGE_ID,
+        "path": "src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx",
+        "start_line": 274,
+        "start_col": 37,
+        "end_line": 274,
+        "end_col": 62,
+        "url": "https: //github.com/org/repository/blob/commit_id/src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx#L274",
+    },
 ]

--- a/tests/data/semgrep/sca.py
+++ b/tests/data/semgrep/sca.py
@@ -14,12 +14,12 @@ SCA_RESPONSE = {
             "id": VULN_ID,
             "ref": "main",
             "syntactic_id": "91f6bebf5c374b3db9ae6b0afeb8ba4f",
-            "match_based_id": "cf89274a455b0f7dae15d218af143cf317fb9886d12f3dcbe0e37cad02d0d29411cecb9a2c3fedc9e973dee5e4dc0b4aeffed2fb666c459a0dadaaa78f420acc_e",
+            "match_based_id": "cf89274a455b0f7dae15d218af143cf317fb9886d12f3dcbe0e37cad02d0d29411cecb9a2c3fedc9e973de",
             "repository": {
                 "name": "org/repository",
                 "url": "https: //github.com/org/repository",
             },
-            "line_of_code_url": "https: //github.com/org/repository/blob/71bbed12f950de8335006d7f91112263d8504f1b/src/packages/components/AccountsTable/constants.tsx#L274",
+            "line_of_code_url": "https: //github.com/org/repository/blob/71bbed12f950de8335006d7f91112263d8504f1b/src/packages/components/AccountsTable/constants.tsx#L274", # noqa E501
             "first_seen_scan_id": 30469982,
             "state": "unresolved",
             "triage_state": "untriaged",
@@ -73,7 +73,7 @@ SCA_RESPONSE = {
                     "start_col": 37,
                     "end_line": 274,
                     "end_col": 62,
-                    "url": "https: //github.com/org/repository/blob/commit_id/src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx#L274",
+                    "url": "https: //github.com/org/repository/blob/commit_id/src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx#L274", # noqa E501
                 },
                 "external_ticket": None,
             },
@@ -92,6 +92,6 @@ USAGES = [
         "start_col": 37,
         "end_line": 274,
         "end_col": 62,
-        "url": "https: //github.com/org/repository/blob/commit_id/src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx#L274",
+        "url": "https: //github.com/org/repository/blob/commit_id/src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx#L274", # noqa E501
     },
 ]


### PR DESCRIPTION
### Summary
Semgrep is consolidating their API  for both SCA and SAST findings: https://semgrep.dev/api/v1/docs/#tag/Finding/operation/semgrep_app.core_exp.findings.handlers.issue.openapi_list_recent_issues deprecating the one we use https://semgrep.dev/api/v1/deployments/1111/ssc-vulns.

This replaces the call to the new API, updates the mapping based on the new info retrieved, adds some guard rails to prevent issues during data ingestion and tackles read time-outs to the new API.

### Related issues or links
None

### Before the change
![Screenshot 2024-07-24 at 7 21 42 p m](https://github.com/user-attachments/assets/25b8df7e-b71b-4b5e-9cc3-560190e7fdb4)


### After the change
![Screenshot 2024-07-24 at 7 22 35 p m](https://github.com/user-attachments/assets/221fe737-81ec-4bd8-821b-e8b920bbf082)

### Log trace
![Screenshot 2024-07-24 at 7 25 19 p m](https://github.com/user-attachments/assets/64c90a8a-fdd7-4d4d-b7fc-ba452584fddc)


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [x ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://lyft.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
