### PR TITLE
#1353: fix: stack trace while logging message

### DIFF
--- a/cartography/intel/kandji/__init__.py
+++ b/cartography/intel/kandji/__init__.py
@@ -22,7 +22,7 @@ def start_kandji_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     if config.kandji_base_uri is None or config.kandji_token is None or config.kandji_tenant_id is None:
         logger.warning(
             'Required parameter missing. Skipping sync. '
-            'See docs to configure.'
+            'See docs to configure.',
         )
         return
 

--- a/cartography/intel/kandji/__init__.py
+++ b/cartography/intel/kandji/__init__.py
@@ -21,8 +21,8 @@ def start_kandji_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     """
     if config.kandji_base_uri is None or config.kandji_token is None or config.kandji_tenant_id is None:
         logger.warning(
-            'Required parameter missing. Skipping sync.',
-            'See docs to configure.',
+            'Required parameter missing. Skipping sync. '
+            'See docs to configure.'
         )
         return
 

--- a/cartography/intel/kandji/__init__.py
+++ b/cartography/intel/kandji/__init__.py
@@ -21,7 +21,7 @@ def start_kandji_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     """
     if config.kandji_base_uri is None or config.kandji_token is None or config.kandji_tenant_id is None:
         logger.warning(
-            'Required parameter(s) missing. Skipping sync.',
+            'Required parameter missing. Skipping sync.',
             'See docs to configure.',
         )
         return


### PR DESCRIPTION
### Summary
We have a comma in between the log messages causing stack trace when the logger is trying to format the message before output, instead of concatenating the two log messages.

### Related issues or links
- https://github.com/lyft/cartography/issues/1353


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Include console log trace showing what happened before and after your changes.

Before
```
$ pipenv run cartography --neo4j-uri "bolt://localhost:7687" --selected-modules "kandji"
Loading .env environment variables...
WARNING:cartography.cli:A Kandji base URI was not provided.
WARNING:cartography.cli:A SnipeIT base URI was not provided.
INFO:cartography.sync:Starting sync with update tag '1726613741'
INFO:cartography.sync:Starting sync stage 'kandji'
--- Logging error ---
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 1160, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 703, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.6/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/__init__.py", line 392, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "/Users/chandan/maestro/cartography/.venv/bin/cartography", line 8, in <module>
    sys.exit(main())
  File "/Users/chandan/maestro/cartography/cartography/cartography/cli.py", line 810, in main
    sys.exit(CLI(prog='cartography').main(argv))
  File "/Users/chandan/maestro/cartography/cartography/cartography/cli.py", line 791, in main
    return cartography.sync.run_with_config(self.sync, config)
  File "/Users/chandan/maestro/cartography/cartography/cartography/sync.py", line 193, in run_with_config
    return sync.run(neo4j_driver, config)
  File "/Users/chandan/maestro/cartography/cartography/cartography/sync.py", line 115, in run
    stage_func(neo4j_session, config)
  File "/Users/chandan/maestro/cartography/cartography/cartography/util.py", line 197, in timed
    return method(*args, **kwargs)
  File "/Users/chandan/maestro/cartography/cartography/cartography/intel/kandji/__init__.py", line 23, in start_kandji_ingestion
    logger.warning(
Message: 'Required parameter missing. Skipping sync.'
Arguments: ('See docs to configure.',)
INFO:cartography.sync:Finishing sync stage 'kandji'
INFO:cartography.sync:Finishing sync with update tag '1726613741'
```

After
```
$ pipenv run cartography --neo4j-uri "bolt://localhost:7687" --selected-modules "kandji"
Loading .env environment variables...
WARNING:cartography.cli:A Kandji base URI was not provided.
WARNING:cartography.cli:A SnipeIT base URI was not provided.
INFO:cartography.sync:Starting sync with update tag '1726613793'
INFO:cartography.sync:Starting sync stage 'kandji'
WARNING:cartography.intel.kandji:Required parameter(s) missing. Skipping sync. See docs to configure.
INFO:cartography.sync:Finishing sync stage 'kandji'
INFO:cartography.sync:Finishing sync with update tag '1726613793'
```
