### PR TITLE
Prevent .compose volumes from being doubly included in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 build/
 *.egg-info/
 venv/
+.compose
+.cache
+.local


### PR DESCRIPTION
docker-compose maps in ./.compose/* in the host source tree to the neo4j container so that neo4j data can be persisted on each container re-run.

dev.Dockerfile copies in the contents of everything on the host source tree, and that also includes the contents of .compose, which can get very big. 

This PR makes sure that we don't include .compose in the dev.Dockerfile so that the size stays manageable.